### PR TITLE
Add sign posts limiting the public surface of bigtable-client-core

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -41,27 +41,27 @@ public class BigtableOptions implements Serializable, Cloneable {
 
   private static final long serialVersionUID = 1L;
 
-  /** <p>For internal use only - public for technical reasons. */
+  /** For internal use only - public for technical reasons. */
   @InternalApi("For internal usage only")
   public static final String BIGTABLE_EMULATOR_HOST_ENV_VAR = "BIGTABLE_EMULATOR_HOST";
 
-  /** <p>For internal use only - public for technical reasons. */
+  /** For internal use only - public for technical reasons. */
   @InternalApi("For internal usage only")
   public static final String BIGTABLE_ADMIN_HOST_DEFAULT = "bigtableadmin.googleapis.com";
 
-  /** <p>For internal use only - public for technical reasons. */
+  /** For internal use only - public for technical reasons. */
   @InternalApi("For internal usage only")
   public static final String BIGTABLE_DATA_HOST_DEFAULT = "bigtable.googleapis.com";
 
-  /** <p>For internal use only - public for technical reasons. */
+  /** For internal use only - public for technical reasons. */
   @InternalApi("For internal usage only")
   public static final String BIGTABLE_BATCH_DATA_HOST_DEFAULT = "batch-bigtable.googleapis.com";
 
-  /** <p>For internal use only - public for technical reasons. */
+  /** For internal use only - public for technical reasons. */
   @InternalApi("For internal usage only")
   public static final int BIGTABLE_PORT_DEFAULT = 443;
 
-  /** <p>For internal use only - public for technical reasons. */
+  /** For internal use only - public for technical reasons. */
   @InternalApi("For internal usage only")
   public static final int BIGTABLE_DATA_CHANNEL_COUNT_DEFAULT = getDefaultDataChannelCount();
 
@@ -74,11 +74,8 @@ public class BigtableOptions implements Serializable, Cloneable {
   @InternalApi("For internal usage only")
   public static final String BIGTABLE_APP_PROFILE_DEFAULT = "";
 
-  /**
-   * @deprecated This field will be removed in future versions.
-   */
-  @Deprecated
-  public static final String BIGTABLE_CLIENT_ADAPTER = "BIGTABLE_CLIENT_ADAPTER";
+  /** @deprecated This field will be removed in future versions. */
+  @Deprecated public static final String BIGTABLE_CLIENT_ADAPTER = "BIGTABLE_CLIENT_ADAPTER";
 
   private static final Logger LOG = new Logger(BigtableOptions.class);
 
@@ -177,7 +174,7 @@ public class BigtableOptions implements Serializable, Cloneable {
       return this;
     }
 
-    /** <p>For internal use only - public for technical reasons. */
+    /** For internal use only - public for technical reasons. */
     @InternalApi("For internal usage only")
     public int getDataChannelCount() {
       return options.dataChannelCount;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -15,6 +15,9 @@
  */
 package com.google.cloud.bigtable.config;
 
+import com.google.api.core.BetaApi;
+import com.google.api.core.InternalApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.cloud.bigtable.grpc.BigtableInstanceName;
 import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.common.annotations.VisibleForTesting;
@@ -33,34 +36,48 @@ import java.util.concurrent.TimeUnit;
  */
 // TODO: Perhaps break this down into smaller options objects?
 // TODO: This should be @Autovalue + Builder
+@InternalExtensionOnly
 public class BigtableOptions implements Serializable, Cloneable {
 
   private static final long serialVersionUID = 1L;
 
-  // If set to a host:port address, this environment variable will configure the client to connect
-  // to a Bigtable emulator running at the given address with plaintext negotiation.
-  // TODO: Link to emulator documentation when available.
-  /** Constant <code>BIGTABLE_EMULATOR_HOST_ENV_VAR="bigtableadmin.googleapis.com"</code> */
+  /** <p>For internal use only - public for technical reasons. */
+  @InternalApi("For internal usage only")
   public static final String BIGTABLE_EMULATOR_HOST_ENV_VAR = "BIGTABLE_EMULATOR_HOST";
 
-  /** Constant <code>BIGTABLE_ADMIN_HOST_DEFAULT="bigtableadmin.googleapis.com"</code> */
+  /** <p>For internal use only - public for technical reasons. */
+  @InternalApi("For internal usage only")
   public static final String BIGTABLE_ADMIN_HOST_DEFAULT = "bigtableadmin.googleapis.com";
-  /** Constant <code>BIGTABLE_DATA_HOST_DEFAULT="bigtable.googleapis.com"</code> */
+
+  /** <p>For internal use only - public for technical reasons. */
+  @InternalApi("For internal usage only")
   public static final String BIGTABLE_DATA_HOST_DEFAULT = "bigtable.googleapis.com";
-  /** Constant <code>BIGTABLE_BATCH_DATA_HOST_DEFAULT="bigtable.googleapis.com"</code> */
+
+  /** <p>For internal use only - public for technical reasons. */
+  @InternalApi("For internal usage only")
   public static final String BIGTABLE_BATCH_DATA_HOST_DEFAULT = "batch-bigtable.googleapis.com";
-  /** Constant <code>BIGTABLE_PORT_DEFAULT=443</code> */
+
+  /** <p>For internal use only - public for technical reasons. */
+  @InternalApi("For internal usage only")
   public static final int BIGTABLE_PORT_DEFAULT = 443;
 
-  /** Constant <code>BIGTABLE_DATA_CHANNEL_COUNT_DEFAULT=getDefaultDataChannelCount()</code> */
+  /** <p>For internal use only - public for technical reasons. */
+  @InternalApi("For internal usage only")
   public static final int BIGTABLE_DATA_CHANNEL_COUNT_DEFAULT = getDefaultDataChannelCount();
 
   /**
    * Constant <code>BIGTABLE_APP_PROFILE_DEFAULT=""</code>, defaults to the server default app
    * profile
+   *
+   * <p>For internal use only - public for technical reasons.
    */
+  @InternalApi("For internal usage only")
   public static final String BIGTABLE_APP_PROFILE_DEFAULT = "";
 
+  /**
+   * @deprecated This field will be removed in future versions.
+   */
+  @Deprecated
   public static final String BIGTABLE_CLIENT_ADAPTER = "BIGTABLE_CLIENT_ADAPTER";
 
   private static final Logger LOG = new Logger(BigtableOptions.class);
@@ -160,6 +177,8 @@ public class BigtableOptions implements Serializable, Cloneable {
       return this;
     }
 
+    /** <p>For internal use only - public for technical reasons. */
+    @InternalApi("For internal usage only")
     public int getDataChannelCount() {
       return options.dataChannelCount;
     }
@@ -202,6 +221,7 @@ public class BigtableOptions implements Serializable, Cloneable {
       return this;
     }
 
+    @BetaApi("Will be removed after hbase transitions away from bigtable-client-core")
     public Builder setUseGCJClient(boolean useGCJClient) {
       options.useGCJClient = useGCJClient;
       return this;
@@ -456,6 +476,7 @@ public class BigtableOptions implements Serializable, Cloneable {
    *
    * @return a boolean flag to decide which client to use for Data & Admin Operations.
    */
+  @BetaApi("Will be removed after hbase transitions away from bigtable-client-core")
   public boolean useGCJClient() {
     return useGCJClient;
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableVeneerSettingsFactory.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableVeneerSettingsFactory.java
@@ -21,6 +21,7 @@ import static io.grpc.internal.GrpcUtil.USER_AGENT_KEY;
 import static org.threeten.bp.Duration.ofMillis;
 
 import com.google.api.core.ApiFunction;
+import com.google.api.core.InternalApi;
 import com.google.api.gax.batching.BatchingSettings;
 import com.google.api.gax.batching.FlowControlSettings;
 import com.google.api.gax.core.CredentialsProvider;
@@ -49,7 +50,10 @@ import org.threeten.bp.Duration;
 /**
  * Static methods to convert an instance of {@link BigtableOptions} to a {@link
  * BigtableDataSettings} or {@link BigtableTableAdminSettings} instance .
+ *
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public class BigtableVeneerSettingsFactory {
 
   /** Constant <code>LOG</code> */

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableVersionInfo.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableVersionInfo.java
@@ -1,9 +1,14 @@
 package com.google.cloud.bigtable.config;
 
+import com.google.api.core.InternalApi;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
+/**
+ * <p>For internal use only - public for technical reasons.
+ */
+@InternalApi("For internal usage only")
 public class BigtableVersionInfo {
 
   private static final Logger LOG = new Logger(BigtableVersionInfo.class);

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableVersionInfo.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableVersionInfo.java
@@ -5,9 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
-/**
- * <p>For internal use only - public for technical reasons.
- */
+/** For internal use only - public for technical reasons. */
 @InternalApi("For internal usage only")
 public class BigtableVersionInfo {
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BulkOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BulkOptions.java
@@ -23,15 +23,13 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import java.io.Serializable;
 
-/**
- * An immutable class providing access to bulk related configuration options for Bigtable.
- */
+/** An immutable class providing access to bulk related configuration options for Bigtable. */
 @InternalExtensionOnly
 public class BulkOptions implements Serializable, Cloneable {
 
   private static final long serialVersionUID = 1L;
 
-  /**<p>For internal use only - public for technical reasons. */
+  /** For internal use only - public for technical reasons. */
   @InternalApi("For internal usage only")
   public static final int BIGTABLE_ASYNC_MUTATOR_COUNT_DEFAULT = 2;
 
@@ -184,9 +182,7 @@ public class BulkOptions implements Serializable, Cloneable {
       return this;
     }
 
-    /**
-     * @deprecated This will be removed in the future
-     */
+    /** @deprecated This will be removed in the future */
     @Deprecated
     public Builder setBulkMutationRpcTargetMs(int bulkMutationRpcTargetMs) {
       options.bulkMutationRpcTargetMs = bulkMutationRpcTargetMs;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BulkOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BulkOptions.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.bigtable.config;
 
+import com.google.api.core.InternalApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.cloud.bigtable.grpc.async.BulkMutation;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
@@ -23,34 +25,42 @@ import java.io.Serializable;
 
 /**
  * An immutable class providing access to bulk related configuration options for Bigtable.
- *
- * @author sduskis
- * @version $Id: $Id
  */
+@InternalExtensionOnly
 public class BulkOptions implements Serializable, Cloneable {
 
   private static final long serialVersionUID = 1L;
 
-  /** Constant <code>BIGTABLE_ASYNC_MUTATOR_COUNT_DEFAULT=2</code> */
+  /**<p>For internal use only - public for technical reasons. */
+  @InternalApi("For internal usage only")
   public static final int BIGTABLE_ASYNC_MUTATOR_COUNT_DEFAULT = 2;
 
   /**
    * This describes the maximum size a bulk mutation RPC should be before sending it to the server
    * and starting the next bulk call. Defaults to 1 MB.
+   *
+   * <p>For internal use only - public for technical reasons.
    */
+  @InternalApi("For internal usage only")
   public static final long BIGTABLE_BULK_MAX_REQUEST_SIZE_BYTES_DEFAULT = 1 << 20;
 
   /**
    * This describes the maximum number of individual MutateRowsRequest.Entry objects to bundle in a
    * single bulk mutation RPC before sending it to the server and starting the next bulk call. The
    * server has a maximum of 100,000 total mutations.
+   *
+   * <p>For internal use only - public for technical reasons.
    */
+  @InternalApi("For internal usage only")
   public static final int BIGTABLE_BULK_MAX_ROW_KEY_COUNT_DEFAULT = 125;
 
   /**
    * Whether or not to enable a mechanism that reduces the likelihood that a {@link BulkMutation}
    * intensive application will overload a cluster.
+   *
+   * <p>For internal use only - public for technical reasons.
    */
+  @InternalApi("For internal usage only")
   public static final boolean BIGTABLE_BULK_ENABLE_THROTTLE_REBALANCE_DEFAULT = false;
 
   /**
@@ -58,19 +68,35 @@ public class BulkOptions implements Serializable, Cloneable {
    * mutation throttling is enabled. 100 ms. is a generally ok latency for MutateRows RPCs, but it
    * could go higher (for example 300 ms) for less latency sensitive applications that need more
    * throughput, or lower (10 ms) for latency sensitive applications.
+   *
+   * <p>For internal use only - public for technical reasons.
    */
+  @InternalApi("For internal usage only")
   public static final int BIGTABLE_BULK_THROTTLE_TARGET_MS_DEFAULT = 100;
 
-  /** The maximum amount of time a row will be buffered for. By default 0: indefinitely. */
+  /**
+   * The maximum amount of time a row will be buffered for. By default 0: indefinitely.
+   *
+   * <p>For internal use only - public for technical reasons.
+   */
+  @InternalApi("For internal usage only")
   public static long BIGTABLE_BULK_AUTOFLUSH_MS_DEFAULT = 0;
 
-  /** Default rpc count per channel. */
+  /**
+   * Default rpc count per channel.
+   *
+   * <p>For internal use only - public for technical reasons.
+   */
+  @InternalApi("For internal usage only")
   public static final int BIGTABLE_MAX_INFLIGHT_RPCS_PER_CHANNEL_DEFAULT = 10;
 
   /**
    * This is the maximum accumulated size of uncompleted requests that we allow before throttling.
    * Default to 10% of available memory with a max of 1GB.
+   *
+   * <p>For internal use only - public for technical reasons.
    */
+  @InternalApi("For internal usage only")
   public static final long BIGTABLE_MAX_MEMORY_DEFAULT =
       (long) Math.min(1 << 30, (Runtime.getRuntime().maxMemory() * 0.1d));
 
@@ -150,13 +176,18 @@ public class BulkOptions implements Serializable, Cloneable {
      * request latency surpasses a latency threshold. The default is {@link
      * BulkOptions#BIGTABLE_BULK_THROTTLE_TARGET_MS_DEFAULT}.
      *
-     * @return a {@link Builder} object, for convenience.
+     * @deprecated This will be removed in the future
      */
+    @Deprecated
     public Builder enableBulkMutationThrottling() {
       options.enableBulkMutationThrottling = true;
       return this;
     }
 
+    /**
+     * @deprecated This will be removed in the future
+     */
+    @Deprecated
     public Builder setBulkMutationRpcTargetMs(int bulkMutationRpcTargetMs) {
       options.bulkMutationRpcTargetMs = bulkMutationRpcTargetMs;
       return this;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CallOptionsConfig.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CallOptionsConfig.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.config;
 
+import com.google.api.core.InternalExtensionOnly;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import java.io.Serializable;
@@ -22,10 +23,8 @@ import java.io.Serializable;
 /**
  * Experimental options to turn on timeout options. {@link io.grpc.CallOptions} supports other
  * settings as well, which this configuration object could help set.
- *
- * @author sduskis
- * @version $Id: $Id
  */
+@InternalExtensionOnly
 public class CallOptionsConfig implements Serializable {
 
   private static final long serialVersionUID = 1L;
@@ -58,6 +57,7 @@ public class CallOptionsConfig implements Serializable {
     private int mutateRpcTimeoutMs = LONG_TIMEOUT_MS_DEFAULT;
     private int readRowsRpcTimeoutMs = LONG_TIMEOUT_MS_DEFAULT;
 
+    /** @deprecated Please use {@link CallOptionsConfig#builder()} */
     @Deprecated
     public Builder() {}
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CredentialFactory.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CredentialFactory.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.config;
 
 import com.google.api.client.util.SecurityUtils;
+import com.google.api.core.InternalApi;
 import com.google.auth.Credentials;
 import com.google.auth.RequestMetadataCallback;
 import com.google.auth.http.HttpTransportFactory;
@@ -41,9 +42,9 @@ import java.util.concurrent.Executor;
 /**
  * Simple factory for creating OAuth Credential objects for use with Bigtable.
  *
- * @author sduskis
- * @version $Id: $Id
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public class CredentialFactory {
 
   /** The OAuth scope required to perform administrator actions such as creating tables. */

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CredentialOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CredentialOptions.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.bigtable.config;
 
+import com.google.api.core.InternalApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.auth.Credentials;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -43,14 +45,15 @@ import java.util.Objects;
  *
  * @see CredentialFactory#getCredentials(CredentialOptions) CredentialFactory for more details on
  *     how CredentialOptions are used to create a {@link com.google.auth.Credentials}.
- * @author sduskis
- * @version $Id: $Id
  */
+@InternalExtensionOnly
 public class CredentialOptions implements Serializable {
   private static final long serialVersionUID = 1L;
 
-  /** Constant <code>SERVICE_ACCOUNT_JSON_ENV_VARIABLE="GOOGLE_APPLICATION_CREDENTIALS"</code> */
+  /** For internal use only - public for technical reasons. */
+  @InternalApi("For internal usage only")
   public static final String SERVICE_ACCOUNT_JSON_ENV_VARIABLE = "GOOGLE_APPLICATION_CREDENTIALS";
+
   /** Constant <code>LOG</code> */
   protected static final Logger LOG = new Logger(CredentialOptions.class);
 
@@ -143,6 +146,7 @@ public class CredentialOptions implements Serializable {
   }
 
   /** A CredentialOptions defined by a serviceAccount and a p12 key file. */
+  @InternalExtensionOnly
   public static class P12CredentialOptions extends CredentialOptions {
     private static final long serialVersionUID = 596647835888116163L;
     private final String serviceAccount;
@@ -179,6 +183,7 @@ public class CredentialOptions implements Serializable {
   }
 
   /** A CredentialOption that supplies the Credentials directly. */
+  @InternalExtensionOnly
   public static class UserSuppliedCredentialOptions extends CredentialOptions {
     private static final long serialVersionUID = -7167146778823641468L;
     private final Credentials credential;
@@ -206,6 +211,7 @@ public class CredentialOptions implements Serializable {
    * A CredentialOption that has a json credentials configured as an InputStream instead of a system
    * environment property.
    */
+  @InternalExtensionOnly
   public static class JsonCredentialsOptions extends CredentialOptions {
     private static final long serialVersionUID = -7868808741264867962L;
     private final InputStream inputStream;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/Logger.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/Logger.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.config;
 
+import com.google.api.core.InternalApi;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -22,9 +23,9 @@ import org.apache.commons.logging.LogFactory;
  * Wrapper around {@link org.apache.commons.logging.Log} to conditionally format messages if a
  * specified log level is enabled.
  *
- * @author sduskis
- * @version $Id: $Id
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public class Logger {
   protected final Log log;
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/RetryOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/RetryOptions.java
@@ -44,7 +44,7 @@ public class RetryOptions implements Serializable, Cloneable {
   @InternalApi("For internal usage only")
   public static final boolean DEFAULT_ENABLE_GRPC_RETRIES = true;
 
-  /** /** For internal use only - public for technical reasons. */
+  /** For internal use only - public for technical reasons. */
   @InternalApi("For internal usage only")
   public static final Set<Status.Code> DEFAULT_ENABLE_GRPC_RETRIES_SET =
       ImmutableSet.of(

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/RetryOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/RetryOptions.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.bigtable.config;
 
+import com.google.api.core.InternalApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 import io.grpc.Status;
@@ -26,24 +28,29 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Options for retrying requests, including back off configuration.
- *
- * @author sduskis
- * @version $Id: $Id
  */
+@InternalExtensionOnly
 public class RetryOptions implements Serializable, Cloneable {
 
   private static final long serialVersionUID = 1L;
 
-  /** Constant <code>DEFAULT_STREAMING_BUFFER_SIZE=60</code> */
+  /**
+   * @deprecated This field will be removed in the future
+   */
+  @Deprecated
   public static int DEFAULT_STREAMING_BUFFER_SIZE = 60;
 
   /**
    * Flag indicating whether or not grpc retries should be enabled. The default is to enable retries
    * on failed idempotent operations.
+   *
+   * <p>For internal use only - public for technical reasons.
    */
+  @InternalApi("For internal usage only")
   public static final boolean DEFAULT_ENABLE_GRPC_RETRIES = true;
 
-  /** Constant <code>DEFAULT_ENABLE_GRPC_RETRIES_SET</code> */
+  /**   /** For internal use only - public for technical reasons. */
+  @InternalApi("For internal usage only")
   public static final Set<Status.Code> DEFAULT_ENABLE_GRPC_RETRIES_SET =
       ImmutableSet.of(
           Status.Code.DEADLINE_EXCEEDED,
@@ -54,18 +61,41 @@ public class RetryOptions implements Serializable, Cloneable {
   /**
    * We can timeout when reading large cells with a low value here. With a 10MB cell limit, 60
    * seconds allows our connection to drop to ~170kbyte/s. A 10 second timeout requires 1Mbyte/s
+   *
+   * <p>For internal use only - public for technical reasons.
    */
+  @InternalApi("For internal usage only")
   public static final int DEFAULT_READ_PARTIAL_ROW_TIMEOUT_MS =
       (int) TimeUnit.MILLISECONDS.convert(60, TimeUnit.SECONDS);
 
-  /** Initial amount of time to wait before retrying failed operations (default value: 5ms). */
+  /**
+   * Initial amount of time to wait before retrying failed operations (default value: 5ms).
+   *
+   * <p>For internal use only - public for technical reasons.
+   */
+  @InternalApi("For internal usage only")
   public static final int DEFAULT_INITIAL_BACKOFF_MILLIS = 5;
-  /** Multiplier to apply to wait times after failed retries (default value: 1.5). */
+  /**
+   * Multiplier to apply to wait times after failed retries (default value: 1.5).
+   *
+   * <p>For internal use only - public for technical reasons.
+   */
+  @InternalApi("For internal usage only")
   public static final double DEFAULT_BACKOFF_MULTIPLIER = 1.5;
-  /** Maximum amount of time to retry before failing the operation (default value: 60 seconds). */
+  /**
+   * Maximum amount of time to retry before failing the operation (default value: 60 seconds).
+   *
+   * <p>For internal use only - public for technical reasons.
+   */
+  @InternalApi("For internal usage only")
   public static final int DEFAULT_MAX_ELAPSED_BACKOFF_MILLIS =
       (int) TimeUnit.MILLISECONDS.convert(60, TimeUnit.SECONDS);
-  /** Maximum number of times to retry after a scan timeout */
+  /**
+   * Maximum number of times to retry after a scan timeout
+   *
+   * <p>For internal use only - public for technical reasons.
+   */
+  @InternalApi("For internal usage only")
   public static final int DEFAULT_MAX_SCAN_TIMEOUT_RETRIES = 3;
 
   public static RetryOptions getDefaultOptions() {
@@ -80,6 +110,9 @@ public class RetryOptions implements Serializable, Cloneable {
   public static class Builder {
     private RetryOptions options;
 
+    /**
+     * @deprecated Please use RetryOptions.builder()
+     */
     @Deprecated
     public Builder() {
       options = new RetryOptions();
@@ -94,6 +127,9 @@ public class RetryOptions implements Serializable, Cloneable {
       options.statusToRetryOn = new HashSet<>(DEFAULT_ENABLE_GRPC_RETRIES_SET);
     }
 
+    /**
+     * @deprecated Please use RetryOptions.toBuilder()
+     */
     public Builder(RetryOptions options) {
       this.options = options.clone();
     }
@@ -178,6 +214,7 @@ public class RetryOptions implements Serializable, Cloneable {
   private int initialBackoffMillis;
   private int maxElapsedBackoffMillis;
   private double backoffMultiplier;
+  @Deprecated
   private int streamingBufferSize;
   private int readPartialRowTimeoutMillis;
   private int maxScanTimeoutRetries;
@@ -194,6 +231,8 @@ public class RetryOptions implements Serializable, Cloneable {
    * @param readPartialRowTimeoutMillis a int.
    * @param maxScanTimeoutRetries a int.
    * @param statusToRetryOn a Set.
+   *
+   * @deprecated Please use RetryOptions.builder()
    */
   @Deprecated
   public RetryOptions(
@@ -272,11 +311,8 @@ public class RetryOptions implements Serializable, Cloneable {
     return statusToRetryOn.contains(Status.Code.DEADLINE_EXCEEDED);
   }
 
-  /**
-   * The maximum number of messages to buffer when scanning.
-   *
-   * @return a int.
-   */
+  /** @deprecated This getter will be removed in the future */
+  @Deprecated
   public int getStreamingBufferSize() {
     return streamingBufferSize;
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/RetryOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/RetryOptions.java
@@ -26,19 +26,14 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-/**
- * Options for retrying requests, including back off configuration.
- */
+/** Options for retrying requests, including back off configuration. */
 @InternalExtensionOnly
 public class RetryOptions implements Serializable, Cloneable {
 
   private static final long serialVersionUID = 1L;
 
-  /**
-   * @deprecated This field will be removed in the future
-   */
-  @Deprecated
-  public static int DEFAULT_STREAMING_BUFFER_SIZE = 60;
+  /** @deprecated This field will be removed in the future */
+  @Deprecated public static int DEFAULT_STREAMING_BUFFER_SIZE = 60;
 
   /**
    * Flag indicating whether or not grpc retries should be enabled. The default is to enable retries
@@ -49,7 +44,7 @@ public class RetryOptions implements Serializable, Cloneable {
   @InternalApi("For internal usage only")
   public static final boolean DEFAULT_ENABLE_GRPC_RETRIES = true;
 
-  /**   /** For internal use only - public for technical reasons. */
+  /** /** For internal use only - public for technical reasons. */
   @InternalApi("For internal usage only")
   public static final Set<Status.Code> DEFAULT_ENABLE_GRPC_RETRIES_SET =
       ImmutableSet.of(
@@ -110,9 +105,7 @@ public class RetryOptions implements Serializable, Cloneable {
   public static class Builder {
     private RetryOptions options;
 
-    /**
-     * @deprecated Please use RetryOptions.builder()
-     */
+    /** @deprecated Please use RetryOptions.builder() */
     @Deprecated
     public Builder() {
       options = new RetryOptions();
@@ -127,9 +120,7 @@ public class RetryOptions implements Serializable, Cloneable {
       options.statusToRetryOn = new HashSet<>(DEFAULT_ENABLE_GRPC_RETRIES_SET);
     }
 
-    /**
-     * @deprecated Please use RetryOptions.toBuilder()
-     */
+    /** @deprecated Please use RetryOptions.toBuilder() */
     public Builder(RetryOptions options) {
       this.options = options.clone();
     }
@@ -214,8 +205,7 @@ public class RetryOptions implements Serializable, Cloneable {
   private int initialBackoffMillis;
   private int maxElapsedBackoffMillis;
   private double backoffMultiplier;
-  @Deprecated
-  private int streamingBufferSize;
+  @Deprecated private int streamingBufferSize;
   private int readPartialRowTimeoutMillis;
   private int maxScanTimeoutRetries;
   private Set<Status.Code> statusToRetryOn;
@@ -231,7 +221,6 @@ public class RetryOptions implements Serializable, Cloneable {
    * @param readPartialRowTimeoutMillis a int.
    * @param maxScanTimeoutRetries a int.
    * @param statusToRetryOn a Set.
-   *
    * @deprecated Please use RetryOptions.builder()
    */
   @Deprecated

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBigtableDataClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBigtableDataClient.java
@@ -31,6 +31,8 @@ import java.util.List;
 /**
  * Interface to wrap {@link com.google.cloud.bigtable.grpc.BigtableDataClient} with
  * Google-Cloud-java's models.
+ *
+ * <p>For internal use only - public for technical reasons.
  */
 @InternalApi("For internal usage only")
 public interface IBigtableDataClient {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBigtableTableAdminClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBigtableTableAdminClient.java
@@ -33,6 +33,8 @@ import java.util.List;
 /**
  * Interface to wrap {@link com.google.cloud.bigtable.grpc.BigtableTableAdminClient} with
  * Google-Cloud-java's models.
+ *
+ * <p>For internal use only - public for technical reasons.
  */
 @InternalApi("For internal usage only")
 public interface IBigtableTableAdminClient {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBulkMutation.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 
 /**
  * Interface to support batching multiple {@link RowMutation} request into a single grpc request.
+ *
+ * <p>For internal use only - public for technical reasons.
  */
 @InternalApi("For internal usage only")
 public interface IBulkMutation extends AutoCloseable {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterName.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterName.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.bigtable.grpc;
 
+import com.google.api.core.InternalApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.common.base.Preconditions;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -23,6 +25,7 @@ import java.util.regex.Pattern;
  * This class encapsulates a cluster name of the form
  * projects/(projectId)/instances/(instanceId)/clusters/(clusterId)
  */
+@InternalExtensionOnly
 public class BigtableClusterName {
   // Use a very loose pattern so we don't validate more strictly than the server.
   private static final Pattern PATTERN =
@@ -32,6 +35,8 @@ public class BigtableClusterName {
   private final String instanceId;
   private final String clusterId;
 
+  /** For internal use only - public for technical reasons. */
+  @InternalApi("For internal usage only")
   public BigtableClusterName(String clusterName) {
     this.clusterName = clusterName;
     Matcher matcher = PATTERN.matcher(clusterName);

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterUtilities.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterUtilities.java
@@ -74,9 +74,7 @@ public class BigtableClusterUtilities implements AutoCloseable {
    * @return The instance id associated with the given project, zone and cluster. We expect instance
    *     and cluster to have one-to-one relationship.
    * @throws IllegalStateException if the cluster is not found
-   * @deprecated This method will be removed in future versions
    */
-  @Deprecated
   public static String lookupInstanceId(String projectId, String clusterId, String zoneId)
       throws IOException {
     BigtableClusterUtilities utils;
@@ -103,9 +101,7 @@ public class BigtableClusterUtilities implements AutoCloseable {
    *     cluster to have one-to-one relationship.
    * @throws IllegalStateException if the cluster is not found or if there are many clusters in this
    *     instance.
-   * @deprecated This method will be removed in future versions
    */
-  @Deprecated
   public static Cluster lookupCluster(String projectId, String instanceId) throws IOException {
     BigtableClusterUtilities utils;
     try {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterUtilities.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterUtilities.java
@@ -74,7 +74,6 @@ public class BigtableClusterUtilities implements AutoCloseable {
    * @return The instance id associated with the given project, zone and cluster. We expect instance
    *     and cluster to have one-to-one relationship.
    * @throws IllegalStateException if the cluster is not found
-   *
    * @deprecated This method will be removed in future versions
    */
   @Deprecated
@@ -104,7 +103,6 @@ public class BigtableClusterUtilities implements AutoCloseable {
    *     cluster to have one-to-one relationship.
    * @throws IllegalStateException if the cluster is not found or if there are many clusters in this
    *     instance.
-   *
    * @deprecated This method will be removed in future versions
    */
   @Deprecated

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterUtilities.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterUtilities.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.bigtable.grpc;
 
+import com.google.api.core.InternalExtensionOnly;
 import com.google.bigtable.admin.v2.Cluster;
 import com.google.bigtable.admin.v2.ListClustersRequest;
 import com.google.bigtable.admin.v2.ListClustersResponse;
@@ -35,6 +36,7 @@ import java.util.concurrent.TimeUnit;
  * large job to increase Cloud Bigtable capacity and 20 minutes after a large batch job to reduce
  * the size.
  */
+@InternalExtensionOnly
 public class BigtableClusterUtilities implements AutoCloseable {
   private static Logger logger = new Logger(BigtableClusterUtilities.class);
 
@@ -72,7 +74,10 @@ public class BigtableClusterUtilities implements AutoCloseable {
    * @return The instance id associated with the given project, zone and cluster. We expect instance
    *     and cluster to have one-to-one relationship.
    * @throws IllegalStateException if the cluster is not found
+   *
+   * @deprecated This method will be removed in future versions
    */
+  @Deprecated
   public static String lookupInstanceId(String projectId, String clusterId, String zoneId)
       throws IOException {
     BigtableClusterUtilities utils;
@@ -99,7 +104,10 @@ public class BigtableClusterUtilities implements AutoCloseable {
    *     cluster to have one-to-one relationship.
    * @throws IllegalStateException if the cluster is not found or if there are many clusters in this
    *     instance.
+   *
+   * @deprecated This method will be removed in future versions
    */
+  @Deprecated
   public static Cluster lookupCluster(String projectId, String instanceId) throws IOException {
     BigtableClusterUtilities utils;
     try {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataClient.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.bigtable.grpc;
 
+import com.google.api.core.InternalApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.bigtable.v2.CheckAndMutateRowRequest;
 import com.google.bigtable.v2.CheckAndMutateRowResponse;
 import com.google.bigtable.v2.MutateRowRequest;
@@ -36,11 +38,8 @@ import java.util.List;
 
 /**
  * Interface to access v2 Bigtable data service methods.
- *
- * @author sduskis
- * @version $Id: $Id
  */
-// TODO: rename this class to differentiate it from `BigtableDataClient` amd `IBigtableDataClient`
+@InternalExtensionOnly
 public interface BigtableDataClient {
 
   /**
@@ -189,7 +188,8 @@ public interface BigtableDataClient {
    * Sets a {@link com.google.cloud.bigtable.grpc.CallOptionsFactory} which creates {@link
    * io.grpc.CallOptions}
    *
-   * @param callOptionsFactory a {@link com.google.cloud.bigtable.grpc.CallOptionsFactory} object.
+   * <p>For internal use only - public for technical reasons.
    */
+  @InternalApi("For internal usage only")
   void setCallOptionsFactory(CallOptionsFactory callOptionsFactory);
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataClient.java
@@ -36,9 +36,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import io.grpc.stub.StreamObserver;
 import java.util.List;
 
-/**
- * Interface to access v2 Bigtable data service methods.
- */
+/** Interface to access v2 Bigtable data service methods. */
 @InternalExtensionOnly
 public interface BigtableDataClient {
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataClientWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataClientWrapper.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.grpc;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.core.InternalApi;
 import com.google.bigtable.v2.CheckAndMutateRowRequest;
 import com.google.bigtable.v2.CheckAndMutateRowResponse;
 import com.google.bigtable.v2.MutateRowRequest;
@@ -51,7 +52,10 @@ import javax.annotation.Nullable;
 /**
  * This class implements the {@link IBigtableDataClient} interface and wraps {@link
  * BigtableDataClient} with Google-cloud-java's models.
+ *
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public class BigtableDataClientWrapper implements IBigtableDataClient {
 
   private final BigtableDataClient delegate;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGCJClient.java
@@ -40,6 +40,8 @@ import java.util.List;
 /**
  * This class implements existing {@link IBigtableDataClient} operations with Google-cloud-java's
  * {@link com.google.cloud.bigtable.data.v2.BigtableDataClient}.
+ *
+ * <p>For internal use only - public for technical reasons.
  */
 @InternalApi("For internal usage only")
 public class BigtableDataGCJClient implements IBigtableDataClient, AutoCloseable {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigtable.grpc;
 import static com.google.cloud.bigtable.grpc.io.GoogleCloudResourcePrefixInterceptor.GRPC_RESOURCE_PREFIX_KEY;
 
 import com.google.api.core.ApiClock;
+import com.google.api.core.InternalApi;
 import com.google.api.core.NanoClock;
 import com.google.bigtable.v2.BigtableGrpc;
 import com.google.bigtable.v2.CheckAndMutateRowRequest;
@@ -77,9 +78,9 @@ import javax.annotation.Nullable;
  * <p>Most of the methods are unary (single response). The only exception is ReadRows which is a
  * streaming call.
  *
- * @author sduskis
- * @version $Id: $Id
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public class BigtableDataGrpcClient implements BigtableDataClient {
 
   private static final ApiClock CLOCK = NanoClock.getDefaultClock();

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableInstanceClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableInstanceClient.java
@@ -47,9 +47,7 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-/**
- * BigtableInstanceClient manages instances and clusters.
- */
+/** BigtableInstanceClient manages instances and clusters. */
 @InternalExtensionOnly
 public interface BigtableInstanceClient {
   /**
@@ -105,9 +103,7 @@ public interface BigtableInstanceClient {
    */
   ListInstancesResponse listInstances(ListInstancesRequest request);
 
-  /**
-   * @deprecated Please use {@link #partialUpdateInstance(PartialUpdateInstanceRequest)}
-   */
+  /** @deprecated Please use {@link #partialUpdateInstance(PartialUpdateInstanceRequest)} */
   @Deprecated
   Instance updateInstance(Instance instance);
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableInstanceClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableInstanceClient.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.grpc;
 
+import com.google.api.core.InternalExtensionOnly;
 import com.google.bigtable.admin.v2.AppProfile;
 import com.google.bigtable.admin.v2.Cluster;
 import com.google.bigtable.admin.v2.CreateAppProfileRequest;
@@ -48,10 +49,8 @@ import java.util.concurrent.TimeoutException;
 
 /**
  * BigtableInstanceClient manages instances and clusters.
- *
- * @author sduskis
- * @version $Id: $Id
  */
+@InternalExtensionOnly
 public interface BigtableInstanceClient {
   /**
    * Create an instance within a project.
@@ -107,11 +106,9 @@ public interface BigtableInstanceClient {
   ListInstancesResponse listInstances(ListInstancesRequest request);
 
   /**
-   * Updates an instance within a project.
-   *
-   * @param instance a {@link com.google.bigtable.admin.v2.Instance} object.
-   * @return a {@link com.google.bigtable.admin.v2.Instance} object.
+   * @deprecated Please use {@link #partialUpdateInstance(PartialUpdateInstanceRequest)}
    */
+  @Deprecated
   Instance updateInstance(Instance instance);
 
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableInstanceGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableInstanceGrpcClient.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.grpc;
 
 import com.google.api.client.util.BackOff;
 import com.google.api.client.util.ExponentialBackOff;
+import com.google.api.core.InternalApi;
 import com.google.bigtable.admin.v2.AppProfile;
 import com.google.bigtable.admin.v2.BigtableInstanceAdminGrpc;
 import com.google.bigtable.admin.v2.Cluster;
@@ -56,9 +57,9 @@ import java.util.concurrent.TimeoutException;
 /**
  * BigtableInstanceGrpcClient class.
  *
- * @author sduskis
- * @version $Id: $Id
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public class BigtableInstanceGrpcClient implements BigtableInstanceClient {
 
   private final BigtableInstanceAdminGrpc.BigtableInstanceAdminBlockingStub instanceClient;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableInstanceName.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableInstanceName.java
@@ -16,6 +16,8 @@
 package com.google.cloud.bigtable.grpc;
 
 import com.google.api.client.util.Strings;
+import com.google.api.core.InternalApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.common.base.Preconditions;
 import java.io.Serializable;
 
@@ -23,10 +25,8 @@ import java.io.Serializable;
  * This class encapsulates a Bigtable instance name. An instance name is of the form
  * projects/(projectId)/instances/(instanceId). It also has convenience methods to create a
  * tableName and a tableId. TableName is (instanceName)/tables/(tableId).
- *
- * @author sduskis
- * @version $Id: $Id
  */
+@InternalExtensionOnly
 public class BigtableInstanceName implements Serializable {
   private static final long serialVersionUID = 1L;
 
@@ -40,12 +40,8 @@ public class BigtableInstanceName implements Serializable {
   private final String projectId;
   private final String instanceId;
 
-  /**
-   * Constructor for BigtableInstanceName.
-   *
-   * @param projectId a {@link java.lang.String} object.
-   * @param instanceId a {@link java.lang.String} object.
-   */
+  /** For internal use only - public for technical reasons. */
+  @InternalApi("For internal usage only")
   public BigtableInstanceName(String projectId, String instanceId) {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId), "projectId must be supplied");
     Preconditions.checkArgument(!Strings.isNullOrEmpty(instanceId), "instanceId must be supplied");

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -19,6 +19,7 @@ package com.google.cloud.bigtable.grpc;
 import com.google.api.client.util.Clock;
 import com.google.api.client.util.Strings;
 import com.google.api.core.InternalApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.grpc.GaxGrpcProperties;
 import com.google.api.gax.rpc.ApiClientHeaderProvider;
 import com.google.bigtable.admin.v2.ListClustersResponse;
@@ -91,10 +92,8 @@ import javax.net.ssl.SSLException;
  *   <li>Creates ChannelInterceptors - auth headers, performance interceptors.
  *   <li>Close anything above that needs to be closed (ExecutorService, ChannelImpls)
  * </ol>
- *
- * @author sduskis
- * @version $Id: $Id
  */
+@InternalExtensionOnly
 public class BigtableSession implements Closeable {
 
   private static final Logger LOG = new Logger(BigtableSession.class);
@@ -399,7 +398,7 @@ public class BigtableSession implements Closeable {
   /**
    * Getter for the field <code>clientWrapper</code>.
    *
-   * @return a {@link IBigtableDataClient} object.
+   * <p>For internal use only - public for technical reasons.
    */
   @InternalApi("For internal usage only")
   public IBigtableDataClient getDataClientWrapper() {
@@ -427,12 +426,7 @@ public class BigtableSession implements Closeable {
         options.getBulkOptions());
   }
 
-  /**
-   * createBulkMutationWrapper.
-   *
-   * @param tableName a {@link BigtableTableName} object.
-   * @return a {@link IBigtableDataClient} object.
-   */
+  /** For internal use only - public for technical reasons. */
   @InternalApi("For internal usage only")
   public IBulkMutation createBulkMutationWrapper(BigtableTableName tableName) {
     if (options.useGCJClient()) {
@@ -476,8 +470,7 @@ public class BigtableSession implements Closeable {
    * Initializes bigtableTableAdminClient based on flag to use GCJ adapter, available in {@link
    * BigtableOptions}.
    *
-   * @return a {@link BigtableTableAdminClientWrapper} object.
-   * @throws IOException if any.
+   * <p>For internal use only - public for technical reasons.
    */
   @InternalApi("For internal usage only")
   public synchronized IBigtableTableAdminClient getTableAdminClientWrapper() throws IOException {
@@ -566,10 +559,9 @@ public class BigtableSession implements Closeable {
    * project id or instance id, so {@link BigtableOptions#getDefaultOptions()} may be used if there
    * are no service account credentials settings.
    *
-   * @return a fully formed {@link BigtableInstanceClient}
-   * @throws IOException
-   * @throws GeneralSecurityException
+   * <p>For internal use only - public for technical reasons.
    */
+  @InternalApi("For internal usage only")
   public static BigtableInstanceClient createInstanceClient(BigtableOptions options)
       throws IOException, GeneralSecurityException {
     return new BigtableInstanceGrpcClient(createChannelPool(options.getAdminHost(), options));
@@ -578,12 +570,9 @@ public class BigtableSession implements Closeable {
   /**
    * Create a new {@link ChannelPool}, with auth headers.
    *
-   * @param host a {@link String} object.
-   * @param options a {@link BigtableOptions} object.
-   * @return a {@link ChannelPool} object.
-   * @throws IOException if any.
-   * @throws GeneralSecurityException
+   * <p>For internal use only - public for technical reasons.
    */
+  @InternalApi("For internal usage only")
   public static ManagedChannel createChannelPool(final String host, final BigtableOptions options)
       throws IOException, GeneralSecurityException {
     return createChannelPool(host, options, 1);
@@ -592,14 +581,9 @@ public class BigtableSession implements Closeable {
   /**
    * Create a new {@link ChannelPool}, with auth headers.
    *
-   * @param host a {@link String} object specifying the host to connect to.
-   * @param options a {@link BigtableOptions} object with the credentials, retry and other
-   *     connection options.
-   * @param count an int defining the number of channels to create
-   * @return a {@link ChannelPool} object.
-   * @throws IOException if any.
-   * @throws GeneralSecurityException
+   * <p>For internal use only - public for technical reasons.
    */
+  @InternalApi("For internal usage only")
   public static ManagedChannel createChannelPool(
       final String host, final BigtableOptions options, int count)
       throws IOException, GeneralSecurityException {
@@ -629,14 +613,8 @@ public class BigtableSession implements Closeable {
     return new ChannelPool(factory, count);
   }
 
-  /**
-   * createNettyChannel.
-   *
-   * @param host a {@link String} object.
-   * @param options a {@link BigtableOptions} object.
-   * @return a {@link ManagedChannel} object.
-   * @throws SSLException if any.
-   */
+  /** For internal use only - public for technical reasons. */
+  @InternalApi("For internal usage only")
   public static ManagedChannel createNettyChannel(
       String host, BigtableOptions options, ClientInterceptor... interceptors) throws SSLException {
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSessionSharedThreadPools.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSessionSharedThreadPools.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.grpc;
 
+import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.util.ThreadUtil;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -25,9 +26,9 @@ import java.util.concurrent.ScheduledExecutorService;
  * few {@link com.google.cloud.bigtable.grpc.BigtableSession}s. All executors are automatically
  * expand if there is higher use.
  *
- * @author sduskis
- * @version $Id: $Id
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public class BigtableSessionSharedThreadPools {
   /** Constant <code>BATCH_POOL_THREAD_NAME="bigtable-batch-pool-%d"</code> */
   private static final String BATCH_POOL_THREAD_NAME_PATTERN = "bigtable-batch-pool-%d";

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSnapshotName.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSnapshotName.java
@@ -19,10 +19,8 @@ import com.google.common.base.Preconditions;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-/**
- * This class encapsulates a Snapshot name of the form
- * projects/(projectId)/instances/(instanceId)/clusters/(clusterId)
- */
+/** @deprecated Snapshots will be removed in the future */
+@Deprecated
 public class BigtableSnapshotName {
   // Use a very loose pattern so we don't validate more strictly than the server.
   private static final Pattern PATTERN =

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminClient.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.grpc;
 
+import com.google.api.core.InternalExtensionOnly;
 import com.google.bigtable.admin.v2.CreateTableFromSnapshotRequest;
 import com.google.bigtable.admin.v2.CreateTableRequest;
 import com.google.bigtable.admin.v2.DeleteSnapshotRequest;
@@ -37,10 +38,8 @@ import java.util.concurrent.TimeoutException;
 
 /**
  * A client for the Cloud Bigtable Table Admin API.
- *
- * @author sduskis
- * @version $Id: $Id
  */
+@InternalExtensionOnly
 public interface BigtableTableAdminClient {
 
   /**
@@ -152,42 +151,23 @@ public interface BigtableTableAdminClient {
       throws InterruptedException, TimeoutException;
 
   // ////////////// SNAPSHOT methods /////////////
-  /**
-   * Creates a new snapshot from a table in a specific cluster.
-   *
-   * @param request a {@link SnapshotTableRequest} object.
-   * @return The long running {@link Operation} for the request.
-   */
+  /** @deprecated Snapshots will be removed in the future */
+  @Deprecated
   ListenableFuture<Operation> snapshotTableAsync(SnapshotTableRequest request);
 
-  /**
-   * Gets metadata information about the specified snapshot.
-   *
-   * @param request a {@link GetSnapshotRequest} object.
-   * @return The {@link Snapshot} defined by the request.
-   */
+  /** @deprecated Snapshots will be removed in the future */
+  @Deprecated
   ListenableFuture<Snapshot> getSnapshotAsync(GetSnapshotRequest request);
 
-  /**
-   * Lists all snapshots associated with the specified cluster.
-   *
-   * @param request a {@link ListSnapshotsRequest} object.
-   * @return The {@link ListSnapshotsResponse} which has the list of the snapshots in the cluster.
-   */
+  /** @deprecated Snapshots will be removed in the future */
+  @Deprecated
   ListenableFuture<ListSnapshotsResponse> listSnapshotsAsync(ListSnapshotsRequest request);
 
-  /**
-   * Permanently deletes the specified snapshot.
-   *
-   * @param request a {@link DeleteSnapshotRequest} object.
-   */
+  /** @deprecated Snapshots will be removed in the future */
+  @Deprecated
   ListenableFuture<Empty> deleteSnapshotAsync(DeleteSnapshotRequest request);
 
-  /**
-   * Creates a new table from a snapshot.
-   *
-   * @param request a {@link CreateTableFromSnapshotRequest} object.
-   * @return The long running {@link Operation} for the request.
-   */
+  /** @deprecated Snapshots will be removed in the future */
+  @Deprecated
   ListenableFuture<Operation> createTableFromSnapshotAsync(CreateTableFromSnapshotRequest request);
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminClient.java
@@ -36,9 +36,7 @@ import com.google.longrunning.Operation;
 import com.google.protobuf.Empty;
 import java.util.concurrent.TimeoutException;
 
-/**
- * A client for the Cloud Bigtable Table Admin API.
- */
+/** A client for the Cloud Bigtable Table Admin API. */
 @InternalExtensionOnly
 public interface BigtableTableAdminClient {
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminClientWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminClientWrapper.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.grpc;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.core.InternalApi;
 import com.google.bigtable.admin.v2.CreateTableFromSnapshotRequest;
 import com.google.bigtable.admin.v2.DeleteSnapshotRequest;
 import com.google.bigtable.admin.v2.DeleteTableRequest;
@@ -47,7 +48,10 @@ import javax.annotation.Nonnull;
 /**
  * This class implements the {@link IBigtableTableAdminClient} interface and wraps {@link
  * BigtableTableAdminClient} with Google-cloud-java's models.
+ *
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public class BigtableTableAdminClientWrapper implements IBigtableTableAdminClient {
 
   private final BigtableTableAdminClient delegate;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminGCJClient.java
@@ -42,6 +42,8 @@ import javax.annotation.Nonnull;
 /**
  * This class implements existing {@link IBigtableTableAdminClient} operations with
  * Google-cloud-java's {@link BigtableTableAdminClient} & {@link BaseBigtableTableAdminClient}.
+ *
+ * <p>For internal use only - public for technical reasons.
  */
 @InternalApi("For internal usage only")
 public class BigtableTableAdminGCJClient implements IBigtableTableAdminClient, AutoCloseable {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminGrpcClient.java
@@ -19,6 +19,7 @@ import static com.google.cloud.bigtable.grpc.io.GoogleCloudResourcePrefixInterce
 
 import com.google.api.client.util.BackOff;
 import com.google.api.client.util.ExponentialBackOff;
+import com.google.api.core.InternalApi;
 import com.google.api.core.NanoClock;
 import com.google.bigtable.admin.v2.BigtableTableAdminGrpc;
 import com.google.bigtable.admin.v2.CheckConsistencyRequest;
@@ -61,9 +62,9 @@ import java.util.concurrent.TimeoutException;
 /**
  * A gRPC client for accessing the Bigtable Table Admin API.
  *
- * @author sduskis
- * @version $Id: $Id
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public class BigtableTableAdminGrpcClient implements BigtableTableAdminClient {
 
   private final BigtableAsyncRpc<ListTablesRequest, ListTablesResponse> listTablesRpc;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableName.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableName.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.grpc;
 
+import com.google.api.core.InternalExtensionOnly;
 import com.google.common.base.Preconditions;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -22,10 +23,8 @@ import java.util.regex.Pattern;
 /**
  * This class encapsulates a tableName. A tableName is of the form
  * projects/(projectId)/zones/(zoneId)/clusters/(clusterId)/tables/(tableId).
- *
- * @author sduskis
- * @version $Id: $Id
  */
+@InternalExtensionOnly
 public class BigtableTableName {
   // Use a very loose pattern so we don't validate more strictly than the server.
   private static final Pattern PATTERN =

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/CallOptionsFactory.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/CallOptionsFactory.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.bigtable.grpc;
 
+import com.google.api.core.InternalApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.bigtable.v2.MutateRowsRequest;
 import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.v2.RowSet;
@@ -28,31 +30,25 @@ import java.util.concurrent.TimeUnit;
 /**
  * A factory that creates {@link CallOptions} for use in {@link BigtableDataClient} RPCs.
  *
- * @author sduskis
- * @version $Id: $Id
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public interface CallOptionsFactory {
 
   /**
    * Provide a {@link CallOptions} object to be used in a single RPC. {@link CallOptions} can
    * contain state, specifically start time with an expiration is set; in cases when timeouts are
    * used, implementations should create a new CallOptions each time this method is called.
-   *
-   * @param descriptor The RPC that's being called. Different methods have different performance
-   *     characteristics, so this parameter can be useful to craft the right timeout for the right
-   *     method.
-   * @param request Some methods, specifically ReadRows, can have variability depending on the
-   *     request. The request can be for either a single row, or a range. This parameter can be used
-   *     to tune timeouts
-   * @param <RequestT> a RequestT object.
-   * @return a {@link CallOptions} object.
    */
   <RequestT> CallOptions create(MethodDescriptor<RequestT, ?> descriptor, RequestT request);
 
   /**
    * Returns {@link CallOptions#DEFAULT} with any {@link Context#current()}'s {@link
    * Context#getDeadline()} applied to it.
+   *
+   * <p>For internal use only - public for technical reasons.
    */
+  @InternalApi("For internal usage only")
   public static class Default implements CallOptionsFactory {
     @Override
     public <RequestT> CallOptions create(
@@ -66,7 +62,12 @@ public interface CallOptionsFactory {
     }
   }
 
-  /** Creates a new {@link CallOptions} based on a {@link CallOptionsConfig}. */
+  /**
+   * Creates a new {@link CallOptions} based on a {@link CallOptionsConfig}.
+   *
+   * <p>For internal use only - public for technical reasons.
+   */
+  @InternalApi("For internal usage only")
   public static class ConfiguredCallOptionsFactory implements CallOptionsFactory {
     private final CallOptionsConfig config;
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/CallOptionsFactory.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/CallOptionsFactory.java
@@ -16,7 +16,6 @@
 package com.google.cloud.bigtable.grpc;
 
 import com.google.api.core.InternalApi;
-import com.google.api.core.InternalExtensionOnly;
 import com.google.bigtable.v2.MutateRowsRequest;
 import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.v2.RowSet;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.grpc.async;
 
 import com.google.api.core.ApiClock;
+import com.google.api.core.InternalApi;
 import com.google.api.gax.retrying.ExponentialRetryAlgorithm;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.retrying.TimedAttemptSettings;
@@ -53,7 +54,12 @@ import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 import org.threeten.bp.temporal.ChronoUnit;
 
-/** A {@link ClientCall.Listener} that retries a {@link BigtableAsyncRpc} request. */
+/**
+ * A {@link ClientCall.Listener} that retries a {@link BigtableAsyncRpc} request.
+ *
+ * <p>For internal use only - public for technical reasons.
+ */
+@InternalApi("For internal usage only")
 @SuppressWarnings("unchecked")
 public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
     extends ClientCall.Listener<ResponseT> {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BigtableAsyncRpc.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BigtableAsyncRpc.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.grpc.async;
 
+import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.metrics.BigtableClientMetrics;
 import com.google.cloud.bigtable.metrics.BigtableClientMetrics.MetricLevel;
 import com.google.cloud.bigtable.metrics.Meter;
@@ -29,9 +30,9 @@ import io.grpc.MethodDescriptor;
  * This interface represents a logical asynchronous RPC end point, including creating a {@link
  * io.grpc.ClientCall} for a new request.
  *
- * @author sduskis
- * @version $Id: $Id
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public interface BigtableAsyncRpc<REQUEST, RESPONSE> {
 
   public static class RpcMetrics {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BigtableAsyncUtilities.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BigtableAsyncUtilities.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.grpc.async;
 
+import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.grpc.async.BigtableAsyncRpc.RpcMetrics;
 import com.google.common.base.Predicate;
@@ -29,9 +30,9 @@ import io.grpc.MethodDescriptor;
 /**
  * Utilities for creating and executing async methods.
  *
- * @author sduskis
- * @version $Id: $Id
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public interface BigtableAsyncUtilities {
 
   /**
@@ -46,7 +47,7 @@ public interface BigtableAsyncUtilities {
   <RequestT, ResponseT> BigtableAsyncRpc<RequestT, ResponseT> createAsyncRpc(
       MethodDescriptor<RequestT, ResponseT> method, Predicate<RequestT> isRetryable);
 
-  public static class Default implements BigtableAsyncUtilities {
+  class Default implements BigtableAsyncUtilities {
     private static final Logger LOG = new Logger(BigtableAsyncUtilities.class);
     private final Channel channel;
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutation.java
@@ -17,6 +17,8 @@
 package com.google.cloud.bigtable.grpc.async;
 
 import com.google.api.client.util.NanoClock;
+import com.google.api.core.InternalApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.bigtable.v2.MutateRowRequest;
 import com.google.bigtable.v2.MutateRowResponse;
 import com.google.bigtable.v2.MutateRowsRequest;
@@ -52,10 +54,8 @@ import java.util.concurrent.TimeUnit;
  * This class combines a collection of {@link MutateRowRequest}s into a single {@link
  * MutateRowsRequest}. This class is not thread safe, and requires calling classes to make it thread
  * safe.
- *
- * @author sduskis
- * @version $Id: $Id
  */
+@InternalExtensionOnly
 public class BulkMutation {
 
   private static final StatusRuntimeException MISSING_ENTRY_EXCEPTION =
@@ -63,9 +63,18 @@ public class BulkMutation {
           .withDescription("Mutation does not have a status")
           .asRuntimeException();
   /** Constant <code>LOG</code> */
-  @VisibleForTesting static Logger LOG = new Logger(BulkMutation.class);
+  @VisibleForTesting
+  static Logger LOG = new Logger(BulkMutation.class);
 
+  /**
+   * <p>For internal use only - public for technical reasons.
+   */
+  @InternalApi("For internal usage only")
   public static final long MAX_RPC_WAIT_TIME_NANOS = TimeUnit.MINUTES.toNanos(12);
+  /**
+   * <p>For internal use only - public for technical reasons.
+   */
+  @InternalApi("For internal usage only")
   public static final long MAX_NUMBER_OF_MUTATIONS = 100_000;
 
   private static StatusRuntimeException toException(Status status) {
@@ -354,18 +363,8 @@ public class BulkMutation {
 
   @VisibleForTesting NanoClock clock = NanoClock.SYSTEM;
 
-  /**
-   * Constructor for BulkMutation.
-   *
-   * @param tableName a {@link BigtableTableName} object for the table to which all {@link
-   *     MutateRowRequest}s will be sent.
-   * @param client a {@link BigtableDataClient} object on which to perform RPCs. RPCs that this
-   *     object performed.
-   * @param retryExecutorService a {@link ScheduledExecutorService} object on which to schedule
-   *     retries.
-   * @param bulkOptions a {@link BulkOptions} with the user specified options for the behavior of
-   *     this instance.
-   */
+  /** For internal use only - public for technical reasons. */
+  @InternalApi("For internal usage only")
   public BulkMutation(
       BigtableTableName tableName,
       BigtableDataClient client,
@@ -374,6 +373,8 @@ public class BulkMutation {
     this(tableName, client, new OperationAccountant(), retryExecutorService, bulkOptions);
   }
 
+  /** For internal use only - public for technical reasons. */
+  @InternalApi("For internal usage only")
   BulkMutation(
       BigtableTableName tableName,
       BigtableDataClient client,

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutation.java
@@ -63,17 +63,12 @@ public class BulkMutation {
           .withDescription("Mutation does not have a status")
           .asRuntimeException();
   /** Constant <code>LOG</code> */
-  @VisibleForTesting
-  static Logger LOG = new Logger(BulkMutation.class);
+  @VisibleForTesting static Logger LOG = new Logger(BulkMutation.class);
 
-  /**
-   * <p>For internal use only - public for technical reasons.
-   */
+  /** For internal use only - public for technical reasons. */
   @InternalApi("For internal usage only")
   public static final long MAX_RPC_WAIT_TIME_NANOS = TimeUnit.MINUTES.toNanos(12);
-  /**
-   * <p>For internal use only - public for technical reasons.
-   */
+  /** For internal use only - public for technical reasons. */
   @InternalApi("For internal usage only")
   public static final long MAX_NUMBER_OF_MUTATIONS = 100_000;
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationGCJClient.java
@@ -30,6 +30,8 @@ import java.util.concurrent.TimeoutException;
 /**
  * This class is meant to replicate existing {@link BulkMutation} while translating calls to
  * Google-Cloud-Java's {@link BulkMutationBatcher} api.
+ *
+ * <p>For internal use only - public for technical reasons.
  */
 @InternalApi("For internal usage only")
 public class BulkMutationGCJClient implements IBulkMutation {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationWrapper.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.grpc.async;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.core.InternalApi;
 import com.google.bigtable.v2.MutateRowResponse;
 import com.google.cloud.bigtable.core.IBulkMutation;
 import com.google.cloud.bigtable.data.v2.internal.RequestContext;
@@ -25,7 +26,12 @@ import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import java.io.IOException;
 
-/** This class wraps existing {@link BulkMutation} with Google-cloud-java's model. */
+/**
+ * This class wraps existing {@link BulkMutation} with Google-cloud-java's model.
+ *
+ * <p>For internal use only - public for technical reasons.
+ */
+@InternalApi("For internal usage only")
 public class BulkMutationWrapper implements IBulkMutation {
 
   private final BulkMutation delegate;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkRead.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkRead.java
@@ -16,6 +16,8 @@
 package com.google.cloud.bigtable.grpc.async;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.core.InternalApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.api.core.SettableApiFuture;
 import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.v2.RowFilter;
@@ -50,10 +52,8 @@ import java.util.concurrent.ExecutorService;
  * row key into a single {@link com.google.bigtable.v2.ReadRowsRequest} with a {@link
  * com.google.bigtable.v2.RowSet} which will result in fewer round trips. This class is not thread
  * safe, and requires calling classes to make it thread safe.
- *
- * @author sduskis
- * @version $Id: $Id
  */
+@InternalExtensionOnly
 public class BulkRead {
 
   /** Constant <code>LOG</code> */
@@ -84,7 +84,10 @@ public class BulkRead {
    * @param tableName a {@link BigtableTableName} object.
    * @param batchSizes The number of keys to lookup per RPC.
    * @param threadPool the {@link ExecutorService} to execute the batched reads on
+   *
+   * <p>For internal use only - public for technical reasons.
    */
+  @InternalApi("For internal usage only")
   public BulkRead(
       IBigtableDataClient client,
       BigtableTableName tableName,
@@ -222,6 +225,10 @@ public class BulkRead {
     }
   }
 
+  /**
+   * <p>For internal use only - public for technical reasons.
+   */
+  @InternalApi("For internal usage only")
   public int getBatchSizes() {
     return batchSizes;
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkRead.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkRead.java
@@ -84,8 +84,7 @@ public class BulkRead {
    * @param tableName a {@link BigtableTableName} object.
    * @param batchSizes The number of keys to lookup per RPC.
    * @param threadPool the {@link ExecutorService} to execute the batched reads on
-   *
-   * <p>For internal use only - public for technical reasons.
+   *     <p>For internal use only - public for technical reasons.
    */
   @InternalApi("For internal usage only")
   public BulkRead(
@@ -225,9 +224,7 @@ public class BulkRead {
     }
   }
 
-  /**
-   * <p>For internal use only - public for technical reasons.
-   */
+  /** For internal use only - public for technical reasons. */
   @InternalApi("For internal usage only")
   public int getBatchSizes() {
     return batchSizes;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/CallController.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/CallController.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.grpc.async;
 
+import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.grpc.scanner.ResponseQueueReader;
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
@@ -26,8 +27,9 @@ import javax.annotation.Nullable;
  * Wraps a {@link ClientCall}, and implements {@link ClientCallStreamObserver} to allow access to
  * the call's underlying functionality.
  *
- * <p>This class is intended to be used by the user to control flow and the life of the call.
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public class CallController<RequestT, ResponseT> extends ClientCallStreamObserver<RequestT> {
   @SuppressWarnings("rawtypes")
   private static final ClientCall NULL_CALL =

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/MutateRowsRequestManager.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/MutateRowsRequestManager.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.grpc.async;
 
+import com.google.api.core.InternalApi;
 import com.google.bigtable.v2.MutateRowsRequest;
 import com.google.bigtable.v2.MutateRowsResponse;
 import com.google.bigtable.v2.MutateRowsResponse.Entry;
@@ -25,7 +26,12 @@ import io.grpc.Status.Code;
 import java.util.ArrayList;
 import java.util.List;
 
-/** Performs retries for {@link BigtableDataClient#mutateRows(MutateRowsRequest)} operations. */
+/**
+ * Performs retries for {@link BigtableDataClient#mutateRows(MutateRowsRequest)} operations.
+ *
+ * <p>For internal use only - public for technical reasons.
+ */
+@InternalApi("For internal usage only")
 public class MutateRowsRequestManager {
   private static final Status STATUS_INTERNAL =
       Status.newBuilder()

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/OperationAccountant.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/OperationAccountant.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.grpc.async;
 
 import com.google.api.client.util.NanoClock;
+import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.FutureCallback;
@@ -28,9 +29,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * Throttles the number of operations that are outstanding at any point in time.
  *
- * @author sduskis
- * @version $Id: $Id
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public class OperationAccountant {
   /** Constant <code>LOG</code> */
   @VisibleForTesting static Logger LOG = new Logger(OperationAccountant.class);

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/ResourceLimiter.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/ResourceLimiter.java
@@ -2,6 +2,7 @@ package com.google.cloud.bigtable.grpc.async;
 
 import com.codahale.metrics.Timer;
 import com.google.api.client.util.NanoClock;
+import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.grpc.BigtableSessionSharedThreadPools;
 import com.google.common.annotations.VisibleForTesting;
@@ -17,9 +18,9 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * This class limits access by RPCs to system resources
  *
- * @author sduskis
- * @version $Id: $Id
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public class ResourceLimiter {
   private static final Logger LOG = new Logger(ResourceLimiter.class);
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/ResourceLimiterStats.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/ResourceLimiterStats.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.grpc.async;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.grpc.BigtableInstanceName;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.HashMap;
@@ -27,7 +28,10 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * This class tracks timing and counts of mutations performed by {@link BulkMutation} and throttling
  * performed by {@link ResourceLimiter}.
+ *
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public class ResourceLimiterStats {
 
   private static Map<String, ResourceLimiterStats> stats = new HashMap<>();

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingMutateRowsOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingMutateRowsOperation.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.grpc.async;
 
 import com.google.api.core.ApiClock;
+import com.google.api.core.InternalApi;
 import com.google.bigtable.v2.MutateRowsRequest;
 import com.google.bigtable.v2.MutateRowsResponse;
 import com.google.cloud.bigtable.config.RetryOptions;
@@ -29,7 +30,12 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 
-/** Performs retries for {@link BigtableDataClient#mutateRows(MutateRowsRequest)} operations. */
+/**
+ * Performs retries for {@link BigtableDataClient#mutateRows(MutateRowsRequest)} operations.
+ *
+ * <p>For internal use only - public for technical reasons.
+ */
+@InternalApi("For internal usage only")
 public class RetryingMutateRowsOperation
     extends AbstractRetryingOperation<
         MutateRowsRequest, MutateRowsResponse, List<MutateRowsResponse>> {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingStreamOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingStreamOperation.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.grpc.async;
 
 import com.google.api.core.ApiClock;
+import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.common.collect.ImmutableList;
 import io.grpc.CallOptions;
@@ -27,9 +28,9 @@ import java.util.concurrent.ScheduledExecutorService;
  * An extension of {@link AbstractRetryingOperation} that aggregates all responses from a streaming
  * request into a List.
  *
- * @author sduskis
- * @version $Id: $Id
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public class RetryingStreamOperation<RequestT, ResponseT>
     extends AbstractRetryingOperation<RequestT, ResponseT, List<ResponseT>> {
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingUnaryOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingUnaryOperation.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.grpc.async;
 
 import com.google.api.core.ApiClock;
+import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.config.RetryOptions;
 import io.grpc.CallOptions;
 import io.grpc.Metadata;
@@ -26,9 +27,9 @@ import java.util.concurrent.ScheduledExecutorService;
 /**
  * A {@link AbstractRetryingOperation} for a unary operation.
  *
- * @author sduskis
- * @version $Id: $Id
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public class RetryingUnaryOperation<RequestT, ResponseT>
     extends AbstractRetryingOperation<RequestT, ResponseT, ResponseT> {
   static final StatusRuntimeException NO_VALUE_SET_EXCEPTION =

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/ThrottlingClientInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/ThrottlingClientInterceptor.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.grpc.async;
 
+import com.google.api.core.InternalApi;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.MessageLite;
 import io.grpc.CallOptions;
@@ -28,7 +29,12 @@ import io.grpc.Status;
 import java.util.concurrent.CancellationException;
 import javax.annotation.Nullable;
 
-/** Throttles requests based on {@link ResourceLimiter} */
+/**
+ * Throttles requests based on {@link ResourceLimiter}
+ *
+ * <p>For internal use only - public for technical reasons.
+ */
+@InternalApi("For internal usage only")
 public class ThrottlingClientInterceptor implements ClientInterceptor {
   private final ResourceLimiter resourceLimiter;
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/ChannelPool.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/ChannelPool.java
@@ -16,7 +16,6 @@
 package com.google.cloud.bigtable.grpc.io;
 
 import com.google.api.core.InternalApi;
-import com.google.api.core.InternalExtensionOnly;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.metrics.BigtableClientMetrics;
 import com.google.cloud.bigtable.metrics.BigtableClientMetrics.MetricLevel;
@@ -54,9 +53,7 @@ public class ChannelPool extends ManagedChannel {
   private static final Key<String> CHANNEL_ID_KEY =
       Key.of("bigtable-channel-id", Metadata.ASCII_STRING_MARSHALLER);
 
-  /**
-   * <p>For internal use only - public for technical reasons.
-   */
+  /** For internal use only - public for technical reasons. */
   @InternalApi("For internal usage only")
   public static final String extractIdentifier(Metadata trailers) {
     return trailers != null ? trailers.get(ChannelPool.CHANNEL_ID_KEY) : "";

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/ChannelPool.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/ChannelPool.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.bigtable.grpc.io;
 
+import com.google.api.core.InternalApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.metrics.BigtableClientMetrics;
 import com.google.cloud.bigtable.metrics.BigtableClientMetrics.MetricLevel;
@@ -40,9 +42,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * Manages a set of ClosableChannels and uses them in a round robin.
  *
- * @author sduskis
- * @version $Id: $Id
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public class ChannelPool extends ManagedChannel {
 
   /** Constant <code>LOG</code> */
@@ -52,6 +54,10 @@ public class ChannelPool extends ManagedChannel {
   private static final Key<String> CHANNEL_ID_KEY =
       Key.of("bigtable-channel-id", Metadata.ASCII_STRING_MARSHALLER);
 
+  /**
+   * <p>For internal use only - public for technical reasons.
+   */
+  @InternalApi("For internal usage only")
   public static final String extractIdentifier(Metadata trailers) {
     return trailers != null ? trailers.get(ChannelPool.CHANNEL_ID_KEY) : "";
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/CredentialInterceptorCache.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/CredentialInterceptorCache.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.grpc.io;
 
+import com.google.api.core.InternalApi;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.cloud.bigtable.config.CredentialFactory;
@@ -35,9 +36,9 @@ import java.util.concurrent.Executors;
  * default authorization cases. In other types of authorization, such as file based Credentials, it
  * will create a new one.
  *
- * @author sduskis
- * @version $Id: $Id
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public class CredentialInterceptorCache {
   private static CredentialInterceptorCache instance = new CredentialInterceptorCache();
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/GoogleCloudResourcePrefixInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/GoogleCloudResourcePrefixInterceptor.java
@@ -15,16 +15,16 @@
  */
 package com.google.cloud.bigtable.grpc.io;
 
+import com.google.api.core.InternalApi;
 import io.grpc.Metadata;
 
 /**
  * Adds a header ("google-cloud-resource-prefix") that usually contains a fully qualified instance
  * or table name.
  *
- * @author sduskis
- * @version $Id: $Id
- * @since 0.9.2
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public class GoogleCloudResourcePrefixInterceptor extends HeaderInterceptor {
 
   /** Constant <code>GRPC_RESOURCE_PREFIX_KEY</code> */

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/HeaderInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/HeaderInterceptor.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.grpc.io;
 
+import com.google.api.core.InternalApi;
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -28,10 +29,9 @@ import io.grpc.MethodDescriptor;
  * Adds a header ("google-cloud-resource-prefix") that usually contains a fully qualified instance
  * or table name.
  *
- * @author sduskis
- * @version $Id: $Id
- * @since 0.9.2
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public class HeaderInterceptor implements ClientInterceptor {
 
   private final Metadata.Key<String> key;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/IOExceptionWithStatus.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/IOExceptionWithStatus.java
@@ -20,9 +20,7 @@ import com.google.api.core.InternalExtensionOnly;
 import io.grpc.Status;
 import java.io.IOException;
 
-/**
- * An IOException that carries a gRPC Status object.
- */
+/** An IOException that carries a gRPC Status object. */
 @InternalExtensionOnly
 public class IOExceptionWithStatus extends IOException {
   private static final long serialVersionUID = 1L;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/IOExceptionWithStatus.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/IOExceptionWithStatus.java
@@ -15,15 +15,15 @@
  */
 package com.google.cloud.bigtable.grpc.io;
 
+import com.google.api.core.InternalApi;
+import com.google.api.core.InternalExtensionOnly;
 import io.grpc.Status;
 import java.io.IOException;
 
 /**
  * An IOException that carries a gRPC Status object.
- *
- * @author sduskis
- * @version $Id: $Id
  */
+@InternalExtensionOnly
 public class IOExceptionWithStatus extends IOException {
   private static final long serialVersionUID = 1L;
   private final Status status;
@@ -31,10 +31,9 @@ public class IOExceptionWithStatus extends IOException {
   /**
    * Constructor for IOExceptionWithStatus.
    *
-   * @param message a {@link java.lang.String} object.
-   * @param cause a {@link java.lang.Throwable} object.
-   * @param status a {@link io.grpc.Status} object.
+   * <p>For internal use only - public for technical reasons.
    */
+  @InternalApi("For internal usage only")
   public IOExceptionWithStatus(String message, Throwable cause, Status status) {
     super(message, cause);
     this.status = status;
@@ -43,9 +42,9 @@ public class IOExceptionWithStatus extends IOException {
   /**
    * Constructor for IOExceptionWithStatus.
    *
-   * @param message a {@link java.lang.String} object.
-   * @param status a {@link io.grpc.Status} object.
+   * <p>For internal use only - public for technical reasons.
    */
+  @InternalApi("For internal usage only")
   public IOExceptionWithStatus(String message, Status status) {
     this(message, status.asRuntimeException(), status);
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/OAuthCredentialsCache.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/OAuthCredentialsCache.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.grpc.io;
 
 import com.google.api.client.util.Clock;
+import com.google.api.core.InternalApi;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.cloud.bigtable.config.Logger;
@@ -40,9 +41,9 @@ import javax.annotation.concurrent.GuardedBy;
  * This class caches calls to {@link OAuth2Credentials#refreshAccessToken()}. It asynchronously
  * refreshes the token when it becomes stale.
  *
- * @author sduskis
- * @version $Id: $Id
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public class OAuthCredentialsCache {
 
   private static final Logger LOG = new Logger(OAuthCredentialsCache.class);

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/RefreshingOAuth2CredentialsInterceptor.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.grpc.io;
 
+import com.google.api.core.InternalApi;
 import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.grpc.io.OAuthCredentialsCache.HeaderToken;
@@ -45,9 +46,9 @@ import java.util.concurrent.TimeUnit;
  * of the Bigtable endpoints are OAuth2 based. It uses the OAuth AccessToken to get the token value
  * and next refresh time. The refresh is scheduled asynchronously.
  *
- * @author sduskis
- * @version $Id: $Id
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public class RefreshingOAuth2CredentialsInterceptor implements ClientInterceptor {
   private static final Logger LOG = new Logger(RefreshingOAuth2CredentialsInterceptor.class);
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/Watchdog.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/Watchdog.java
@@ -46,8 +46,10 @@ import javax.annotation.concurrent.GuardedBy;
  *       stream and forcefully closing the stream. This is measured from the last time the caller
  *       had no outstanding demand.
  * </ul>
+ *
+ * <p>For internal use only - public for technical reasons.
  */
-@InternalApi
+@InternalApi("For internal usage only")
 public class Watchdog implements Runnable {
   public enum State {
     NOT_STARTED,

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/WatchdogInterceptor.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/WatchdogInterceptor.java
@@ -23,8 +23,12 @@ import io.grpc.ClientInterceptor;
 import io.grpc.MethodDescriptor;
 import java.util.Set;
 
-/** Internal implementation detail to prevent RPC from hanging. */
-@InternalApi
+/**
+ * Internal implementation detail to prevent RPC from hanging.
+ *
+ * <p>For internal use only - public for technical reasons.
+ */
+@InternalApi("For internal usage only")
 public class WatchdogInterceptor implements ClientInterceptor {
   private final Set<MethodDescriptor<?, ?>> watchedMethods;
   private final Watchdog watchdog;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/BigtableResultScannerFactory.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/BigtableResultScannerFactory.java
@@ -18,12 +18,9 @@ package com.google.cloud.bigtable.grpc.scanner;
 import com.google.bigtable.v2.ReadRowsRequest;
 
 /**
- * A factory for creating ResultScanners that can be used to scan over Rows for a given
- * ReadRowsRequest.
- *
- * @author sduskis
- * @version $Id: $Id
+ * @deprecated This class will be removed in the future
  */
+@Deprecated
 public interface BigtableResultScannerFactory<ResponseT> {
 
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/BigtableResultScannerFactory.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/BigtableResultScannerFactory.java
@@ -17,9 +17,7 @@ package com.google.cloud.bigtable.grpc.scanner;
 
 import com.google.bigtable.v2.ReadRowsRequest;
 
-/**
- * @deprecated This class will be removed in the future
- */
+/** @deprecated This class will be removed in the future */
 @Deprecated
 public interface BigtableResultScannerFactory<ResponseT> {
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/BigtableRetriesExhaustedException.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/BigtableRetriesExhaustedException.java
@@ -15,23 +15,22 @@
  */
 package com.google.cloud.bigtable.grpc.scanner;
 
+import com.google.api.core.InternalApi;
+import com.google.api.core.InternalExtensionOnly;
 import java.io.IOException;
 
 /**
  * An Exception that is thrown when an operation fails, even in the face of retries.
- *
- * @author sduskis
- * @version $Id: $Id
  */
+@InternalExtensionOnly
 public class BigtableRetriesExhaustedException extends IOException {
   private static final long serialVersionUID = 6905598607595217072L;
 
+
   /**
-   * Constructor for BigtableRetriesExhaustedException.
-   *
-   * @param message a {@link java.lang.String} object.
-   * @param cause a {@link java.lang.Throwable} object.
+   * <p>For internal use only - public for technical reasons.
    */
+  @InternalApi("For internal usage only")
   public BigtableRetriesExhaustedException(String message, Throwable cause) {
     super(message, cause);
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/BigtableRetriesExhaustedException.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/BigtableRetriesExhaustedException.java
@@ -19,17 +19,12 @@ import com.google.api.core.InternalApi;
 import com.google.api.core.InternalExtensionOnly;
 import java.io.IOException;
 
-/**
- * An Exception that is thrown when an operation fails, even in the face of retries.
- */
+/** An Exception that is thrown when an operation fails, even in the face of retries. */
 @InternalExtensionOnly
 public class BigtableRetriesExhaustedException extends IOException {
   private static final long serialVersionUID = 6905598607595217072L;
 
-
-  /**
-   * <p>For internal use only - public for technical reasons.
-   */
+  /** For internal use only - public for technical reasons. */
   @InternalApi("For internal usage only")
   public BigtableRetriesExhaustedException(String message, Throwable cause) {
     super(message, cause);

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/FlatRow.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/FlatRow.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.bigtable.grpc.scanner;
 
+import com.google.api.core.InternalApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.bigtable.v2.Row;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
@@ -27,10 +29,8 @@ import java.util.List;
 
 /**
  * This class stores represents a single row. It's a flattened version of the data of a {@link Row}
- *
- * @author tyagihas
- * @version $Id: $Id
  */
+@InternalExtensionOnly
 public class FlatRow implements Serializable {
 
   private static final long serialVersionUID = 1L;
@@ -39,6 +39,10 @@ public class FlatRow implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * <p>For internal use only - public for technical reasons.
+     */
+    @InternalApi("For internal usage only")
     public static final class Builder {
       private String family;
       private ByteString qualifier;
@@ -79,6 +83,10 @@ public class FlatRow implements Serializable {
       }
     }
 
+    /**
+     * <p>For internal use only - public for technical reasons.
+     */
+    @InternalApi("For internal usage only")
     public static Builder newBuilder() {
       return new Builder();
     }
@@ -89,6 +97,10 @@ public class FlatRow implements Serializable {
     private final ByteString value;
     private final List<String> labels;
 
+    /**
+     * <p>For internal use only - public for technical reasons.
+     */
+    @InternalApi("For internal usage only")
     public Cell(
         String family,
         ByteString qualifier,
@@ -147,6 +159,10 @@ public class FlatRow implements Serializable {
     }
   }
 
+  /**
+   * <p>For internal use only - public for technical reasons.
+   */
+  @InternalApi("For internal usage only")
   public static final class Builder {
     private ByteString rowKey = null;
     private final ImmutableList.Builder<Cell> listBuilder;
@@ -189,6 +205,10 @@ public class FlatRow implements Serializable {
     }
   }
 
+  /**
+   * <p>For internal use only - public for technical reasons.
+   */
+  @InternalApi("For internal usage only")
   public static Builder newBuilder() {
     return new Builder();
   }
@@ -196,6 +216,10 @@ public class FlatRow implements Serializable {
   private final ByteString rowKey;
   private final ImmutableList<Cell> cells;
 
+  /**
+   * <p>For internal use only - public for technical reasons.
+   */
+  @InternalApi("For internal usage only")
   public FlatRow(ByteString rowKey, ImmutableList<Cell> cells) {
     this.rowKey = rowKey;
     this.cells = cells;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/FlatRow.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/FlatRow.java
@@ -39,9 +39,7 @@ public class FlatRow implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    /**
-     * <p>For internal use only - public for technical reasons.
-     */
+    /** For internal use only - public for technical reasons. */
     @InternalApi("For internal usage only")
     public static final class Builder {
       private String family;
@@ -83,9 +81,7 @@ public class FlatRow implements Serializable {
       }
     }
 
-    /**
-     * <p>For internal use only - public for technical reasons.
-     */
+    /** For internal use only - public for technical reasons. */
     @InternalApi("For internal usage only")
     public static Builder newBuilder() {
       return new Builder();
@@ -97,9 +93,7 @@ public class FlatRow implements Serializable {
     private final ByteString value;
     private final List<String> labels;
 
-    /**
-     * <p>For internal use only - public for technical reasons.
-     */
+    /** For internal use only - public for technical reasons. */
     @InternalApi("For internal usage only")
     public Cell(
         String family,
@@ -159,9 +153,7 @@ public class FlatRow implements Serializable {
     }
   }
 
-  /**
-   * <p>For internal use only - public for technical reasons.
-   */
+  /** For internal use only - public for technical reasons. */
   @InternalApi("For internal usage only")
   public static final class Builder {
     private ByteString rowKey = null;
@@ -205,9 +197,7 @@ public class FlatRow implements Serializable {
     }
   }
 
-  /**
-   * <p>For internal use only - public for technical reasons.
-   */
+  /** For internal use only - public for technical reasons. */
   @InternalApi("For internal usage only")
   public static Builder newBuilder() {
     return new Builder();
@@ -216,9 +206,7 @@ public class FlatRow implements Serializable {
   private final ByteString rowKey;
   private final ImmutableList<Cell> cells;
 
-  /**
-   * <p>For internal use only - public for technical reasons.
-   */
+  /** For internal use only - public for technical reasons. */
   @InternalApi("For internal usage only")
   public FlatRow(ByteString rowKey, ImmutableList<Cell> cells) {
     this.rowKey = rowKey;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/FlatRowAdapter.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/FlatRowAdapter.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.grpc.scanner;
 
+import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.data.v2.models.RowAdapter;
 import com.google.cloud.bigtable.grpc.scanner.FlatRow.Cell;
 import com.google.common.collect.ImmutableList;
@@ -25,7 +26,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
 
-/** Adapter for {@link RowAdapter} that uses {@link FlatRow}'s to represent logical rows. */
+/**
+ * Adapter for {@link RowAdapter} that uses {@link FlatRow}'s to represent logical rows.
+ *
+ * <p>For internal use only - public for technical reasons.
+ */
+@InternalApi("For internal usage only")
 public class FlatRowAdapter implements RowAdapter<FlatRow> {
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/FlatRowConverter.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/FlatRowConverter.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.grpc.scanner;
 
+import com.google.api.core.InternalApi;
 import com.google.bigtable.v2.Cell;
 import com.google.bigtable.v2.Column;
 import com.google.bigtable.v2.Family;
@@ -26,9 +27,9 @@ import com.google.protobuf.ByteString;
 /**
  * This class converts between instances of {@link FlatRow} and {@link Row}.
  *
- * @author tyagihas
- * @version $Id: $Id
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public class FlatRowConverter {
 
   public static Row convert(FlatRow row) {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/OutstandingRequestCountListener.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/OutstandingRequestCountListener.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.bigtable.grpc.scanner;
 
-import com.google.api.core.InternalApi;
 import io.grpc.ClientCall;
 import io.grpc.Metadata;
 import io.grpc.Status;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/OutstandingRequestCountListener.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/OutstandingRequestCountListener.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.grpc.scanner;
 
+import com.google.api.core.InternalApi;
 import io.grpc.ClientCall;
 import io.grpc.Metadata;
 import io.grpc.Status;
@@ -25,9 +26,9 @@ import java.util.concurrent.atomic.AtomicInteger;
  * A {@link io.grpc.ClientCall.Listener} that wraps a {@link io.grpc.stub.StreamObserver} and
  * decrements outstandingRequestCount when a message is received.
  *
- * @author sduskis
- * @version $Id: $Id
+ * @deprecated This class will be removed in the future
  */
+@Deprecated
 public class OutstandingRequestCountListener<ResponseT> extends ClientCall.Listener<ResponseT> {
   private StreamObserver<ResponseT> observer;
   private AtomicInteger outstandingRequestCount;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ReadRowsRequestManager.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ReadRowsRequestManager.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.grpc.scanner;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.api.core.InternalApi;
 import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.v2.RowRange;
 import com.google.bigtable.v2.RowRange.EndKeyCase;
@@ -29,9 +30,9 @@ import com.google.protobuf.ByteString;
  * Keeps track of Rows returned from a readRows RPC for information relevant to resuming the RPC
  * after temporary problems.
  *
- * @author sduskis
- * @version $Id: $Id
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 class ReadRowsRequestManager {
 
   // Member variables from the constructor.

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResponseQueueReader.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResponseQueueReader.java
@@ -17,7 +17,6 @@ package com.google.cloud.bigtable.grpc.scanner;
 
 import com.google.api.core.InternalApi;
 import com.google.bigtable.v2.ReadRowsRequest;
-import com.google.cloud.bigtable.grpc.BigtableDataGrpcClient;
 import com.google.cloud.bigtable.metrics.BigtableClientMetrics;
 import com.google.cloud.bigtable.metrics.BigtableClientMetrics.MetricLevel;
 import com.google.cloud.bigtable.metrics.Timer;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResponseQueueReader.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResponseQueueReader.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.grpc.scanner;
 
+import com.google.api.core.InternalApi;
 import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.cloud.bigtable.grpc.BigtableDataGrpcClient;
 import com.google.cloud.bigtable.metrics.BigtableClientMetrics;
@@ -34,11 +35,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * Manages a queue of {@link ResultQueueEntry}s of {@link FlatRow}.
  *
- * @author sduskis
- * @version $Id: $Id
- * @see BigtableDataGrpcClient#readFlatRows(com.google.bigtable.v2.ReadRowsRequest) for more
- *     information.
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public class ResponseQueueReader
     implements StreamObserver<FlatRow>, ClientResponseObserver<ReadRowsRequest, FlatRow> {
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResultQueueEntry.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResultQueueEntry.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.grpc.scanner;
 
+import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.grpc.io.IOExceptionWithStatus;
 import com.google.common.base.Preconditions;
 import io.grpc.Status;
@@ -25,8 +26,9 @@ import java.util.Objects;
  * An entry in the result queue which may be one of: A data message, a Throwable or a marker
  * indicating end-of-stream.
  *
- * @param <T> The type of messages representing data.
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 abstract class ResultQueueEntry<T> {
 
   public enum Type {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResultScanner.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResultScanner.java
@@ -15,16 +15,14 @@
  */
 package com.google.cloud.bigtable.grpc.scanner;
 
+import com.google.api.core.InternalExtensionOnly;
 import java.io.Closeable;
 import java.io.IOException;
 
 /**
  * A scanner of Bigtable rows.
- *
- * @param <T> The type of Rows this scanner will iterate over. Expected Bigtable Row objects.
- * @author sduskis
- * @version $Id: $Id
  */
+@InternalExtensionOnly
 public interface ResultScanner<T> extends Closeable {
   /**
    * Read the next row and block until a row is available. Will return null on end-of-stream.

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResultScanner.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResultScanner.java
@@ -19,9 +19,7 @@ import com.google.api.core.InternalExtensionOnly;
 import java.io.Closeable;
 import java.io.IOException;
 
-/**
- * A scanner of Bigtable rows.
- */
+/** A scanner of Bigtable rows. */
 @InternalExtensionOnly
 public interface ResultScanner<T> extends Closeable {
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResumingStreamingResultScanner.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResumingStreamingResultScanner.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.grpc.scanner;
 
+import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.metrics.BigtableClientMetrics;
 import com.google.cloud.bigtable.metrics.BigtableClientMetrics.MetricLevel;
 import com.google.cloud.bigtable.metrics.Meter;
@@ -27,9 +28,9 @@ import javax.annotation.concurrent.NotThreadSafe;
  * A ResultScanner that attempts to resume the readRows call when it encounters gRPC INTERNAL
  * errors.
  *
- * @author sduskis
- * @version $Id: $Id
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 @NotThreadSafe
 public class ResumingStreamingResultScanner implements ResultScanner<FlatRow> {
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.grpc.scanner;
 
 import com.google.api.client.util.Preconditions;
 import com.google.api.core.ApiClock;
+import com.google.api.core.InternalApi;
 import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.v2.ReadRowsResponse;
 import com.google.cloud.bigtable.config.RetryOptions;
@@ -41,8 +42,9 @@ import javax.annotation.concurrent.NotThreadSafe;
  * RPC. This class will keep track of the last returned row key via {@link ReadRowsRequestManager}
  * and automatically retry from the last row key .
  *
- * @author sduskis
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 @NotThreadSafe
 public class RetryingReadRowsOperation
     extends AbstractRetryingOperation<ReadRowsRequest, ReadRowsResponse, String>

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RowMerger.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RowMerger.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.grpc.scanner;
 
+import com.google.api.core.InternalApi;
 import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.v2.ReadRowsResponse;
 import com.google.bigtable.v2.ReadRowsResponse.CellChunk;
@@ -56,9 +57,9 @@ import java.util.TreeMap;
  *
  * <p><b>NOTE: RowMerger is not threadsafe.</b>
  *
- * @author sduskis
- * @version $Id: $Id
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public class RowMerger implements StreamObserver<ReadRowsResponse> {
 
   protected static final Logger LOG = new Logger(RowMerger.class);

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RowResultScanner.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RowResultScanner.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.grpc.scanner;
 
+import com.google.api.core.InternalApi;
 import com.google.api.gax.rpc.ServerStream;
 import com.google.cloud.bigtable.metrics.BigtableClientMetrics;
 import com.google.cloud.bigtable.metrics.Meter;
@@ -22,7 +23,12 @@ import com.google.cloud.bigtable.metrics.Timer;
 import java.util.ArrayList;
 import java.util.Iterator;
 
-/** A {@link ResultScanner} that wraps GCJ {@link ServerStream}. */
+/**
+ * A {@link ResultScanner} that wraps GCJ {@link ServerStream}.
+ *
+ * <p>For internal use only - public for technical reasons.
+ */
+@InternalApi("For internal usage only")
 public class RowResultScanner<T> implements ResultScanner<T> {
 
   private static final Meter resultsMeter =

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ScanHandler.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ScanHandler.java
@@ -15,10 +15,13 @@
  */
 package com.google.cloud.bigtable.grpc.scanner;
 
+import com.google.api.core.InternalExtensionOnly;
+
 /**
  * An interface that handles timeout exception situations and request cancellations in scan
  * situations.
  */
+@InternalExtensionOnly
 public interface ScanHandler {
   /** Perform an rpc cancellation given a client-side request. */
   void cancel();

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ScanTimeoutException.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ScanTimeoutException.java
@@ -15,14 +15,16 @@
  */
 package com.google.cloud.bigtable.grpc.scanner;
 
+import com.google.api.core.InternalApi;
 import java.io.IOException;
 
 /**
  * An IOException that presents timeout when reading response.
  *
- * @author sduskis
- * @version $Id: $Id
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
+@Deprecated
 public class ScanTimeoutException extends IOException {
 
   private static final long serialVersionUID = 4115316291347038875L;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/StreamObserverAdapter.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/StreamObserverAdapter.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.grpc.scanner;
 
+import com.google.api.core.InternalApi;
 import io.grpc.ClientCall;
 import io.grpc.Metadata;
 import io.grpc.Status;
@@ -24,9 +25,10 @@ import io.grpc.stub.StreamObserver;
  * Adapts a {@link io.grpc.stub.StreamObserver} to a {@link io.grpc.ClientCall.Listener}. {@link
  * io.grpc.ClientCall#request(int)} will be called onNext.
  *
- * @author sduskis
- * @version $Id: $Id
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
+@Deprecated
 public class StreamObserverAdapter<T> extends ClientCall.Listener<T> {
 
   private final ClientCall<?, T> call;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/metrics/DropwizardMetricRegistry.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/metrics/DropwizardMetricRegistry.java
@@ -19,6 +19,7 @@ import com.codahale.metrics.Counting;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.Slf4jReporter;
+import com.google.api.core.InternalExtensionOnly;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 
@@ -26,6 +27,7 @@ import org.slf4j.Logger;
  * A {@link MetricRegistry} that wraps a Dropwizard Metrics {@link
  * com.codahale.metrics.MetricRegistry}.
  */
+@InternalExtensionOnly
 public class DropwizardMetricRegistry implements MetricRegistry {
 
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/ApiFutureUtil.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/ApiFutureUtil.java
@@ -17,12 +17,17 @@ package com.google.cloud.bigtable.util;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureToListenableFuture;
+import com.google.api.core.InternalApi;
 import com.google.api.core.ListenableFutureToApiFuture;
 import com.google.common.base.Function;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 
+/**
+ * <p>For internal use only - public for technical reasons.
+ */
+@InternalApi("For internal usage only")
 public final class ApiFutureUtil {
 
   public static <T> ListenableFuture<T> adapt(final ApiFuture<T> apiFuture) {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/ApiFutureUtil.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/ApiFutureUtil.java
@@ -24,9 +24,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 
-/**
- * <p>For internal use only - public for technical reasons.
- */
+/** For internal use only - public for technical reasons. */
 @InternalApi("For internal usage only")
 public final class ApiFutureUtil {
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/ByteStringComparator.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/ByteStringComparator.java
@@ -15,10 +15,16 @@
  */
 package com.google.cloud.bigtable.util;
 
+import com.google.api.core.InternalApi;
 import com.google.protobuf.ByteString;
 import java.util.Comparator;
 
-/** Compares {@link ByteString}s. */
+/**
+ * Compares {@link ByteString}s.
+ *
+ * <p>For internal use only - public for technical reasons.
+ */
+@InternalApi("For internal usage only")
 public final class ByteStringComparator implements Comparator<ByteString> {
 
   public static final ByteStringComparator INSTANCE = new ByteStringComparator();

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/RowKeyUtil.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/RowKeyUtil.java
@@ -15,8 +15,10 @@
  */
 package com.google.cloud.bigtable.util;
 
+import com.google.api.core.InternalExtensionOnly;
 import java.util.Arrays;
 
+@InternalExtensionOnly
 public class RowKeyUtil {
   private static final byte[] EMPTY_KEY = new byte[0];
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/RowKeyWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/RowKeyWrapper.java
@@ -18,9 +18,7 @@ package com.google.cloud.bigtable.util;
 import com.google.api.core.InternalApi;
 import com.google.protobuf.ByteString;
 
-/**
- * <p>For internal use only - public for technical reasons.
- */
+/** For internal use only - public for technical reasons. */
 @InternalApi("For internal usage only")
 public class RowKeyWrapper implements Comparable<RowKeyWrapper> {
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/RowKeyWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/RowKeyWrapper.java
@@ -15,8 +15,13 @@
  */
 package com.google.cloud.bigtable.util;
 
+import com.google.api.core.InternalApi;
 import com.google.protobuf.ByteString;
 
+/**
+ * <p>For internal use only - public for technical reasons.
+ */
+@InternalApi("For internal usage only")
 public class RowKeyWrapper implements Comparable<RowKeyWrapper> {
 
   private final ByteString key;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/ThreadUtil.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/ThreadUtil.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.util;
 
+import com.google.api.core.InternalApi;
 import com.google.cloud.PlatformInformation;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -25,7 +26,10 @@ import java.util.concurrent.ThreadFactory;
  *
  * <p>This class copies code that originates in {@link
  * io.grpc.internal.GrpcUtil#getThreadFactory(String, boolean)}.
+ *
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public class ThreadUtil {
 
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/TracingUtilities.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/util/TracingUtilities.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.util;
 
+import com.google.api.core.InternalExtensionOnly;
 import com.google.bigtable.admin.v2.BigtableTableAdminGrpc;
 import com.google.bigtable.v2.BigtableGrpc;
 import io.grpc.MethodDescriptor;
@@ -54,6 +55,7 @@ import java.util.List;
  * }
  * </pre>
  */
+@InternalExtensionOnly
 public final class TracingUtilities {
 
   /**

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/src/main/java/com/google/cloud/bigtable/mapreduce/Driver.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/src/main/java/com/google/cloud/bigtable/mapreduce/Driver.java
@@ -15,14 +15,11 @@
  */
 package com.google.cloud.bigtable.mapreduce;
 
+import org.apache.hadoop.classification.InterfaceStability.Evolving;
 import org.apache.hadoop.util.ProgramDriver;
 
-/**
- * Driver for bigtable mapreduce jobs. Select which to run by passing name of job to this main.
- *
- * @author sduskis
- * @version $Id: $Id
- */
+/** Driver for bigtable mapreduce jobs. Select which to run by passing name of job to this main. */
+@Evolving
 public class Driver {
 
   /**


### PR DESCRIPTION
This is in preparation for migrating bigtable-hbase to the new native client

- Mark all default constants as InternalApi
- Mark all wrappers intended for bigtable-hbase's transition to gcj as InternalApi
- Mark all classes that are not exposed directly to user via BigtableSession as InternalApi
- Deprecate bulk mutation throttling
- Remove all `@author` & `@version` boilerplate
- Mark all public classes are InternalExtensionOnly
- Mark all unused classes as deprecated