### PR TITLE
Updated HBase BulkMutation to use new Batcher API through GCJ client

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBigtableDataClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBigtableDataClient.java
@@ -71,7 +71,7 @@ public interface IBigtableDataClient {
   ApiFuture<Row> readModifyWriteRowAsync(ReadModifyWriteRow readModifyWriteRow);
 
   /** Creates {@link IBulkMutation} batcher. */
-  IBulkMutation createBulkMutationBatcher();
+  IBulkMutation createBulkMutationBatcher(String tableId);
 
   /**
    * Mutate a row atomically dependent on a precondition.

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBulkMutation.java
@@ -17,11 +17,12 @@ package com.google.cloud.bigtable.core;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
 import java.io.IOException;
 
 /**
- * Interface to support batching multiple {@link RowMutation} request into a single grpc request.
+ * Interface to support batching multiple {@link RowMutationEntry} request into a single grpc *
+ * request.
  *
  * <p>For internal use only - public for technical reasons.
  */
@@ -29,18 +30,18 @@ import java.io.IOException;
 public interface IBulkMutation extends AutoCloseable {
 
   /**
-   * Adds a {@link RowMutation} to the underlying IBulkMutation mechanism.
+   * Adds a {@link RowMutationEntry} to the underlying IBulkMutation mechanism.
    *
-   * @param rowMutation The {@link RowMutation} to add.
+   * @param rowMutation The RowMutationEntry which holds row mutation details.
    * @return a {@link ApiFuture} of type {@link Void} will be set when request is successful
    *     otherwise exception will be thrown.
    */
-  ApiFuture<Void> add(RowMutation rowMutation);
+  ApiFuture<Void> add(RowMutationEntry rowMutation);
 
-  /** Sends any outstanding {@link RowMutation}s, present in the current batch. */
+  /** Sends any outstanding entry, present in the current batch but doesn't wait for response. */
   void sendUnsent();
 
-  /** Sends any outstanding {@link RowMutation} and wait until all requests are complete. */
+  /** Sends any outstanding RowMutationEntry and blocks until all requests are complete. */
   void flush() throws InterruptedException;
 
   /** Closes this bulk Mutation and prevents from mutating any more elements */

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataClientWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataClientWrapper.java
@@ -115,7 +115,7 @@ public class BigtableDataClientWrapper implements IBigtableDataClient {
 
   /** {@inheritDoc} */
   @Override
-  public IBulkMutation createBulkMutationBatcher() {
+  public IBulkMutation createBulkMutationBatcher(String tableId) {
     throw new UnsupportedOperationException("Not implemented yet");
   }
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGCJClient.java
@@ -73,8 +73,8 @@ public class BigtableDataGCJClient implements IBigtableDataClient, AutoCloseable
   }
 
   @Override
-  public IBulkMutation createBulkMutationBatcher() {
-    return new BulkMutationGCJClient(delegate.newBulkMutationBatcher());
+  public IBulkMutation createBulkMutationBatcher(String tableId) {
+    return new BulkMutationGCJClient(delegate.newBulkMutationBatcher(tableId));
   }
 
   @Override

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -430,9 +430,9 @@ public class BigtableSession implements Closeable {
   @InternalApi("For internal usage only")
   public IBulkMutation createBulkMutationWrapper(BigtableTableName tableName) {
     if (options.useGCJClient()) {
-      return getDataClientWrapper().createBulkMutationBatcher();
+      return getDataClientWrapper().createBulkMutationBatcher(tableName.getTableId());
     } else {
-      return new BulkMutationWrapper(createBulkMutation(tableName), dataRequestContext);
+      return new BulkMutationWrapper(createBulkMutation(tableName));
     }
   }
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationGCJClient.java
@@ -17,56 +17,52 @@ package com.google.cloud.bigtable.grpc.async;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.config.Logger;
+import com.google.api.gax.batching.Batcher;
 import com.google.cloud.bigtable.core.IBulkMutation;
-import com.google.cloud.bigtable.data.v2.models.BulkMutationBatcher;
-import com.google.cloud.bigtable.data.v2.models.BulkMutationBatcher.BulkMutationFailure;
-import com.google.cloud.bigtable.data.v2.models.RowMutation;
-import com.google.cloud.bigtable.util.ApiFutureUtil;
+import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
 import com.google.common.base.Preconditions;
 import java.io.IOException;
-import java.util.concurrent.TimeoutException;
 
 /**
- * This class is meant to replicate existing {@link BulkMutation} while translating calls to
- * Google-Cloud-Java's {@link BulkMutationBatcher} api.
+ * This class is meant to replicate existing {@link BulkMutation} while translating calls to *
+ * Google-Cloud-Java's {@link Batcher} api.
  *
  * <p>For internal use only - public for technical reasons.
  */
 @InternalApi("For internal usage only")
 public class BulkMutationGCJClient implements IBulkMutation {
 
-  private static Logger LOG = new Logger(BulkMutationGCJClient.class);
+  private final Batcher<RowMutationEntry, Void> bulkMutateBatcher;
 
-  private final BulkMutationBatcher bulkMutateBatcher;
-  private final OperationAccountant operationAccountant;
-
-  public BulkMutationGCJClient(BulkMutationBatcher bulkMutateBatcher) {
+  public BulkMutationGCJClient(Batcher<RowMutationEntry, Void> bulkMutateBatcher) {
     this.bulkMutateBatcher = bulkMutateBatcher;
-    this.operationAccountant = new OperationAccountant();
   }
 
   /** {@inheritDoc} */
   @Override
-  public synchronized ApiFuture<Void> add(RowMutation rowMutation) {
+  public synchronized ApiFuture<Void> add(RowMutationEntry rowMutation) {
     Preconditions.checkNotNull(rowMutation, "mutation details cannot be null");
-    final ApiFuture<Void> response = bulkMutateBatcher.add(rowMutation);
-    operationAccountant.registerOperation(ApiFutureUtil.adapt(response));
-    return response;
+    return bulkMutateBatcher.add(rowMutation);
   }
 
   /** {@inheritDoc} */
   @Override
   public void sendUnsent() {
-    LOG.info("This operation will be implemented once the underlying API has this feature.");
+    try {
+      // TODO(rahulkql): Please use Batcher.sendOutstanding once below change is available
+      //  https://github.com/googleapis/gax-java/pull/786
+      bulkMutateBatcher.flush();
+    } catch (InterruptedException ex) {
+      throw new RuntimeException("Could not complete RPC for current Batch", ex);
+    }
   }
 
   /** {@inheritDoc} */
   @Override
   public void flush() {
     try {
-      operationAccountant.awaitCompletion();
-    } catch (BulkMutationFailure | InterruptedException ex) {
+      bulkMutateBatcher.flush();
+    } catch (InterruptedException ex) {
       throw new RuntimeException("Could not complete RPC for current Batch", ex);
     }
   }
@@ -75,7 +71,7 @@ public class BulkMutationGCJClient implements IBulkMutation {
   public void close() throws IOException {
     try {
       bulkMutateBatcher.close();
-    } catch (InterruptedException | TimeoutException e) {
+    } catch (InterruptedException e) {
       throw new IOException("Could not close the bulk mutation Batcher", e);
     }
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationWrapper.java
@@ -19,8 +19,7 @@ import com.google.api.core.ApiFuture;
 import com.google.api.core.InternalApi;
 import com.google.bigtable.v2.MutateRowResponse;
 import com.google.cloud.bigtable.core.IBulkMutation;
-import com.google.cloud.bigtable.data.v2.internal.RequestContext;
-import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
 import com.google.cloud.bigtable.util.ApiFutureUtil;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
@@ -35,20 +34,18 @@ import java.io.IOException;
 public class BulkMutationWrapper implements IBulkMutation {
 
   private final BulkMutation delegate;
-  private final RequestContext requestContext;
   private boolean isClosed;
 
-  public BulkMutationWrapper(BulkMutation bulkMutation, RequestContext requestContext) {
+  public BulkMutationWrapper(BulkMutation bulkMutation) {
     this.delegate = bulkMutation;
-    this.requestContext = requestContext;
   }
 
   /** {@inheritDoc} */
   @Override
-  public ApiFuture<Void> add(RowMutation rowMutation) {
+  public ApiFuture<Void> add(RowMutationEntry rowMutation) {
     Preconditions.checkState(!isClosed, "can't mutate when the bulk mutation is closed.");
     return ApiFutureUtil.transformAndAdapt(
-        delegate.add(rowMutation.toBulkProto(requestContext).getEntries(0)),
+        delegate.add(rowMutation.toProto()),
         new Function<MutateRowResponse, Void>() {
           @Override
           public Void apply(MutateRowResponse response) {

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestAppProfile.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestAppProfile.java
@@ -37,6 +37,7 @@ import com.google.cloud.bigtable.data.v2.models.Mutation;
 import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
 import com.google.cloud.bigtable.grpc.async.BulkRead;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Queues;
@@ -187,7 +188,7 @@ public class TestAppProfile {
     BigtableTableName fakeTableName =
         new BigtableTableName("projects/fake-project/instances/fake-instance/tables/fake-table");
 
-    RowMutation rowMutation = RowMutation.create(TABLE_ID, "fake-key");
+    RowMutationEntry rowMutation = RowMutationEntry.create("fake-key");
 
     IBulkMutation bulkMutation = defaultSession.createBulkMutationWrapper(fakeTableName);
     bulkMutation.add(rowMutation);

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGCJClient.java
@@ -26,12 +26,12 @@ import static org.mockito.Mockito.when;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
+import com.google.api.gax.batching.Batcher;
 import com.google.api.gax.rpc.ResponseObserver;
 import com.google.api.gax.rpc.ServerStream;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.bigtable.data.v2.BigtableDataClient;
-import com.google.cloud.bigtable.data.v2.models.BulkMutationBatcher;
 import com.google.cloud.bigtable.data.v2.models.ConditionalRowMutation;
 import com.google.cloud.bigtable.data.v2.models.KeyOffset;
 import com.google.cloud.bigtable.data.v2.models.Mutation;
@@ -40,6 +40,7 @@ import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.data.v2.models.Row;
 import com.google.cloud.bigtable.data.v2.models.RowCell;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
 import com.google.cloud.bigtable.grpc.scanner.FlatRow;
 import com.google.cloud.bigtable.grpc.scanner.FlatRowAdapter;
 import com.google.cloud.bigtable.grpc.scanner.ResultScanner;
@@ -292,10 +293,9 @@ public class TestBigtableDataGCJClient {
 
   @Test
   public void testCreateBulkMutationBatcher() {
-    UnaryCallable<RowMutation, Void> unaryCallable = mock(UnaryCallable.class);
-    BulkMutationBatcher batcher = new BulkMutationBatcher(unaryCallable);
-    when(dataClientV2.newBulkMutationBatcher()).thenReturn(batcher);
-    dataGCJClient.createBulkMutationBatcher();
-    verify(dataClientV2).newBulkMutationBatcher();
+    Batcher<RowMutationEntry, Void> batcher = mock(Batcher.class);
+    when(dataClientV2.newBulkMutationBatcher(TABLE_ID)).thenReturn(batcher);
+    dataGCJClient.createBulkMutationBatcher(TABLE_ID);
+    verify(dataClientV2).newBulkMutationBatcher(TABLE_ID);
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationWrapper.java
@@ -24,8 +24,7 @@ import static org.mockito.Mockito.when;
 import com.google.bigtable.v2.MutateRowResponse;
 import com.google.bigtable.v2.MutateRowsRequest;
 import com.google.cloud.bigtable.core.IBulkMutation;
-import com.google.cloud.bigtable.data.v2.internal.RequestContext;
-import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
 import com.google.common.util.concurrent.Futures;
 import java.io.IOException;
 import java.util.concurrent.Future;
@@ -39,14 +38,12 @@ import org.mockito.Mockito;
 public class TestBulkMutationWrapper {
 
   private BulkMutation mockDelegate;
-  private RequestContext requestContext =
-      RequestContext.create("ProjectId", "instanceId", "appProfileId");
   private IBulkMutation bulkWrapper;
 
   @Before
   public void setUp() {
     mockDelegate = Mockito.mock(BulkMutation.class);
-    bulkWrapper = new BulkMutationWrapper(mockDelegate, requestContext);
+    bulkWrapper = new BulkMutationWrapper(mockDelegate);
   }
 
   @Test
@@ -65,8 +62,8 @@ public class TestBulkMutationWrapper {
 
   @Test
   public void testAddMutate() {
-    RowMutation rowMutation = RowMutation.create("tableId", "key");
-    MutateRowsRequest.Entry requestProto = rowMutation.toBulkProto(requestContext).getEntries(0);
+    RowMutationEntry rowMutation = RowMutationEntry.create("key");
+    MutateRowsRequest.Entry requestProto = rowMutation.toProto();
     when(mockDelegate.add(requestProto))
         .thenReturn(Futures.immediateFuture(MutateRowResponse.getDefaultInstance()));
     Future<Void> response = bulkWrapper.add(rowMutation);
@@ -83,7 +80,7 @@ public class TestBulkMutationWrapper {
     bulkWrapper.close();
     Exception actualEx = null;
     try {
-      bulkWrapper.add(RowMutation.create("tableId", "key"));
+      bulkWrapper.add(RowMutationEntry.create("key"));
     } catch (Exception e) {
       actualEx = e;
     }

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/TestBufferedMutator.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/TestBufferedMutator.java
@@ -16,13 +16,20 @@
 package com.google.cloud.bigtable.hbase;
 
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.ImmutableList;
+import java.util.List;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.hadoop.hbase.client.BufferedMutator;
 import org.apache.hadoop.hbase.client.BufferedMutatorParams;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Assert;
@@ -93,6 +100,37 @@ public class TestBufferedMutator extends AbstractTest {
       // getWriteBufferSize.  https://issues.apache.org/jira/browse/HBASE-13113
       Assert.assertTrue(
           0 == mutator.getWriteBufferSize() || maxSize == mutator.getWriteBufferSize());
+    }
+  }
+
+  @Test
+  public void testBulkMutation() throws Exception {
+    final String rowKeyPrefix = RandomStringUtils.randomAlphanumeric(10);
+    try (BufferedMutator mutator =
+            getConnection().getBufferedMutator(sharedTestEnv.getDefaultTableName());
+        Table tableForRead = getConnection().getTable(sharedTestEnv.getDefaultTableName())) {
+
+      ImmutableList.Builder<Put> builder = ImmutableList.builder();
+      for (int i = 0; i < 10; i++) {
+        builder.add(
+            new Put(Bytes.toBytes(rowKeyPrefix + i))
+                .addColumn(COLUMN_FAMILY, qualifier, 10_001L, value));
+      }
+      List<Put> mutations = builder.build();
+
+      mutator.mutate(mutations);
+      // force bufferedMutator to apply mutation
+      mutator.flush();
+
+      Scan scan = new Scan();
+      scan.setRowPrefixFilter(Bytes.toBytes(rowKeyPrefix));
+      ResultScanner resultScanner = tableForRead.getScanner(scan);
+      Result[] results = resultScanner.next(20);
+
+      assertEquals("mutations should have been applied now", mutations.size(), results.length);
+      for (int i = 0; i < results.length; i++) {
+        assertArrayEquals(mutations.get(i).getRow(), results[i].getRow());
+      }
     }
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
@@ -22,6 +22,7 @@ import com.google.cloud.bigtable.data.v2.models.MutationApi;
 import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.hbase.adapters.read.DefaultReadHooks;
 import com.google.cloud.bigtable.hbase.adapters.read.ReadHooks;
@@ -145,10 +146,10 @@ public class HBaseRequestAdapter {
    * adapt.
    *
    * @param delete a {@link Delete} object.
-   * @return a {@link RowMutation} object.
+   * @return a {@link RowMutationEntry} object.
    */
-  public RowMutation adaptEntry(Delete delete) {
-    RowMutation rowMutation = newRowMutationModel(delete.getRow());
+  public RowMutationEntry adaptEntry(Delete delete) {
+    RowMutationEntry rowMutation = buildRowMutationEntry(delete.getRow());
     adapt(delete, rowMutation);
     return rowMutation;
   }
@@ -235,10 +236,10 @@ public class HBaseRequestAdapter {
    * adaptEntry.
    *
    * @param put a {@link Put} object.
-   * @return a {@link RowMutation} object.
+   * @return a {@link RowMutationEntry} object.
    */
-  public RowMutation adaptEntry(Put put) {
-    RowMutation rowMutation = newRowMutationModel(put.getRow());
+  public RowMutationEntry adaptEntry(Put put) {
+    RowMutationEntry rowMutation = buildRowMutationEntry(put.getRow());
     adapt(put, rowMutation);
     return rowMutation;
   }
@@ -270,10 +271,10 @@ public class HBaseRequestAdapter {
    * adaptEntry.
    *
    * @param mutations a {@link org.apache.hadoop.hbase.client.RowMutations} object.
-   * @return a {@link RowMutation} object.
+   * @return a {@link RowMutationEntry} object.
    */
-  public RowMutation adaptEntry(RowMutations mutations) {
-    RowMutation rowMutation = newRowMutationModel(mutations.getRow());
+  public RowMutationEntry adaptEntry(RowMutations mutations) {
+    RowMutationEntry rowMutation = buildRowMutationEntry(mutations.getRow());
     adapt(mutations, rowMutation);
     return rowMutation;
   }
@@ -325,5 +326,13 @@ public class HBaseRequestAdapter {
           bigtableTableName.getTableId(), ByteString.copyFrom(rowKey), Mutation.createUnsafe());
     }
     return RowMutation.create(bigtableTableName.getTableId(), ByteString.copyFrom(rowKey));
+  }
+
+  private RowMutationEntry buildRowMutationEntry(byte[] rowKey) {
+    if (!mutationAdapters.putAdapter.isSetClientTimestamp()) {
+      return RowMutationEntry.createUnsafe(ByteString.copyFrom(rowKey));
+    }
+
+    return RowMutationEntry.create(ByteString.copyFrom(rowKey));
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
@@ -29,10 +29,9 @@ import com.google.api.core.ApiFutures;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.core.IBigtableDataClient;
 import com.google.cloud.bigtable.core.IBulkMutation;
-import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
-import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
 import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.grpc.async.BulkRead;
@@ -129,12 +128,9 @@ public class TestBatchExecutor {
         BigtableOptions.builder().setProjectId("projectId").setInstanceId("instanceId").build();
     requestAdapter =
         new HBaseRequestAdapter(options, TableName.valueOf("table"), new Configuration(false));
-    RequestContext requetsContext =
-        RequestContext.create(
-            options.getProjectId(), options.getInstanceId(), options.getAppProfileId());
 
     MockitoAnnotations.initMocks(this);
-    when(mockBulkMutation.add(any(RowMutation.class))).thenReturn(mockFuture);
+    when(mockBulkMutation.add(any(RowMutationEntry.class))).thenReturn(mockFuture);
     when(mockBigtableSession.getDataClientWrapper()).thenReturn(mockDataClient);
     when(mockDataClient.readModifyWriteRowAsync(any(ReadModifyWriteRow.class)))
         .thenReturn(mockFuture);

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
@@ -29,7 +29,7 @@ import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.core.IBigtableDataClient;
 import com.google.cloud.bigtable.core.IBulkMutation;
 import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
-import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
 import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
@@ -105,18 +105,18 @@ public class TestBigtableBufferedMutator {
 
   @Test
   public void testPut() throws IOException {
-    when(mockBulkMutation.add(any(RowMutation.class))).thenReturn(future);
+    when(mockBulkMutation.add(any(RowMutationEntry.class))).thenReturn(future);
     BigtableBufferedMutator underTest = createMutator(new Configuration(false));
     underTest.mutate(SIMPLE_PUT);
-    verify(mockBulkMutation, times(1)).add(any(RowMutation.class));
+    verify(mockBulkMutation, times(1)).add(any(RowMutationEntry.class));
   }
 
   @Test
   public void testDelete() throws IOException {
-    when(mockBulkMutation.add(any(RowMutation.class))).thenReturn(future);
+    when(mockBulkMutation.add(any(RowMutationEntry.class))).thenReturn(future);
     BigtableBufferedMutator underTest = createMutator(new Configuration(false));
     underTest.mutate(new Delete(EMPTY_BYTES));
-    verify(mockBulkMutation, times(1)).add(any(RowMutation.class));
+    verify(mockBulkMutation, times(1)).add(any(RowMutationEntry.class));
   }
 
   @Test
@@ -137,7 +137,7 @@ public class TestBigtableBufferedMutator {
 
   @Test
   public void testInvalidPut() throws Exception {
-    when(mockBulkMutation.add(any(RowMutation.class)))
+    when(mockBulkMutation.add(any(RowMutationEntry.class)))
         .thenReturn(ApiFutures.<Void>immediateFailedFuture(new RuntimeException()));
     BigtableBufferedMutator underTest = createMutator(new Configuration(false));
     underTest.mutate(SIMPLE_PUT);
@@ -152,10 +152,10 @@ public class TestBigtableBufferedMutator {
   @Test
   public void testBulkSingleRequests() throws IOException, InterruptedException {
     Configuration config = new Configuration(false);
-    when(mockBulkMutation.add(any(RowMutation.class))).thenReturn(future);
+    when(mockBulkMutation.add(any(RowMutationEntry.class))).thenReturn(future);
     final BigtableBufferedMutator underTest = createMutator(config);
     underTest.mutate(SIMPLE_PUT);
-    verify(mockBulkMutation, times(1)).add(any(RowMutation.class));
+    verify(mockBulkMutation, times(1)).add(any(RowMutationEntry.class));
     underTest.flush();
     verify(mockBulkMutation, times(1)).flush();
   }
@@ -163,13 +163,13 @@ public class TestBigtableBufferedMutator {
   @Test
   public void testBulkMultipleRequests() throws IOException, InterruptedException {
     Configuration config = new Configuration(false);
-    when(mockBulkMutation.add(any(RowMutation.class))).thenReturn(future);
+    when(mockBulkMutation.add(any(RowMutationEntry.class))).thenReturn(future);
     BigtableBufferedMutator underTest = createMutator(config);
     int count = 30;
     for (int i = 0; i < count; i++) {
       underTest.mutate(SIMPLE_PUT);
     }
-    verify(mockBulkMutation, times(count)).add(any(RowMutation.class));
+    verify(mockBulkMutation, times(count)).add(any(RowMutationEntry.class));
     underTest.flush();
     verify(mockBulkMutation, times(1)).flush();
   }
@@ -178,13 +178,13 @@ public class TestBigtableBufferedMutator {
   public void testClose() throws IOException {
     Configuration config = new Configuration(false);
     doNothing().when(mockBulkMutation).close();
-    when(mockBulkMutation.add(any(RowMutation.class))).thenReturn(future);
+    when(mockBulkMutation.add(any(RowMutationEntry.class))).thenReturn(future);
     BigtableBufferedMutator underTest = createMutator(config);
     underTest.mutate(SIMPLE_PUT);
 
     underTest.close();
 
-    verify(mockBulkMutation).add(any(RowMutation.class));
+    verify(mockBulkMutation).add(any(RowMutationEntry.class));
     verify(mockBulkMutation).close();
   }
 }


### PR DESCRIPTION
This change will enable `BigtableBufferMutator` to use GCJ's `Batcher<>` class through IBulkMutation when user set `useGCJClient`/`google.bigtable.use.gcj.client` flag.

### Summary of changes it contians: 
 - Had to update `IBigtableDataClient#createBulkMutationBatcher(tableID)` to accept tableID which is need for `Batcher` creation.
 - Updated `IBulkMutation` to adapt against `RowMutationEntry`.
 - Now `BulkMutationGCJClient` uses `Batcher<>` to perform batching.
 - Updated `HBaseRequestAdapter` to adapt against `RowMutationEntry` & also incorporate `RowMutationEntry#createUnsafe()`. 
 - Fixed Junit for the Batching related changes and added test case in IT test class `TestBufferedMutator`.