### PR TITLE
Marked GCJ wrappers InternalOnly

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBigtableDataClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBigtableDataClient.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.core;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.data.v2.models.ConditionalRowMutation;
 import com.google.cloud.bigtable.data.v2.models.KeyOffset;
 import com.google.cloud.bigtable.data.v2.models.Query;
@@ -67,6 +68,7 @@ public interface IBigtableDataClient {
   ApiFuture<Row> readModifyWriteRowAsync(ReadModifyWriteRow readModifyWriteRow);
 
   /** Creates {@link IBulkMutation} batcher. */
+  @InternalApi("For internal usage only")
   IBulkMutation createBulkMutationBatcher();
 
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBigtableDataClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBigtableDataClient.java
@@ -32,6 +32,7 @@ import java.util.List;
  * Interface to wrap {@link com.google.cloud.bigtable.grpc.BigtableDataClient} with
  * Google-Cloud-java's models.
  */
+@InternalApi("For internal usage only")
 public interface IBigtableDataClient {
 
   /**
@@ -68,7 +69,6 @@ public interface IBigtableDataClient {
   ApiFuture<Row> readModifyWriteRowAsync(ReadModifyWriteRow readModifyWriteRow);
 
   /** Creates {@link IBulkMutation} batcher. */
-  @InternalApi("For internal usage only")
   IBulkMutation createBulkMutationBatcher();
 
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBigtableTableAdminClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBigtableTableAdminClient.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.core;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.core.InternalApi;
 import com.google.bigtable.admin.v2.CreateTableFromSnapshotRequest;
 import com.google.bigtable.admin.v2.DeleteSnapshotRequest;
 import com.google.bigtable.admin.v2.GetSnapshotRequest;
@@ -33,6 +34,7 @@ import java.util.List;
  * Interface to wrap {@link com.google.cloud.bigtable.grpc.BigtableTableAdminClient} with
  * Google-Cloud-java's models.
  */
+@InternalApi("For internal usage only")
 public interface IBigtableTableAdminClient {
 
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBulkMutation.java
@@ -16,11 +16,13 @@
 package com.google.cloud.bigtable.core;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
 
 /**
  * Interface to support batching multiple {@link RowMutation} request into a single grpc request.
  */
+@InternalApi("For internal usage only")
 public interface IBulkMutation {
 
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGCJClient.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.grpc;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.core.InternalApi;
 import com.google.api.gax.rpc.ServerStream;
 import com.google.api.gax.rpc.StateCheckingResponseObserver;
 import com.google.api.gax.rpc.StreamController;
@@ -40,6 +41,7 @@ import java.util.List;
  * This class implements existing {@link com.google.cloud.bigtable.core.IBigtableDataClient}
  * operations with Google-cloud-java's {@link com.google.cloud.bigtable.data.v2.BigtableDataClient}.
  */
+@InternalApi("For internal usage only")
 public class BigtableDataGCJClient implements IBigtableDataClient, AutoCloseable {
 
   private final BigtableDataClient delegate;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigtable.grpc;
 
 import com.google.api.client.util.Clock;
 import com.google.api.client.util.Strings;
+import com.google.api.core.InternalApi;
 import com.google.api.gax.grpc.GaxGrpcProperties;
 import com.google.api.gax.rpc.ApiClientHeaderProvider;
 import com.google.bigtable.admin.v2.ListClustersResponse;
@@ -400,6 +401,7 @@ public class BigtableSession implements Closeable {
    *
    * @return a {@link IBigtableDataClient} object.
    */
+  @InternalApi("For internal usage only")
   public IBigtableDataClient getDataClientWrapper() {
     if (options.useGCJClient()) {
       return dataGCJClient;
@@ -431,6 +433,7 @@ public class BigtableSession implements Closeable {
    * @param tableName a {@link BigtableTableName} object.
    * @return a {@link IBigtableDataClient} object.
    */
+  @InternalApi("For internal usage only")
   public IBulkMutation createBulkMutationWrapper(BigtableTableName tableName) {
     if (options.useGCJClient()) {
       return getDataClientWrapper().createBulkMutationBatcher();
@@ -456,11 +459,9 @@ public class BigtableSession implements Closeable {
   /**
    * Getter for the field <code>tableAdminClient</code>.
    *
-   * @deprecated Please use {@link #getTableAdminClientWrapper()}.
    * @return a {@link com.google.cloud.bigtable.grpc.BigtableTableAdminClient} object.
    * @throws java.io.IOException if any.
    */
-  @Deprecated
   public synchronized BigtableTableAdminClient getTableAdminClient() throws IOException {
     if (tableAdminClient == null) {
       ManagedChannel channel = createManagedPool(options.getAdminHost(), 1);
@@ -478,6 +479,7 @@ public class BigtableSession implements Closeable {
    * @return a {@link BigtableTableAdminClientWrapper} object.
    * @throws java.io.IOException if any.
    */
+  @InternalApi("For internal usage only")
   public synchronized IBigtableTableAdminClient getTableAdminClientWrapper() throws IOException {
     if (options.useGCJClient()) {
       if (adminGCJClient == null) {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminGCJClient.java
@@ -20,6 +20,7 @@ import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
+import com.google.api.core.InternalApi;
 import com.google.bigtable.admin.v2.CreateTableFromSnapshotRequest;
 import com.google.bigtable.admin.v2.DeleteSnapshotRequest;
 import com.google.bigtable.admin.v2.GetSnapshotRequest;
@@ -42,6 +43,7 @@ import javax.annotation.Nonnull;
  * This class implements existing {@link IBigtableTableAdminClient} operations with
  * Google-cloud-java's {@link BigtableTableAdminClient} & {@link BaseBigtableTableAdminClient}.
  */
+@InternalApi("For internal usage only")
 public class BigtableTableAdminGCJClient implements IBigtableTableAdminClient, AutoCloseable {
 
   private final BigtableTableAdminClient delegate;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationGCJClient.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.grpc.async;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.core.IBulkMutation;
 import com.google.cloud.bigtable.data.v2.models.BulkMutationBatcher;
@@ -28,6 +29,7 @@ import com.google.common.base.Preconditions;
  * This class is meant to replicate existing {@link BulkMutation} while translating calls to
  * Google-Cloud-Java's {@link BulkMutationBatcher} api.
  */
+@InternalApi("For internal usage only")
 public class BulkMutationGCJClient implements IBulkMutation {
 
   private static Logger LOG = new Logger(BulkMutation.class);


### PR DESCRIPTION
All wrapper classes which wrap GCJ client is now be marked with `@InternalApi`, Also removed deprecation from `BigtableSession#getTableAdminClient`.