### PR TITLE
Small refactoring on core & hbase module

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGCJClient.java
@@ -38,8 +38,8 @@ import io.grpc.stub.StreamObserver;
 import java.util.List;
 
 /**
- * This class implements existing {@link com.google.cloud.bigtable.core.IBigtableDataClient}
- * operations with Google-cloud-java's {@link com.google.cloud.bigtable.data.v2.BigtableDataClient}.
+ * This class implements existing {@link IBigtableDataClient} operations with Google-cloud-java's
+ * {@link com.google.cloud.bigtable.data.v2.BigtableDataClient}.
  */
 @InternalApi("For internal usage only")
 public class BigtableDataGCJClient implements IBigtableDataClient, AutoCloseable {
@@ -138,8 +138,6 @@ public class BigtableDataGCJClient implements IBigtableDataClient, AutoCloseable
   /**
    * To wrap stream of native CBT client's {@link StreamObserver} onto GCJ {@link
    * com.google.api.gax.rpc.ResponseObserver}.
-   *
-   * <p>Note:Inspired from {@link com.google.api.gax.rpc.ApiStreamObserverAdapter} of GCJ.
    */
   private static class StreamObserverAdapter<T> extends StateCheckingResponseObserver<T> {
     private final StreamObserver<T> delegate;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -216,8 +216,8 @@ public class BigtableSession implements Closeable {
   /**
    * Constructor for BigtableSession.
    *
-   * @param opts a {@link com.google.cloud.bigtable.config.BigtableOptions} object.
-   * @throws java.io.IOException if any.
+   * @param opts a {@link BigtableOptions} object.
+   * @throws IOException if any.
    */
   public BigtableSession(BigtableOptions opts) throws IOException {
     this.options = opts;
@@ -390,7 +390,7 @@ public class BigtableSession implements Closeable {
   /**
    * Getter for the field <code>dataClient</code>.
    *
-   * @return a {@link com.google.cloud.bigtable.grpc.BigtableDataClient} object.
+   * @return a {@link BigtableDataClient} object.
    */
   public BigtableDataClient getDataClient() {
     return dataClient;
@@ -413,8 +413,8 @@ public class BigtableSession implements Closeable {
   /**
    * createBulkMutation.
    *
-   * @param tableName a {@link com.google.cloud.bigtable.grpc.BigtableTableName} object.
-   * @return a {@link com.google.cloud.bigtable.grpc.async.BulkMutation} object.
+   * @param tableName a {@link BigtableTableName} object.
+   * @return a {@link BulkMutation} object.
    */
   public BulkMutation createBulkMutation(BigtableTableName tableName) {
     if (options.useGCJClient()) {
@@ -445,8 +445,8 @@ public class BigtableSession implements Closeable {
   /**
    * createBulkRead.
    *
-   * @param tableName a {@link com.google.cloud.bigtable.grpc.BigtableTableName} object.
-   * @return a {@link com.google.cloud.bigtable.grpc.async.BulkRead} object.
+   * @param tableName a {@link BigtableTableName} object.
+   * @return a {@link BulkRead} object.
    */
   public BulkRead createBulkRead(BigtableTableName tableName) {
     return new BulkRead(
@@ -459,8 +459,8 @@ public class BigtableSession implements Closeable {
   /**
    * Getter for the field <code>tableAdminClient</code>.
    *
-   * @return a {@link com.google.cloud.bigtable.grpc.BigtableTableAdminClient} object.
-   * @throws java.io.IOException if any.
+   * @return a {@link BigtableTableAdminClient} object.
+   * @throws IOException if any.
    */
   public synchronized BigtableTableAdminClient getTableAdminClient() throws IOException {
     if (tableAdminClient == null) {
@@ -477,7 +477,7 @@ public class BigtableSession implements Closeable {
    * BigtableOptions}.
    *
    * @return a {@link BigtableTableAdminClientWrapper} object.
-   * @throws java.io.IOException if any.
+   * @throws IOException if any.
    */
   @InternalApi("For internal usage only")
   public synchronized IBigtableTableAdminClient getTableAdminClientWrapper() throws IOException {
@@ -500,8 +500,8 @@ public class BigtableSession implements Closeable {
   /**
    * Getter for the field <code>instanceAdminClient</code>.
    *
-   * @return a {@link com.google.cloud.bigtable.grpc.BigtableInstanceClient} object.
-   * @throws java.io.IOException if any.
+   * @return a {@link BigtableInstanceClient} object.
+   * @throws IOException if any.
    */
   public synchronized BigtableInstanceClient getInstanceAdminClient() throws IOException {
     if (instanceAdminClient == null) {
@@ -512,11 +512,11 @@ public class BigtableSession implements Closeable {
   }
 
   /**
-   * Create a new {@link com.google.cloud.bigtable.grpc.io.ChannelPool}, with auth headers.
+   * Create a new {@link ChannelPool}, with auth headers.
    *
-   * @param hostString a {@link java.lang.String} object.
-   * @return a {@link com.google.cloud.bigtable.grpc.io.ChannelPool} object.
-   * @throws java.io.IOException if any.
+   * @param hostString a {@link String} object.
+   * @return a {@link ChannelPool} object.
+   * @throws IOException if any.
    */
   protected ManagedChannel createChannelPool(final String hostString, int count)
       throws IOException {
@@ -533,13 +533,13 @@ public class BigtableSession implements Closeable {
   }
 
   /**
-   * Create a new {@link com.google.cloud.bigtable.grpc.io.ChannelPool}, with auth headers. This
-   * method allows users to override the default implementation with their own.
+   * Create a new {@link ChannelPool}, with auth headers. This method allows users to override the
+   * default implementation with their own.
    *
    * @param channelFactory a {@link ChannelPool.ChannelFactory} object.
    * @param count The number of channels in the pool.
-   * @return a {@link com.google.cloud.bigtable.grpc.io.ChannelPool} object.
-   * @throws java.io.IOException if any.
+   * @return a {@link ChannelPool} object.
+   * @throws IOException if any.
    */
   protected ManagedChannel createChannelPool(
       final ChannelPool.ChannelFactory channelFactory, int count) throws IOException {
@@ -547,12 +547,12 @@ public class BigtableSession implements Closeable {
   }
 
   /**
-   * Create a new {@link com.google.cloud.bigtable.grpc.io.ChannelPool}, with auth headers, that
-   * will be cleaned up when the connection closes.
+   * Create a new {@link ChannelPool}, with auth headers, that will be cleaned up when the
+   * connection closes.
    *
-   * @param host a {@link java.lang.String} object.
-   * @return a {@link com.google.cloud.bigtable.grpc.io.ChannelPool} object.
-   * @throws java.io.IOException if any.
+   * @param host a {@link String} object.
+   * @return a {@link ChannelPool} object.
+   * @throws IOException if any.
    */
   protected ManagedChannel createManagedPool(String host, int channelCount) throws IOException {
     ManagedChannel channelPool = createChannelPool(host, channelCount);
@@ -576,7 +576,7 @@ public class BigtableSession implements Closeable {
   }
 
   /**
-   * Create a new {@link com.google.cloud.bigtable.grpc.io.ChannelPool}, with auth headers.
+   * Create a new {@link ChannelPool}, with auth headers.
    *
    * @param host a {@link String} object.
    * @param options a {@link BigtableOptions} object.
@@ -590,7 +590,7 @@ public class BigtableSession implements Closeable {
   }
 
   /**
-   * Create a new {@link com.google.cloud.bigtable.grpc.io.ChannelPool}, with auth headers.
+   * Create a new {@link ChannelPool}, with auth headers.
    *
    * @param host a {@link String} object specifying the host to connect to.
    * @param options a {@link BigtableOptions} object with the credentials, retry and other
@@ -724,7 +724,7 @@ public class BigtableSession implements Closeable {
   /**
    * Getter for the field <code>options</code>.
    *
-   * @return a {@link com.google.cloud.bigtable.config.BigtableOptions} object.
+   * @return a {@link BigtableOptions} object.
    */
   public BigtableOptions getOptions() {
     return this.options;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutation.java
@@ -416,7 +416,6 @@ public class BulkMutation {
               entry.getMutationsCount(),
               MAX_NUMBER_OF_MUTATIONS));
     }
-    ;
 
     boolean didSend = false;
     if (currentBatch != null && currentBatch.wouldBeFull(entry)) {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationGCJClient.java
@@ -32,7 +32,7 @@ import com.google.common.base.Preconditions;
 @InternalApi("For internal usage only")
 public class BulkMutationGCJClient implements IBulkMutation {
 
-  private static Logger LOG = new Logger(BulkMutation.class);
+  private static Logger LOG = new Logger(BulkMutationGCJClient.class);
 
   private final BulkMutationBatcher bulkMutateBatcher;
   private final OperationAccountant operationAccountant;

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestAppProfile.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestAppProfile.java
@@ -146,17 +146,6 @@ public class TestAppProfile {
   }
 
   @Test
-  public void testMutateRows() throws Exception {
-    defaultSession.getDataClient().mutateRows(MutateRowsRequest.getDefaultInstance());
-    MutateRowsRequest req = fakeDataService.popLastRequest();
-    Preconditions.checkState(req.getAppProfileId().isEmpty());
-
-    profileSession.getDataClient().mutateRows(MutateRowsRequest.getDefaultInstance());
-    MutateRowsRequest req2 = fakeDataService.popLastRequest();
-    Assert.assertEquals(req2.getAppProfileId(), "my-app-profile");
-  }
-
-  @Test
   public void testCheckAndMutateRow() throws Exception {
     ConditionalRowMutation checkAndMuate =
         ConditionalRowMutation.create(TABLE_ID, "fake-key")

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestAppProfile.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestAppProfile.java
@@ -146,6 +146,17 @@ public class TestAppProfile {
   }
 
   @Test
+  public void testMutateRows() throws Exception {
+    defaultSession.getDataClient().mutateRows(MutateRowsRequest.getDefaultInstance());
+    MutateRowsRequest req = fakeDataService.popLastRequest();
+    Preconditions.checkState(req.getAppProfileId().isEmpty());
+
+    profileSession.getDataClient().mutateRows(MutateRowsRequest.getDefaultInstance());
+    MutateRowsRequest req2 = fakeDataService.popLastRequest();
+    Assert.assertEquals(req2.getAppProfileId(), "my-app-profile");
+  }
+
+  @Test
   public void testCheckAndMutateRow() throws Exception {
     ConditionalRowMutation checkAndMuate =
         ConditionalRowMutation.create(TABLE_ID, "fake-key")

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
@@ -319,15 +319,6 @@ public class HBaseRequestAdapter {
     return tableName;
   }
 
-  /**
-   * getTableNameString.
-   *
-   * @return a {@link java.lang.String} object.
-   */
-  protected String getTableNameString() {
-    return getBigtableTableName().toString();
-  }
-
   private RowMutation newRowMutationModel(byte[] rowKey) {
     if (!mutationAdapters.putAdapter.isSetClientTimestamp()) {
       return RowMutation.create(


### PR DESCRIPTION
 - Depreacated `BigtableDataClien#getDataClient` which is replaced by `BigtableSession#getDataClientWrapper` which has implementation for both (existing as well GCJ client).
- Removed only usage of BigtableDataClient in `TestAppProfile`.
- Removed unused `HBaseRequestAdapter#getTableNameString`.
- Removed package qualifier from `BigtableSession` & `BigtableDataGCJClient` javadocs.