### PR TITLE
feat: enable directpath

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -279,7 +279,7 @@ this is not used directly, but upgrading due to transitive vulnerabilities in ol
                 <configuration>
                     <!-- commons-codec is not used directly, but upgrading due to transitive vulnerabilities in older versions.
                     grpc-alts is a runtime dep-->
-                    <usedDependencies>commons-codec:commons-codec,io.grpc:grpc-alts</usedDependencies>
+                    <usedDependencies>commons-codec:commons-codec,io.grpc:grpc-grpclb</usedDependencies>
                 </configuration>
             </plugin>
         </plugins>

--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -179,6 +179,10 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
+            <artifactId>grpc-grpclb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
             <artifactId>grpc-netty-shaded</artifactId>
         </dependency>
         <dependency>

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -55,6 +55,11 @@ public class BigtableOptions implements Serializable, Cloneable {
   @InternalApi("For internal usage only")
   public static final String BIGTABLE_DATA_HOST_DEFAULT = "bigtable.googleapis.com";
 
+  // Temporary DirectPath config
+  private static final String DIRECT_PATH_ENV_VAR = "GOOGLE_CLOUD_ENABLE_DIRECT_PATH";
+  private static final String BIGTABLE_DIRECTPATH_DATA_HOST_DEFAULT =
+      "directpath-bigtable.googleapis.com";
+
   /** For internal use only - public for technical reasons. */
   @InternalApi("For internal usage only")
   public static final String BIGTABLE_BATCH_DATA_HOST_DEFAULT = "batch-bigtable.googleapis.com";
@@ -92,6 +97,27 @@ public class BigtableOptions implements Serializable, Cloneable {
     return builder().build();
   }
 
+  /**
+   * Checks if DirectPath is enabled via an environment variable.
+   *
+   * <p>For internal use only - public for technical reasons.
+   */
+  @InternalApi("For internal use only")
+  public static boolean isDirectPathEnabled() {
+    String whiteList = MoreObjects.firstNonNull(System.getenv(DIRECT_PATH_ENV_VAR), "").trim();
+
+    if (whiteList.isEmpty()) {
+      return false;
+    }
+
+    for (String entry : whiteList.split(",")) {
+      if (BIGTABLE_DATA_HOST_DEFAULT.contains(entry)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /** Create a new instance of the {@link Builder}. */
   public static Builder builder() {
     return new Builder();
@@ -108,7 +134,10 @@ public class BigtableOptions implements Serializable, Cloneable {
       options.appProfileId = BIGTABLE_APP_PROFILE_DEFAULT;
 
       // Optional configuration for hosts - useful for the Bigtable team, more than anything else.
-      options.dataHost = BIGTABLE_DATA_HOST_DEFAULT;
+      options.dataHost =
+          isDirectPathEnabled()
+              ? BIGTABLE_DIRECTPATH_DATA_HOST_DEFAULT
+              : BIGTABLE_DATA_HOST_DEFAULT;
       options.adminHost = BIGTABLE_ADMIN_HOST_DEFAULT;
       options.port = BIGTABLE_PORT_DEFAULT;
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -48,7 +48,6 @@ public class BigtableOptions implements Serializable, Cloneable {
     ManagedChannelBuilder configureChannel(ManagedChannelBuilder builder, String host);
   }
 
-
   private static final long serialVersionUID = 1L;
 
   /** For internal use only - public for technical reasons. */

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -24,9 +24,11 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import io.grpc.ManagedChannelBuilder;
 import java.io.Serializable;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 
 /**
  * An immutable class providing access to configuration options for Bigtable.
@@ -40,6 +42,12 @@ import java.util.concurrent.TimeUnit;
 // TODO: This should be @Autovalue + Builder
 @InternalExtensionOnly
 public class BigtableOptions implements Serializable, Cloneable {
+  /** For internal use only - public for technical reasons. */
+  @InternalApi("Visible for test only")
+  public interface ChannelConfigurator {
+    ManagedChannelBuilder configureChannel(ManagedChannelBuilder builder, String host);
+  }
+
 
   private static final long serialVersionUID = 1L;
 
@@ -206,6 +214,13 @@ public class BigtableOptions implements Serializable, Cloneable {
     }
 
     /** For internal use only - public for technical reasons. */
+    @InternalApi("Visible for test only")
+    public Builder setChannelConfigurator(ChannelConfigurator configurator) {
+      this.options.channelConfigurator = configurator;
+      return this;
+    }
+
+    /** For internal use only - public for technical reasons. */
     @InternalApi("For internal usage only")
     public int getDataChannelCount() {
       return options.dataChannelCount;
@@ -360,6 +375,7 @@ public class BigtableOptions implements Serializable, Cloneable {
   private boolean usePlaintextNegotiation;
   private boolean useCachedDataPool;
   private boolean useGCJClient;
+  private ChannelConfigurator channelConfigurator;
 
   private BigtableInstanceName instanceName;
 
@@ -463,6 +479,13 @@ public class BigtableOptions implements Serializable, Cloneable {
     return dataChannelCount;
   }
 
+  /** For internal use only - public for technical reasons. */
+  @InternalApi("Visible for testing only")
+  @Nullable
+  public ChannelConfigurator getChannelConfigurator() {
+    return channelConfigurator;
+  }
+
   /**
    * Getter for the field <code>instanceName</code>.
    *
@@ -534,7 +557,8 @@ public class BigtableOptions implements Serializable, Cloneable {
         && Objects.equals(bulkOptions, other.bulkOptions)
         && Objects.equals(callOptionsConfig, other.callOptionsConfig)
         && Objects.equals(useBatch, other.useBatch)
-        && Objects.equals(useGCJClient, other.useGCJClient);
+        && Objects.equals(useGCJClient, other.useGCJClient)
+        && Objects.equals(channelConfigurator, other.channelConfigurator);
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterUtilities.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterUtilities.java
@@ -153,7 +153,7 @@ public class BigtableClusterUtilities implements AutoCloseable {
             "ProjectId and instanceId have to be set in the options.  Use '-' for all instanceIds.");
 
     ClientInterceptor[] interceptors =
-        BigtableSession.createInterceptors(options, true).toArray(new ClientInterceptor[0]);
+        BigtableSession.createAdminApiInterceptors(options).toArray(new ClientInterceptor[0]);
     channel = BigtableSession.createNettyChannel(options.getAdminHost(), options, interceptors);
     client = new BigtableInstanceGrpcClient(channel);
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterUtilities.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableClusterUtilities.java
@@ -153,7 +153,7 @@ public class BigtableClusterUtilities implements AutoCloseable {
             "ProjectId and instanceId have to be set in the options.  Use '-' for all instanceIds.");
 
     ClientInterceptor[] interceptors =
-        BigtableSession.createInterceptors(options).toArray(new ClientInterceptor[0]);
+        BigtableSession.createInterceptors(options, true).toArray(new ClientInterceptor[0]);
     channel = BigtableSession.createNettyChannel(options.getAdminHost(), options, interceptors);
     client = new BigtableInstanceGrpcClient(channel);
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -614,6 +614,11 @@ public class BigtableSession implements Closeable {
         builder.usePlaintext();
       }
     }
+
+    if (options.getChannelConfigurator() != null) {
+      builder = options.getChannelConfigurator().configureChannel(builder, host);
+    }
+
     return builder
         .idleTimeout(Long.MAX_VALUE, TimeUnit.SECONDS)
         .maxInboundMessageSize(MAX_MESSAGE_SIZE)

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableOptionsFactory.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableOptionsFactory.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.hbase;
 
 import static com.google.cloud.bigtable.config.CallOptionsConfig.LONG_TIMEOUT_MS_DEFAULT;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.google.auth.Credentials;
 import com.google.cloud.bigtable.config.BigtableOptions;
@@ -81,13 +82,18 @@ public class TestBigtableOptionsFactory {
   }
 
   @Test
-  public void testAdminHostKeyIsUsed() throws IOException {
-    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
-    configuration.set(BigtableOptionsFactory.BIGTABLE_ADMIN_HOST_KEY, TEST_HOST);
-    configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_USE_SERVICE_ACCOUNTS_KEY, false);
-    configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, true);
+  public void testConnectionKeysAreUsed() throws IOException {
+    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, "data-host");
+    configuration.set(BigtableOptionsFactory.BIGTABLE_ADMIN_HOST_KEY, "admin-host");
+    configuration.setInt(BigtableOptionsFactory.BIGTABLE_PORT_KEY, 1234);
+    configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_USE_PLAINTEXT_NEGOTIATION, true);
     BigtableOptions options = BigtableOptionsFactory.fromConfiguration(configuration);
-    assertEquals(TEST_HOST, options.getDataHost());
+
+    assertEquals("data-host", options.getDataHost());
+    assertEquals("admin-host", options.getAdminHost());
+    assertEquals(1234, options.getPort());
+    assertTrue(
+        "BIGTABLE_USE_PLAINTEXT_NEGOTIATION was not propagated", options.usePlaintextNegotiation());
   }
 
   @Test

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
@@ -44,6 +44,9 @@ limitations under the License.
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <trimStackTrace>false</trimStackTrace>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>api-integration-test</id>
@@ -86,6 +89,9 @@ limitations under the License.
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <trimStackTrace>false</trimStackTrace>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>api-integration-test</id>
@@ -132,6 +138,9 @@ limitations under the License.
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <trimStackTrace>false</trimStackTrace>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>api-integration-test</id>
@@ -172,6 +181,9 @@ limitations under the License.
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <trimStackTrace>false</trimStackTrace>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>api-integration-test</id>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/DirectPathFallbackIT.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/DirectPathFallbackIT.java
@@ -1,0 +1,233 @@
+package com.google.cloud.bigtable.hbase;
+
+import com.google.bigtable.repackaged.com.google.bigtable.v2.ReadRowsRequest;
+import com.google.bigtable.repackaged.com.google.bigtable.v2.RowSet;
+import com.google.bigtable.repackaged.com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.bigtable.repackaged.com.google.cloud.bigtable.config.BigtableOptions.ChannelConfigurator;
+import com.google.bigtable.repackaged.com.google.cloud.bigtable.grpc.BigtableSession;
+import com.google.bigtable.repackaged.com.google.protobuf.ByteString;
+import com.google.bigtable.repackaged.io.grpc.ManagedChannelBuilder;
+import com.google.bigtable.repackaged.io.grpc.alts.ComputeEngineChannelBuilder;
+import com.google.bigtable.repackaged.io.grpc.netty.NettyChannelBuilder;
+import com.google.bigtable.repackaged.io.grpc.netty.shaded.io.netty.channel.ChannelDuplexHandler;
+import com.google.bigtable.repackaged.io.grpc.netty.shaded.io.netty.channel.ChannelFactory;
+import com.google.bigtable.repackaged.io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext;
+import com.google.bigtable.repackaged.io.grpc.netty.shaded.io.netty.channel.ChannelPromise;
+import com.google.bigtable.repackaged.io.grpc.netty.shaded.io.netty.channel.EventLoopGroup;
+import com.google.bigtable.repackaged.io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoopGroup;
+import com.google.bigtable.repackaged.io.grpc.netty.shaded.io.netty.channel.socket.nio.NioSocketChannel;
+import com.google.bigtable.repackaged.io.grpc.netty.shaded.io.netty.util.ReferenceCountUtil;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.Inet6Address;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.AssumptionViolatedException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@Category(KnownHBaseGap.class)
+@RunWith(JUnit4.class)
+public class DirectPathFallbackIT extends AbstractTest {
+  // A threshold of completed read calls to observe to ascertain IPv6 is working.
+  // This was determined experimentally to account for both gRPC-LB RPCs and Bigtable api RPCs.
+  private static final int MIN_COMPLETE_READ_CALLS = 40;
+  private static final int NUM_RPCS_TO_SEND = 20;
+
+  private AtomicBoolean blackholeIPv6 = new AtomicBoolean();
+  private AtomicInteger numBlocked = new AtomicInteger();
+  private AtomicInteger numIPv6Read = new AtomicInteger();
+
+  private ChannelFactory<NioSocketChannel> channelFactory;
+  private EventLoopGroup eventLoopGroup;
+  private BigtableSession instrumentedSession;
+
+  public DirectPathFallbackIT() {
+    // Create a transport channel provider that can intercept ipv6 packets.
+    channelFactory = new MyChannelFactory();
+    eventLoopGroup = new NioEventLoopGroup();
+  }
+
+  @Before
+  public void setup() throws IOException {
+    if (!BigtableOptions.isDirectPathEnabled()) {
+      throw new AssumptionViolatedException("DirectPath integration tests can only run against DirectPathEnv");
+    }
+
+    BigtableOptions.Builder bigtableOptions = BigtableOptionsFactory
+        .fromConfiguration(sharedTestEnv.getConfiguration())
+        .toBuilder()
+        .setDataChannelCount(1);
+
+    bigtableOptions.setChannelConfigurator(new ChannelConfigurator() {
+      @Override
+      public ManagedChannelBuilder configureChannel(ManagedChannelBuilder builder, String host) {
+        // TODO: remove this when admin api supports DirectPath
+        if (host.contains("admin")) {
+          return builder;
+        }
+        injectNettyChannelHandler(builder);
+        // Fail fast when blackhole is active
+        builder.keepAliveTime(1, TimeUnit.SECONDS);
+        builder.keepAliveTimeout(1, TimeUnit.SECONDS);
+        return builder;
+      }
+    });
+
+    instrumentedSession = new BigtableSession(bigtableOptions.build());
+  }
+
+  @After
+  public void teardown() throws IOException {
+    if (instrumentedSession != null) {
+      instrumentedSession.close();
+    }
+    if (eventLoopGroup != null) {
+      eventLoopGroup.shutdownGracefully();
+    }
+  }
+
+  @Test
+  public void testFallback() throws InterruptedException {
+    ReadRowsRequest request = ReadRowsRequest.newBuilder()
+        .setTableName(
+            String.format(
+                "projects/%s/instances/%s/tables/%s",
+                sharedTestEnv.getConfiguration().get(BigtableOptionsFactory.PROJECT_ID_KEY),
+                sharedTestEnv.getConfiguration().get(BigtableOptionsFactory.INSTANCE_ID_KEY),
+                sharedTestEnv.getDefaultTableName().toString()))
+        .setRows(
+            RowSet.newBuilder()
+                .addRowKeys(ByteString.copyFromUtf8("nonexistent-row"))
+        )
+        .setRowsLimit(1)
+        .build();
+    // Verify that we can send a request
+    instrumentedSession.getDataClient().readFlatRowsList(request);
+
+    // Enable the blackhole, which will prevent communication via IPv6 and thus DirectPath.
+    blackholeIPv6.set(true);
+
+    // Send a request, which should be routed over IPv4 and CFE.
+    instrumentedSession.getDataClient().readFlatRowsList(request);
+
+    // Verify that the above check was meaningful, by verifying that the blackhole actually dropped
+    // packets.
+    Assert.assertTrue("Failed to detect any IPv6 traffic in blackhole", numBlocked.get() > 0);
+
+    // Make sure that the client will start reading from IPv6 again by sending new requests and
+    // checking the injected IPv6 counter has been updated.
+    blackholeIPv6.set(false);
+    numIPv6Read.set(0);
+
+    while (numIPv6Read.get() < MIN_COMPLETE_READ_CALLS) {
+      for (int i = 0; i < NUM_RPCS_TO_SEND; i++) {
+        instrumentedSession.getDataClient().readFlatRowsList(request);
+      }
+
+      Thread.sleep(100);
+    }
+
+    Assert.assertTrue("Failed to upgrade back to DirectPath", numIPv6Read.get() > MIN_COMPLETE_READ_CALLS);
+  }
+
+  /**
+   * This is a giant hack to enable testing DirectPath CFE fallback.
+   *
+   * <p>It unwraps the {@link ComputeEngineChannelBuilder} to inject a NettyChannelHandler to signal
+   * IPv6 packet loss.
+   */
+  private void injectNettyChannelHandler(ManagedChannelBuilder<?> channelBuilder) {
+    try {
+      // Extract the delegate NettyChannelBuilder using reflection
+      Field delegateField = ComputeEngineChannelBuilder.class.getDeclaredField("delegate");
+      delegateField.setAccessible(true);
+
+      ComputeEngineChannelBuilder gceChannelBuilder =
+          ((ComputeEngineChannelBuilder) channelBuilder);
+      Object delegateChannelBuilder = delegateField.get(gceChannelBuilder);
+
+      NettyChannelBuilder nettyChannelBuilder = (NettyChannelBuilder) delegateChannelBuilder;
+      nettyChannelBuilder.channelFactory(channelFactory);
+      nettyChannelBuilder.eventLoopGroup(eventLoopGroup);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new RuntimeException("Failed to inject the netty ChannelHandler", e);
+    }
+  }
+
+  /** @see MyChannelHandler */
+  private class MyChannelFactory implements ChannelFactory<NioSocketChannel> {
+    @Override
+    public NioSocketChannel newChannel() {
+      NioSocketChannel channel = new NioSocketChannel();
+      channel.pipeline().addLast(new MyChannelHandler());
+
+      return channel;
+    }
+  }
+
+  /**
+   * A netty {@link com.google.bigtable.repackaged.io.grpc.netty.shaded.io.netty.channel.ChannelHandler} that can be instructed to
+   * make IPv6 packets disappear
+   */
+  private class MyChannelHandler extends ChannelDuplexHandler {
+    private boolean isIPv6;
+
+    @Override
+    public void connect(
+        ChannelHandlerContext ctx,
+        SocketAddress remoteAddress,
+        SocketAddress localAddress,
+        ChannelPromise promise)
+        throws Exception {
+
+      this.isIPv6 =
+          (remoteAddress instanceof InetSocketAddress)
+              && ((InetSocketAddress) remoteAddress).getAddress() instanceof Inet6Address;
+
+      if (!(isIPv6 && blackholeIPv6.get())) {
+        super.connect(ctx, remoteAddress, localAddress, promise);
+      } else {
+        // Fail the connection fast
+        promise.setFailure(new IOException("fake error"));
+      }
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+      boolean dropCall = isIPv6 && blackholeIPv6.get();
+
+      if (dropCall) {
+        // Don't notify the next handler and increment counter
+        numBlocked.incrementAndGet();
+        ReferenceCountUtil.release(msg);
+      } else {
+        super.channelRead(ctx, msg);
+      }
+    }
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+      boolean dropCall = isIPv6 && blackholeIPv6.get();
+
+      if (dropCall) {
+        // Don't notify the next handler and increment counter
+        numBlocked.incrementAndGet();
+      } else {
+        if (isIPv6) {
+          numIPv6Read.incrementAndGet();
+        }
+        super.channelReadComplete(ctx);
+      }
+    }
+  }
+}
+

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
@@ -48,6 +48,7 @@ import org.junit.runners.Suite;
   TestTimestamp.class,
   TestTruncateTable.class,
   TestModifyTable.class,
+  DirectPathFallbackIT.class,
 })
 public class IntegrationTests {
   private static final int TIME_OUT_MINUTES =


### PR DESCRIPTION
Add experimental support for DirectPath.

Whitelisted customers can enable the feature by setting the environment variable `GOOGLE_CLOUD_ENABLE_DIRECT_PATH=bigtable`

This PR also contains an inactive integration test that ensures DirectPath fallback works. This test only run when that environment variable is set. Currently there is no execution that has that env var set. Once a kokoro environment is setup for DirectPath, we can add a profile that will enable this test.

