### PR TITLE
[Part-2] IT test cases of Admin API for HBase 1 and HBase 2

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestListTables.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestListTables.java
@@ -15,6 +15,10 @@
  */
 package com.google.cloud.bigtable.hbase;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -179,6 +183,68 @@ public abstract class AbstractTestListTables extends AbstractTest {
       TableName nonExistantTableName =
           TableName.valueOf("NA_table2-" + UUID.randomUUID().toString());
       checkTableDescriptor(admin, nonExistantTableName);
+    }
+  }
+
+  @Test
+  public void testListTablesWithEmptyElement() throws IOException {
+    try (Admin admin = getConnection().getAdmin()) {
+
+      sharedTestEnv.createTable(sharedTestEnv.newTestTableName());
+      Exception actualError = null;
+      //      try {
+      //        HTableDescriptor[] descriptors = admin.listTables((Pattern) null);
+      //        assertTrue(descriptors.length > 0);
+      //      } catch (Exception e) {
+      //        actualError = e;
+      //      }
+      //      assertNull(actualError);
+
+      try {
+        admin.listTables((String) null);
+      } catch (Exception e) {
+        actualError = e;
+      }
+      assertNotNull(actualError);
+      actualError = null;
+
+      try {
+        assertEquals(0, admin.listTables("").length);
+      } catch (Exception e) {
+        actualError = e;
+      }
+      assertNull(actualError);
+    }
+  }
+
+  @Test
+  public void testListTableNamesWithEmptyElement() throws IOException {
+    try (Admin admin = getConnection().getAdmin()) {
+
+      sharedTestEnv.createTable(sharedTestEnv.newTestTableName());
+      Exception actualError = null;
+      //      try {
+      //        TableName[] tableNames = admin.listTableNames((Pattern) null);
+      //        assertTrue(tableNames.length > 0);
+      //      } catch (Exception e) {
+      //        actualError = e;
+      //      }
+      //      assertNull(actualError);
+
+      try {
+        admin.listTableNames((String) null);
+      } catch (Exception e) {
+        actualError = e;
+      }
+      assertNotNull(actualError);
+      actualError = null;
+
+      try {
+        assertEquals(0, admin.listTableNames("").length);
+      } catch (Exception e) {
+        actualError = e;
+      }
+      assertNull(actualError);
     }
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/TestAdminOps.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/TestAdminOps.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.util.regex.Pattern;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TestAdminOps extends AbstractTest {
+
+  @Test
+  public void testIsTableEnabledOrDisabled() throws IOException {
+    try (Admin admin = getConnection().getAdmin()) {
+      Exception actualError = null;
+      try {
+        admin.isTableEnabled(null);
+      } catch (Exception e) {
+        actualError = e;
+      }
+      assertNotNull(actualError);
+      assertEquals("TableName cannot be null", actualError.getMessage());
+    }
+
+    try (Admin admin = getConnection().getAdmin()) {
+      Exception actualError = null;
+      try {
+        admin.isTableDisabled(null);
+      } catch (Exception e) {
+        actualError = e;
+      }
+      assertNotNull(actualError);
+      assertEquals("TableName cannot be null", actualError.getMessage());
+    }
+  }
+
+  @Test
+  public void testDisableTablesWithNullOrEmpty() throws IOException {
+    try (Admin admin = getConnection().getAdmin()) {
+      sharedTestEnv.createTable(sharedTestEnv.newTestTableName());
+      Exception actualError = null;
+      try {
+        HTableDescriptor[] descriptors = admin.disableTables((Pattern) null);
+        assertTrue(descriptors.length > 0);
+      } catch (Exception e) {
+        actualError = e;
+      }
+      assertNull(actualError);
+    }
+
+    try (Admin admin = getConnection().getAdmin()) {
+      Exception actualError = null;
+      try {
+        admin.disableTables((String) null);
+      } catch (Exception e) {
+        actualError = e;
+      }
+      assertNotNull(actualError);
+    }
+
+    try (Admin admin = getConnection().getAdmin()) {
+      Exception actualError = null;
+      try {
+        assertEquals(0, admin.disableTables("").length);
+      } catch (Exception e) {
+        actualError = e;
+      }
+      assertNull(actualError);
+    }
+  }
+
+  @Test
+  public void testEnableTablesWithNull() throws IOException {
+    try (Admin admin = getConnection().getAdmin()) {
+
+      sharedTestEnv.createTable(sharedTestEnv.newTestTableName());
+      Exception actualError = null;
+      try {
+        HTableDescriptor[] descriptors = admin.enableTables((Pattern) null);
+        assertTrue(descriptors.length > 0);
+      } catch (Exception e) {
+        actualError = e;
+      }
+      assertNull(actualError);
+    }
+
+    try (Admin admin = getConnection().getAdmin()) {
+      Exception actualError = null;
+      try {
+        admin.enableTables((String) null);
+      } catch (Exception e) {
+        actualError = e;
+      }
+      assertNotNull(actualError);
+    }
+
+    try (Admin admin = getConnection().getAdmin()) {
+      Exception actualError = null;
+      try {
+        assertEquals(0, admin.enableTables("").length);
+      } catch (Exception e) {
+        actualError = e;
+      }
+      assertNull(actualError);
+    }
+  }
+
+  @Test
+  @Ignore // This fails with either TableNotFoundException or FAILED_PRECONDITION.
+  public void testGetTableDescriptorsByTableNameWithNullAndEmptyList() throws IOException {
+    try (Admin admin = getConnection().getAdmin()) {
+      Exception actualError = null;
+      try {
+        HTableDescriptor[] descriptor = admin.getTableDescriptorsByTableName(null);
+        assertTrue(descriptor.length > 0);
+      } catch (Exception e) {
+        actualError = e;
+      }
+      assertNull(actualError);
+
+      try {
+        HTableDescriptor[] descriptor =
+            admin.getTableDescriptorsByTableName(ImmutableList.<TableName>of());
+        assertTrue(descriptor.length > 0);
+      } catch (Exception e) {
+        e.printStackTrace(System.out);
+        actualError = e;
+      }
+      assertNull(actualError);
+    }
+  }
+
+  @Test
+  @Ignore // This also fails with similar results
+  public void testGetTableDescriptorsWithNullAndEmptyList() throws IOException {
+    try (Admin admin = getConnection().getAdmin()) {
+      Exception actualError = null;
+      try {
+        HTableDescriptor[] descriptor = admin.getTableDescriptors(null);
+        assertTrue(descriptor.length > 0);
+      } catch (Exception e) {
+        actualError = e;
+      }
+      assertNull(actualError);
+
+      try {
+        HTableDescriptor[] descriptor = admin.getTableDescriptors(ImmutableList.<String>of());
+        assertTrue(descriptor.length > 0);
+      } catch (Exception e) {
+        e.printStackTrace(System.out);
+        actualError = e;
+      }
+      assertNull(actualError);
+    }
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
@@ -36,6 +36,7 @@ import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
 import com.google.cloud.bigtable.hbase.adapters.admin.TableAdapter;
 import com.google.cloud.bigtable.hbase.util.ModifyTableBuilder;
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -198,6 +199,9 @@ public abstract class AbstractBigtableAdmin implements Admin {
   /** {@inheritDoc} */
   @Override
   public TableName[] listTableNames(Pattern pattern) throws IOException {
+    if (pattern == null) {
+      return listTableNames();
+    }
     List<TableName> result = new ArrayList<>();
 
     for (TableName tableName : listTableNames()) {
@@ -524,6 +528,7 @@ public abstract class AbstractBigtableAdmin implements Admin {
   /** {@inheritDoc} */
   @Override
   public boolean isTableDisabled(TableName tableName) throws IOException {
+    Preconditions.checkNotNull(tableName, "TableName cannot be null");
     return disabledTables.contains(tableName);
   }
 
@@ -697,6 +702,10 @@ public abstract class AbstractBigtableAdmin implements Admin {
   @Override
   public HTableDescriptor[] getTableDescriptorsByTableName(List<TableName> tableNames)
       throws IOException {
+    if (tableNames == null || tableNames.isEmpty()) {
+      return listTables();
+    }
+
     TableName[] tableNameArray = tableNames.toArray(new TableName[tableNames.size()]);
     return getTableDescriptors(tableNameArray);
   }
@@ -704,6 +713,10 @@ public abstract class AbstractBigtableAdmin implements Admin {
   /** {@inheritDoc} */
   @Override
   public HTableDescriptor[] getTableDescriptors(List<String> names) throws IOException {
+    if (names == null || names.isEmpty()) {
+      return listTables();
+    }
+
     TableName[] tableNameArray = new TableName[names.size()];
     for (int i = 0; i < names.size(); i++) {
       tableNameArray[i] = TableName.valueOf(names.get(i));

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
@@ -24,6 +24,7 @@ import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
+  TestAdminOps.class,
   TestAppend.class,
   TestAuth.class,
   TestBasicOps.class,

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
@@ -36,6 +36,7 @@ import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
+  TestAdminOps.class,
   TestAppend.class,
   TestBasicOps.class,
   TestBatch.class,


### PR DESCRIPTION
This change includes addresses the gap between this Bigtable client and HBase API for the below methods:

- Admin#listTableNames(Pattern)
- Admin#getTableDescriptorsByTableName(List)(It is being called by below operations)
  - Admin#getTableDescriptors(List)
  - Admin#listTables(Pattern)
  - Admin#enableTables(Pattern)
  - Admin#disableTables(Pattern)
  - Admin#deleteTables(Pattern)
- Admin#isTableDisabled(TableName)
  - Admin#isTableEnabled(TableName)