### PR TITLE
Fix Travis build status and landing page [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ Apache 2.0; see [LICENSE](LICENSE) for details.
 
 <!-- references -->
 
-[travis-shield]: https://travis-ci.org/googleapis/cloud-bigtable-client.svg
-[travis-link]: https://travis-ci.org/googleapis/cloud-bigtable-client/builds
+[travis-shield]: https://travis-ci.org/googleapis/java-bigtable-hbase.svg
+[travis-link]: https://travis-ci.org/googleapis/java-bigtable-hbase/builds
 [maven-hbase-shield]: https://maven-badges.herokuapp.com/maven-central/com.google.cloud.bigtable/bigtable-client-core/badge.svg
 [maven-hbase-client-maven-search]: http://search.maven.org/#search%7Cga%7C1%7Ccom.google.cloud.bigtable
 [maven-google-cloud-java-shield]: https://maven-badges.herokuapp.com/maven-central/com.google.cloud/google-cloud-bigtable/badge.svg


### PR DESCRIPTION
Update the name of the repo to match current state, which fixes both issues