### PR TITLE
chore(deps): force upgrade grpc to 1.25.0

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -159,6 +159,10 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
+            <artifactId>grpc-alts</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
             <artifactId>grpc-core</artifactId>
         </dependency>
         <dependency>
@@ -178,9 +182,20 @@ limitations under the License.
             <artifactId>grpc-auth</artifactId>
         </dependency>
 
+        <!--
+            Temporary override for grpc version. This is necessary because bigtable-client-core
+            isn't compatible with the latest version of google-cloud-bigtable, but we need new
+            version of grpc for direct path. This should be removed in the next major version bump -->
         <dependency>
             <groupId>com.google.api</groupId>
             <artifactId>gax-grpc</artifactId>
+
+            <exclusions>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Metrics -->

--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -32,6 +32,17 @@ limitations under the License.
 
     <dependencyManagement>
         <dependencies>
+            <!--
+            Temporary override for grpc version. This is necessary because bigtable-client-core
+            isn't compatible with the latest version of google-cloud-bigtable, but we need new
+            version of grpc for direct path. This should be removed in the next major version bump -->
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-bom</artifactId>
+                <version>${grpc.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>google-cloud-clients</artifactId>
@@ -141,6 +152,10 @@ limitations under the License.
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-protobuf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/io/grpc/DeadlineUtil.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/io/grpc/DeadlineUtil.java
@@ -31,7 +31,7 @@ public class DeadlineUtil {
         unit,
         new Deadline.Ticker() {
           @Override
-          public long read() {
+          public long nanoTime() {
             return clock.nanoTime();
           }
         });

--- a/bigtable-client-core-parent/bigtable-hbase/pom.xml
+++ b/bigtable-client-core-parent/bigtable-hbase/pom.xml
@@ -32,6 +32,17 @@ limitations under the License.
 
     <dependencyManagement>
         <dependencies>
+            <!--
+            Temporary override for grpc version. This is necessary because bigtable-client-core
+            isn't compatible with the latest version of google-cloud-bigtable, but we need new
+            version of grpc for direct path. This should be removed in the next major version bump -->
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-bom</artifactId>
+                <version>${grpc.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>google-cloud-clients</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,11 @@ limitations under the License.
         <!-- google-cloud-java related dependency versions -->
         <!-- TODO: check if commons-codec was upgraded to 1.13 in org.apache.httpcomponents from http-client-->
         <google-cloud.version>0.109.0-alpha</google-cloud.version>
+        <!--
+            Temporary override for grpc version. This is necessary because bigtable-client-core
+            isn't compatible with the latest version of google-cloud-bigtable, but we need new
+            version of grpc for direct path. This should be removed in the next major version bump -->
+        <grpc.version>1.25.0</grpc.version>
         <opencensus.version>0.23.0</opencensus.version>
         <checkerframework.version>2.5.5</checkerframework.version>
 


### PR DESCRIPTION
Under normal circumstances we would upgrade grpc with the veneer client, but we made a breaking binary change to the veneer when GAing, so we can't upgrade the next major version bump. But I need grpc 1.25.0 for DirectPath now, so this PR force upgrades grpc.
