### PR TITLE
Adding AutoCloseable to IBulkMutation interface

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBulkMutation.java
@@ -18,12 +18,13 @@ package com.google.cloud.bigtable.core;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import java.io.IOException;
 
 /**
  * Interface to support batching multiple {@link RowMutation} request into a single grpc request.
  */
 @InternalApi("For internal usage only")
-public interface IBulkMutation {
+public interface IBulkMutation extends AutoCloseable {
 
   /**
    * Adds a {@link RowMutation} to the underlying IBulkMutation mechanism.
@@ -42,4 +43,7 @@ public interface IBulkMutation {
 
   /** @return false if there is any outstanding {@link RowMutation} that still needs to be sent. */
   boolean isFlushed();
+
+  @Override
+  void close() throws IOException;
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBulkMutation.java
@@ -44,6 +44,7 @@ public interface IBulkMutation extends AutoCloseable {
   /** @return false if there is any outstanding {@link RowMutation} that still needs to be sent. */
   boolean isFlushed();
 
+  /** Closes this bulk Mutation and prevents from mutating any more elements */
   @Override
   void close() throws IOException;
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationGCJClient.java
@@ -24,6 +24,8 @@ import com.google.cloud.bigtable.data.v2.models.BulkMutationBatcher.BulkMutation
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
 import com.google.cloud.bigtable.util.ApiFutureUtil;
 import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
 
 /**
  * This class is meant to replicate existing {@link BulkMutation} while translating calls to
@@ -71,5 +73,14 @@ public class BulkMutationGCJClient implements IBulkMutation {
   @Override
   public boolean isFlushed() {
     return !operationAccountant.hasInflightOperations();
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      bulkMutateBatcher.close();
+    } catch (InterruptedException | TimeoutException e) {
+      throw new IOException("Could not close the bulk mutation Batcher", e);
+    }
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationGCJClient.java
@@ -26,6 +26,7 @@ import com.google.api.core.SettableApiFuture;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.bigtable.data.v2.models.BulkMutationBatcher;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -116,5 +117,17 @@ public class TestBulkMutationGCJClient {
     future.set(null);
     assertTrue("BulkMutation should not have any pending element", bulkMutationClient.isFlushed());
     verify(callable).futureCall(rowMutation);
+  }
+
+  @Test
+  public void testIsClosed() throws IOException {
+    bulkMutationClient.close();
+    Exception actualEx = null;
+    try {
+      bulkMutationClient.add(rowMutation);
+    } catch (Exception e) {
+      actualEx = e;
+    }
+    assertTrue(actualEx instanceof IllegalStateException);
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationWrapper.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.grpc.async;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
@@ -26,6 +27,7 @@ import com.google.cloud.bigtable.core.IBulkMutation;
 import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
 import com.google.common.util.concurrent.Futures;
+import java.io.IOException;
 import java.util.concurrent.Future;
 import org.junit.Before;
 import org.junit.Test;
@@ -81,5 +83,18 @@ public class TestBulkMutationWrapper {
       throw new AssertionError("Assertion failed for BulkMutationWrapper#add(RowMutation)");
     }
     verify(mockDelegate).add(requestProto);
+  }
+
+  @Test
+  public void testIsClosed() throws IOException {
+    bulkWrapper.close();
+    Exception actualEx = null;
+    try {
+      bulkWrapper.add(RowMutation.create("tableId", "key"));
+    } catch (Exception e) {
+      actualEx = e;
+    }
+    assertTrue(actualEx instanceof IllegalStateException);
+    assertEquals("can't mutate when the bulk mutation is closed.", actualEx.getMessage());
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
@@ -93,6 +93,7 @@ public class BigtableBufferedMutatorHelper {
     closedWriteLock.lock();
     try {
       flush();
+      bulkMutation.close();
       closed = true;
     } finally {
       closedWriteLock.unlock();

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigtable.hbase;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -171,5 +172,19 @@ public class TestBigtableBufferedMutator {
     verify(mockBulkMutation, times(count)).add(any(RowMutation.class));
     underTest.flush();
     verify(mockBulkMutation, times(1)).flush();
+  }
+
+  @Test
+  public void testClose() throws IOException {
+    Configuration config = new Configuration(false);
+    doNothing().when(mockBulkMutation).close();
+    when(mockBulkMutation.add(any(RowMutation.class))).thenReturn(future);
+    BigtableBufferedMutator underTest = createMutator(config);
+    underTest.mutate(SIMPLE_PUT);
+
+    underTest.close();
+
+    verify(mockBulkMutation).add(any(RowMutation.class));
+    verify(mockBulkMutation).close();
   }
 }


### PR DESCRIPTION
It seems existing [BulkMutation]() does not have `close()` so I extended `AutoCloseable` to `IBulkMutation`.

Currently, `BigtableBufferedMutator` closes the resources in it's `close()`  so I marked `IBulkMutation` closed in the same.

This will help us to close the GCJ's `BulkMutationBatcher` instance in the current `BulkMutationGCJClient`, and in next PRs we can close the new `Batcher` instance as well.