### PR TITLE
Update travis config to trigger in case of bigtable-2.x PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ jdk:
 branches:
   only:
   - master
+  - bigtable-client-2.x
 
 # Skip the initial dependency install step
 install: true


### PR DESCRIPTION
This should trigger the travis-CI if the PR is raised against `bigtable-client-2.x` branch.