### PR TITLE
[Part-1] Adding Integration test cases for Table API

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestBatch.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestBatch.java
@@ -16,7 +16,10 @@
 package com.google.cloud.bigtable.hbase;
 
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -410,6 +413,55 @@ public abstract class AbstractTestBatch extends AbstractTest {
         CellUtil.cloneValue(((Result) results[1]).getColumnLatestCell(COLUMN_FAMILY, qual2)));
 
     table.close();
+  }
+
+  @Test
+  public void testBatchWithNullAndEmptyElements() throws IOException {
+    Table table = getDefaultTable();
+    Exception actualError = null;
+    try {
+      table.batch(null, new Object[1]);
+    } catch (Exception ex) {
+      actualError = ex;
+    }
+    assertNotNull(actualError);
+    actualError = null;
+
+    try {
+      table.batch(ImmutableList.<Row>of(), new Object[0]);
+    } catch (Exception ex) {
+      actualError = ex;
+    }
+    assertNull(actualError);
+  }
+
+  @Test
+  public void testMutateRowWithEmptyElements() throws Exception {
+    Table table = getDefaultTable();
+    Exception actualError = null;
+    try {
+      table.mutateRow(null);
+    } catch (Exception ex) {
+      actualError = ex;
+    }
+    assertNotNull(actualError);
+    actualError = null;
+
+    try {
+      table.mutateRow(new RowMutations(new byte[0]));
+    } catch (Exception ex) {
+      actualError = ex;
+    }
+    assertNotNull(actualError);
+    actualError = null;
+
+    try {
+      // Table#mutateRow ignores requests without Mutations.
+      table.mutateRow(new RowMutations(new byte[1]));
+    } catch (Exception ex) {
+      actualError = ex;
+    }
+    assertNull(actualError);
   }
 
   protected abstract void appendAdd(

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestPut.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestPut.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.hbase;
 
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY2;
+import static org.junit.Assert.assertNotNull;
 
 import com.google.cloud.bigtable.hbase.AbstractTest.QualifierValue;
 import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
@@ -349,6 +350,27 @@ public abstract class AbstractTestPut extends AbstractTest {
     Assert.assertArrayEquals(
         value2, CellUtil.cloneValue(result.getColumnLatestCell(COLUMN_FAMILY, qualifier)));
     table.close();
+  }
+
+  @Test
+  public void testPutWithNullValues() throws IOException {
+    try (Table table = getDefaultTable()) {
+      Exception actualError = null;
+      try {
+        table.put((Put) null);
+      } catch (Exception ex) {
+        actualError = ex;
+      }
+      assertNotNull(actualError);
+      actualError = null;
+
+      try {
+        table.put((List<Put>) null);
+      } catch (Exception ex) {
+        actualError = ex;
+      }
+      assertNotNull(actualError);
+    }
   }
 
   protected abstract Get getGetAddColumnVersion(int version, byte[] rowKey, byte[] qualifier)

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestPut.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestPut.java
@@ -17,10 +17,14 @@ package com.google.cloud.bigtable.hbase;
 
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY2;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import com.google.cloud.bigtable.hbase.AbstractTest.QualifierValue;
 import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
+import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -354,9 +358,14 @@ public abstract class AbstractTestPut extends AbstractTest {
 
   @Test
   public void testPutWithNullValues() throws IOException {
+    // Initialize
+    byte[] testQualifier = dataHelper.randomData("testQualifier-");
+    byte[] testValue = dataHelper.randomData("testValue-");
+
     try (Table table = getDefaultTable()) {
       Exception actualError = null;
       try {
+        // Should throw exception with null Put
         table.put((Put) null);
       } catch (Exception ex) {
         actualError = ex;
@@ -365,11 +374,77 @@ public abstract class AbstractTestPut extends AbstractTest {
       actualError = null;
 
       try {
+        // Should throw exception with null Put
         table.put((List<Put>) null);
       } catch (Exception ex) {
         actualError = ex;
       }
       assertNotNull(actualError);
+      actualError = null;
+
+      try {
+        byte[] rowKeyWithNullQual = dataHelper.randomData("testrow-");
+
+        // Should add a row without any qualifier.
+        table.put(new Put(rowKeyWithNullQual).addColumn(COLUMN_FAMILY, null, testValue));
+
+        Result result = table.get(new Get(rowKeyWithNullQual));
+        assertEquals(1, result.rawCells().length);
+        Cell cell = result.getColumnLatestCell(COLUMN_FAMILY, null);
+        assertArrayEquals(
+            testValue,
+            ByteString.copyFrom(cell.getValueArray(), cell.getValueOffset(), cell.getValueLength())
+                .toByteArray());
+
+      } catch (Exception ex) {
+        actualError = ex;
+      }
+      assertNull(actualError);
+
+      try {
+        byte[] rowKeyWithEmptyQual = dataHelper.randomData("testrow-");
+        byte[] emptyQualifier = new byte[0];
+
+        // should create a row without any qualifier
+        table.put(new Put(rowKeyWithEmptyQual).addColumn(COLUMN_FAMILY, emptyQualifier, testValue));
+
+        Result result = table.get(new Get(rowKeyWithEmptyQual));
+        assertEquals(1, result.rawCells().length);
+        Cell cell = result.getColumnLatestCell(COLUMN_FAMILY, emptyQualifier);
+        assertArrayEquals(
+            testValue,
+            ByteString.copyFrom(cell.getValueArray(), cell.getValueOffset(), cell.getValueLength())
+                .toByteArray());
+      } catch (Exception ex) {
+        actualError = ex;
+      }
+      assertNull(actualError);
+
+      try {
+        byte[] rowKeyEmptyValue = dataHelper.randomData("testrow-");
+
+        // Should create a row with a single column
+        table.put(new Put(rowKeyEmptyValue).addColumn(COLUMN_FAMILY, testQualifier, null));
+
+        Result result = table.get(new Get(rowKeyEmptyValue));
+        assertEquals(1, result.rawCells().length);
+      } catch (Exception ex) {
+        actualError = ex;
+      }
+      assertNull(actualError);
+
+      try {
+        byte[] rowKeyEmptyValue = dataHelper.randomData("testrow-");
+
+        // Should create a row with a single column
+        table.put(new Put(rowKeyEmptyValue).addColumn(COLUMN_FAMILY, testQualifier, new byte[0]));
+
+        Result result = table.get(new Get(rowKeyEmptyValue));
+        assertEquals(1, result.rawCells().length);
+      } catch (Exception ex) {
+        actualError = ex;
+      }
+      assertNull(actualError);
     }
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/TestBufferedMutator.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/TestBufferedMutator.java
@@ -128,6 +128,39 @@ public class TestBufferedMutator extends AbstractTest {
         actualError = ex;
       }
       assertNotNull(actualError);
+      actualError = null;
+
+      try {
+        byte[] rowKey = dataHelper.randomData("test-row");
+        bm.mutate(new Put(rowKey).addColumn(COLUMN_FAMILY, null, value));
+      } catch (Exception ex) {
+        actualError = ex;
+      }
+      assertNull(actualError);
+
+      try {
+        byte[] rowKey = dataHelper.randomData("test-row");
+        bm.mutate(new Put(rowKey).addColumn(COLUMN_FAMILY, new byte[0], value));
+      } catch (Exception ex) {
+        actualError = ex;
+      }
+      assertNull(actualError);
+
+      try {
+        byte[] rowKey = dataHelper.randomData("test-row");
+        bm.mutate(new Put(rowKey).addColumn(COLUMN_FAMILY, qualifier, null));
+      } catch (Exception ex) {
+        actualError = ex;
+      }
+      assertNull(actualError);
+
+      try {
+        byte[] rowKey = dataHelper.randomData("test-row");
+        bm.mutate(new Put(rowKey).addColumn(COLUMN_FAMILY, qualifier, new byte[0]));
+      } catch (Exception ex) {
+        actualError = ex;
+      }
+      assertNull(actualError);
     }
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/TestBufferedMutator.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/TestBufferedMutator.java
@@ -16,12 +16,17 @@
 package com.google.cloud.bigtable.hbase;
 
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
+import com.google.common.collect.ImmutableList;
+import java.util.List;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.hadoop.hbase.client.BufferedMutator;
 import org.apache.hadoop.hbase.client.BufferedMutatorParams;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -93,6 +98,36 @@ public class TestBufferedMutator extends AbstractTest {
       // getWriteBufferSize.  https://issues.apache.org/jira/browse/HBASE-13113
       Assert.assertTrue(
           0 == mutator.getWriteBufferSize() || maxSize == mutator.getWriteBufferSize());
+    }
+  }
+
+  @Test
+  public void testBufferedMutatorWithNullAndEmptyValues() throws Exception {
+    BufferedMutatorParams params = new BufferedMutatorParams(sharedTestEnv.getDefaultTableName());
+    try (BufferedMutator bm = getConnection().getBufferedMutator(params)) {
+      Exception actualError = null;
+      try {
+        bm.mutate((List<? extends Mutation>) null);
+      } catch (Exception ex) {
+        actualError = ex;
+      }
+      assertNotNull(actualError);
+      actualError = null;
+
+      try {
+        bm.mutate(ImmutableList.<Mutation>of());
+      } catch (Exception ex) {
+        actualError = ex;
+      }
+      assertNull(actualError);
+      actualError = null;
+
+      try {
+        bm.mutate(new Put(new byte[0]));
+      } catch (Exception ex) {
+        actualError = ex;
+      }
+      assertNotNull(actualError);
     }
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/TestPutGetDelete.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/TestPutGetDelete.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.hbase;
 
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -63,5 +64,26 @@ public class TestPutGetDelete extends AbstractTest {
     // Confirm deleted
     Assert.assertFalse(table.exists(get));
     table.close();
+  }
+
+  @Test
+  public void testGetWithNullValues() throws IOException {
+    try (Table table = getDefaultTable()) {
+      Exception actualError = null;
+      try {
+        table.get((Get) null);
+      } catch (Exception ex) {
+        actualError = ex;
+      }
+      assertNotNull(actualError);
+      actualError = null;
+
+      try {
+        table.get((List<Get>) null);
+      } catch (Exception ex) {
+        actualError = ex;
+      }
+      assertNotNull(actualError);
+    }
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
@@ -204,9 +204,6 @@ public class BatchExecutor {
    */
   public void batch(List<? extends Row> actions, @Nullable Object[] results)
       throws IOException, InterruptedException {
-    if (results == null) {
-      results = new Object[actions.size()];
-    }
     batchCallback(actions, results, null);
   }
 
@@ -263,8 +260,14 @@ public class BatchExecutor {
       List<? extends Row> actions, Object[] results, Batch.Callback<R> callback)
       throws IOException, InterruptedException {
     Preconditions.checkArgument(
-        results.length == actions.size(),
+        results == null || results.length == actions.size(),
         "Result array must have same dimensions as actions list.");
+    if (actions.isEmpty()) {
+      return;
+    }
+    if (results == null) {
+      results = new Object[actions.size()];
+    }
     Timer.Context timerContext = batchTimer.time();
     List<ApiFuture<?>> resultFutures = issueAsyncRowRequests(actions, results, callback);
     // Don't want to throw an exception for failed futures, instead the place in results is

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
@@ -330,6 +330,12 @@ limitations under the License.
             <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestBatch.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestBatch.java
@@ -15,10 +15,28 @@
  */
 package com.google.cloud.bigtable.hbase;
 
+import static org.junit.Assert.assertNull;
+
+import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.hbase.client.Append;
+import org.apache.hadoop.hbase.client.Table;
+import org.junit.Test;
 
 public class TestBatch extends AbstractTestBatch {
   protected void appendAdd(Append append, byte[] columnFamily, byte[] qualifier, byte[] value) {
     append.addColumn(columnFamily, qualifier, value);
+  }
+
+  @Test
+  public void testBatchWithMismatchedResultArray() throws Exception {
+    Table table = getDefaultTable();
+    Exception actualError = null;
+    try {
+      // This is accepted behaviour in HBase 2 API, It ignores the `new Object[1]` param.
+      table.batchCallback(ImmutableList.of(), new Object[1], null);
+    } catch (Exception ex) {
+      actualError = ex;
+    }
+    assertNull(actualError);
   }
 }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestBatch.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestBatch.java
@@ -16,11 +16,14 @@
 package com.google.cloud.bigtable.hbase;
 
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.verify;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.hbase.client.Append;
 import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.client.coprocessor.Batch;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class TestBatch extends AbstractTestBatch {
   protected void appendAdd(Append append, byte[] columnFamily, byte[] qualifier, byte[] value) {
@@ -28,15 +31,18 @@ public class TestBatch extends AbstractTestBatch {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testBatchWithMismatchedResultArray() throws Exception {
     Table table = getDefaultTable();
     Exception actualError = null;
+    Batch.Callback mockCallBack = Mockito.mock(Batch.Callback.class);
     try {
       // This is accepted behaviour in HBase 2 API, It ignores the `new Object[1]` param.
-      table.batchCallback(ImmutableList.of(), new Object[1], null);
+      table.batchCallback(ImmutableList.of(), new Object[1], mockCallBack);
     } catch (Exception ex) {
       actualError = ex;
     }
     assertNull(actualError);
+    verify(mockCallBack, Mockito.never()).update(Mockito.any(), Mockito.any(), Mockito.any());
   }
 }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableTable.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableTable.java
@@ -28,8 +28,10 @@ import org.apache.hadoop.hbase.client.AbstractBigtableConnection;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Row;
 import org.apache.hadoop.hbase.client.RowMutations;
 import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.client.coprocessor.Batch;
 import org.apache.hadoop.hbase.filter.CompareFilter.CompareOp;
 import org.apache.hadoop.hbase.io.TimeRange;
 
@@ -225,5 +227,16 @@ public class BigtableTable extends AbstractBigtableTable {
         return CheckAndMutateUtil.wasMutationApplied(builder.build(), response);
       }
     };
+  }
+
+  @Override
+  public <R> void batchCallback(
+      List<? extends Row> actions, Object[] results, Batch.Callback<R> callback)
+      throws IOException, InterruptedException {
+    // This check is intentional because HBase-2.x does not perform param validation before return.
+    if (actions.isEmpty()) {
+      return;
+    }
+    super.batchCallback(actions, results, callback);
   }
 }


### PR DESCRIPTION
This change includes fixes for the gap between this & HBase API related focused for Data API.

Note: This PR only contains test cases for operations that had gaps. I would raise more PR for rest of the operations.