### PR TITLE
test: Fix for Gaps b/w HBase and Bigtable Admin API

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestListTables.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestListTables.java
@@ -27,7 +27,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.regex.Pattern;
-import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.TableNotFoundException;
 import org.apache.hadoop.hbase.client.Admin;
@@ -193,9 +192,8 @@ public abstract class AbstractTestListTables extends AbstractTest {
     try (Admin admin = getConnection().getAdmin()) {
       sharedTestEnv.createTable(sharedTestEnv.newTestTableName());
       Exception actualError = null;
-      try {
-        HTableDescriptor[] descriptors = admin.listTables((Pattern) null);
-        assertTrue(descriptors.length > 0);
+      try {;
+        assertTrue(admin.listTables((Pattern) null).length > 0);
       } catch (Exception e) {
         actualError = e;
       }
@@ -207,6 +205,7 @@ public abstract class AbstractTestListTables extends AbstractTest {
         actualError = e;
       }
       assertNotNull(actualError);
+      assertTrue(actualError instanceof NullPointerException);
       actualError = null;
 
       try {
@@ -237,6 +236,7 @@ public abstract class AbstractTestListTables extends AbstractTest {
         actualError = e;
       }
       assertNotNull(actualError);
+      assertTrue(actualError instanceof NullPointerException);
       actualError = null;
 
       try {

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestListTables.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestListTables.java
@@ -17,7 +17,6 @@ package com.google.cloud.bigtable.hbase;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -191,14 +190,10 @@ public abstract class AbstractTestListTables extends AbstractTest {
   public void testListTablesWithEmptyElement() throws IOException {
     try (Admin admin = getConnection().getAdmin()) {
       sharedTestEnv.createTable(sharedTestEnv.newTestTableName());
-      Exception actualError = null;
-      try {;
-        assertTrue(admin.listTables((Pattern) null).length > 0);
-      } catch (Exception e) {
-        actualError = e;
-      }
-      assertNull(actualError);
 
+      assertTrue(admin.listTables((Pattern) null).length > 0);
+
+      Exception actualError = null;
       try {
         admin.listTables((String) null);
       } catch (Exception e) {
@@ -206,14 +201,8 @@ public abstract class AbstractTestListTables extends AbstractTest {
       }
       assertNotNull(actualError);
       assertTrue(actualError instanceof NullPointerException);
-      actualError = null;
 
-      try {
-        assertEquals(0, admin.listTables("").length);
-      } catch (Exception e) {
-        actualError = e;
-      }
-      assertNull(actualError);
+      assertEquals(0, admin.listTables("").length);
     }
   }
 
@@ -221,15 +210,11 @@ public abstract class AbstractTestListTables extends AbstractTest {
   public void testListTableNamesWithEmptyElement() throws IOException {
     try (Admin admin = getConnection().getAdmin()) {
       sharedTestEnv.createTable(sharedTestEnv.newTestTableName());
-      Exception actualError = null;
-      try {
-        TableName[] tableNames = admin.listTableNames((Pattern) null);
-        assertTrue(tableNames.length > 0);
-      } catch (Exception e) {
-        actualError = e;
-      }
-      assertNull(actualError);
 
+      TableName[] tableNames = admin.listTableNames((Pattern) null);
+      assertTrue(tableNames.length > 0);
+
+      Exception actualError = null;
       try {
         admin.listTableNames((String) null);
       } catch (Exception e) {
@@ -237,14 +222,8 @@ public abstract class AbstractTestListTables extends AbstractTest {
       }
       assertNotNull(actualError);
       assertTrue(actualError instanceof NullPointerException);
-      actualError = null;
 
-      try {
-        assertEquals(0, admin.listTableNames("").length);
-      } catch (Exception e) {
-        actualError = e;
-      }
-      assertNull(actualError);
+      assertEquals(0, admin.listTableNames("").length);
     }
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestListTables.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestListTables.java
@@ -15,6 +15,11 @@
  */
 package com.google.cloud.bigtable.hbase;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -22,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.regex.Pattern;
+import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.TableNotFoundException;
 import org.apache.hadoop.hbase.client.Admin;
@@ -179,6 +185,66 @@ public abstract class AbstractTestListTables extends AbstractTest {
       TableName nonExistantTableName =
           TableName.valueOf("NA_table2-" + UUID.randomUUID().toString());
       checkTableDescriptor(admin, nonExistantTableName);
+    }
+  }
+
+  @Test
+  public void testListTablesWithEmptyElement() throws IOException {
+    try (Admin admin = getConnection().getAdmin()) {
+      sharedTestEnv.createTable(sharedTestEnv.newTestTableName());
+      Exception actualError = null;
+      try {
+        HTableDescriptor[] descriptors = admin.listTables((Pattern) null);
+        assertTrue(descriptors.length > 0);
+      } catch (Exception e) {
+        actualError = e;
+      }
+      assertNull(actualError);
+
+      try {
+        admin.listTables((String) null);
+      } catch (Exception e) {
+        actualError = e;
+      }
+      assertNotNull(actualError);
+      actualError = null;
+
+      try {
+        assertEquals(0, admin.listTables("").length);
+      } catch (Exception e) {
+        actualError = e;
+      }
+      assertNull(actualError);
+    }
+  }
+
+  @Test
+  public void testListTableNamesWithEmptyElement() throws IOException {
+    try (Admin admin = getConnection().getAdmin()) {
+      sharedTestEnv.createTable(sharedTestEnv.newTestTableName());
+      Exception actualError = null;
+      try {
+        TableName[] tableNames = admin.listTableNames((Pattern) null);
+        assertTrue(tableNames.length > 0);
+      } catch (Exception e) {
+        actualError = e;
+      }
+      assertNull(actualError);
+
+      try {
+        admin.listTableNames((String) null);
+      } catch (Exception e) {
+        actualError = e;
+      }
+      assertNotNull(actualError);
+      actualError = null;
+
+      try {
+        assertEquals(0, admin.listTableNames("").length);
+      } catch (Exception e) {
+        actualError = e;
+      }
+      assertNull(actualError);
     }
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/TestAdminOps.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/TestAdminOps.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TestAdminOps extends AbstractTest {
+
+  @Test
+  public void testIsTableEnabledOrDisabled() throws IOException {
+    try (Admin admin = getConnection().getAdmin()) {
+      Exception actualError = null;
+      try {
+        admin.isTableEnabled(null);
+      } catch (Exception e) {
+        actualError = e;
+      }
+      assertNotNull(actualError);
+      actualError = null;
+
+      try {
+        admin.isTableDisabled(null);
+      } catch (Exception e) {
+        actualError = e;
+      }
+      assertNotNull(actualError);
+    }
+  }
+
+  @Test
+  public void testDisableTablesWithNullOrEmpty() throws IOException {
+    try (Admin admin = getConnection().getAdmin()) {
+      Exception actualError = null;
+      try {
+        HTableDescriptor[] descriptors = admin.disableTables((String) null);
+        assertTrue(descriptors.length > 0);
+      } catch (Exception e) {
+        actualError = e;
+        e.printStackTrace(System.out);
+      }
+      assertNotNull(actualError);
+      actualError = null;
+
+      try {
+        assertEquals(0, admin.disableTables("").length);
+      } catch (Exception e) {
+        actualError = e;
+        e.printStackTrace(System.out);
+      }
+      assertNull(actualError);
+    }
+  }
+
+  @Test
+  public void testEnableTablesWithNull() throws IOException {
+    try (Admin admin = getConnection().getAdmin()) {
+      Exception actualError = null;
+      try {
+        HTableDescriptor[] descriptors = admin.enableTables((String) null);
+        assertTrue(descriptors.length > 0);
+      } catch (Exception e) {
+        e.printStackTrace(System.out);
+        actualError = e;
+      }
+      assertNotNull(actualError);
+      actualError = null;
+
+      try {
+        assertEquals(0, admin.enableTables("").length);
+      } catch (Exception e) {
+        e.printStackTrace(System.out);
+        actualError = e;
+      }
+      assertNull(actualError);
+    }
+  }
+
+  @Test
+  public void testGetTableDescriptorsByTableNameWithNullAndEmptyList() throws IOException {
+    try (Admin admin = getConnection().getAdmin()) {
+      Exception actualError = null;
+      try {
+        HTableDescriptor[] descriptor = admin.getTableDescriptorsByTableName(null);
+        assertTrue(descriptor.length > 0);
+      } catch (Exception e) {
+        actualError = e;
+      }
+      assertNull(actualError);
+
+      try {
+        HTableDescriptor[] descriptor =
+            admin.getTableDescriptorsByTableName(ImmutableList.<TableName>of());
+        assertTrue(descriptor.length > 0);
+      } catch (Exception e) {
+        e.printStackTrace(System.out);
+        actualError = e;
+      }
+      assertNull(actualError);
+    }
+  }
+
+  @Test
+  public void testGetTableDescriptorsWithNullAndEmptyList() throws IOException {
+    try (Admin admin = getConnection().getAdmin()) {
+      Exception actualError = null;
+      try {
+        HTableDescriptor[] descriptors = admin.getTableDescriptors(null);
+        assertTrue(descriptors.length > 0);
+      } catch (Exception e) {
+        actualError = e;
+      }
+      assertNotNull(actualError);
+      actualError = null;
+
+      try {
+        HTableDescriptor[] descriptors = admin.getTableDescriptors(ImmutableList.<String>of());
+        assertTrue(descriptors.length > 0);
+      } catch (Exception e) {
+        e.printStackTrace(System.out);
+        actualError = e;
+      }
+      assertNull(actualError);
+    }
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/TestAdminOps.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/TestAdminOps.java
@@ -17,12 +17,10 @@ package com.google.cloud.bigtable.hbase;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
-import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Admin;
 import org.junit.Test;
@@ -58,21 +56,14 @@ public class TestAdminOps extends AbstractTest {
     try (Admin admin = getConnection().getAdmin()) {
       Exception actualError = null;
       try {
-        HTableDescriptor[] descriptors = admin.disableTables((String) null);
-        assertTrue(descriptors.length > 0);
+        admin.disableTables((String) null);
       } catch (Exception e) {
         actualError = e;
       }
       assertNotNull(actualError);
       assertTrue(actualError instanceof NullPointerException);
-      actualError = null;
 
-      try {
-        assertEquals(0, admin.disableTables("").length);
-      } catch (Exception e) {
-        actualError = e;
-      }
-      assertNull(actualError);
+      assertEquals(0, admin.disableTables("").length);
     }
   }
 
@@ -81,44 +72,23 @@ public class TestAdminOps extends AbstractTest {
     try (Admin admin = getConnection().getAdmin()) {
       Exception actualError = null;
       try {
-        HTableDescriptor[] descriptors = admin.enableTables((String) null);
-        assertTrue(descriptors.length > 0);
+        admin.enableTables((String) null);
       } catch (Exception e) {
         actualError = e;
       }
       assertNotNull(actualError);
       assertTrue(actualError instanceof NullPointerException);
-      actualError = null;
 
-      try {
-        assertEquals(0, admin.enableTables("").length);
-      } catch (Exception e) {
-        actualError = e;
-      }
-      assertNull(actualError);
+      assertEquals(0, admin.enableTables("").length);
     }
   }
 
   @Test
   public void testGetTableDescriptorsByTableNameWithNullAndEmptyList() throws IOException {
     try (Admin admin = getConnection().getAdmin()) {
-      Exception actualError = null;
-      try {
-        HTableDescriptor[] descriptor = admin.getTableDescriptorsByTableName(null);
-        assertTrue(descriptor.length > 0);
-      } catch (Exception e) {
-        actualError = e;
-      }
-      assertNull(actualError);
+      assertTrue(admin.getTableDescriptorsByTableName(null).length > 0);
 
-      try {
-        HTableDescriptor[] descriptor =
-            admin.getTableDescriptorsByTableName(ImmutableList.<TableName>of());
-        assertTrue(descriptor.length > 0);
-      } catch (Exception e) {
-        actualError = e;
-      }
-      assertNull(actualError);
+      assertTrue(admin.getTableDescriptorsByTableName(ImmutableList.<TableName>of()).length > 0);
     }
   }
 
@@ -127,22 +97,14 @@ public class TestAdminOps extends AbstractTest {
     try (Admin admin = getConnection().getAdmin()) {
       Exception actualError = null;
       try {
-        HTableDescriptor[] descriptors = admin.getTableDescriptors(null);
-        assertTrue(descriptors.length > 0);
+        admin.getTableDescriptors(null);
       } catch (Exception e) {
         actualError = e;
       }
       assertNotNull(actualError);
       assertTrue(actualError instanceof NullPointerException);
-      actualError = null;
 
-      try {
-        HTableDescriptor[] descriptors = admin.getTableDescriptors(ImmutableList.<String>of());
-        assertTrue(descriptors.length > 0);
-      } catch (Exception e) {
-        actualError = e;
-      }
-      assertNull(actualError);
+      assertTrue(admin.getTableDescriptors(ImmutableList.<String>of()).length > 0);
     }
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/TestAdminOps.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/TestAdminOps.java
@@ -62,16 +62,15 @@ public class TestAdminOps extends AbstractTest {
         assertTrue(descriptors.length > 0);
       } catch (Exception e) {
         actualError = e;
-        e.printStackTrace(System.out);
       }
       assertNotNull(actualError);
+      assertTrue(actualError instanceof NullPointerException);
       actualError = null;
 
       try {
         assertEquals(0, admin.disableTables("").length);
       } catch (Exception e) {
         actualError = e;
-        e.printStackTrace(System.out);
       }
       assertNull(actualError);
     }
@@ -85,16 +84,15 @@ public class TestAdminOps extends AbstractTest {
         HTableDescriptor[] descriptors = admin.enableTables((String) null);
         assertTrue(descriptors.length > 0);
       } catch (Exception e) {
-        e.printStackTrace(System.out);
         actualError = e;
       }
       assertNotNull(actualError);
+      assertTrue(actualError instanceof NullPointerException);
       actualError = null;
 
       try {
         assertEquals(0, admin.enableTables("").length);
       } catch (Exception e) {
-        e.printStackTrace(System.out);
         actualError = e;
       }
       assertNull(actualError);
@@ -118,7 +116,6 @@ public class TestAdminOps extends AbstractTest {
             admin.getTableDescriptorsByTableName(ImmutableList.<TableName>of());
         assertTrue(descriptor.length > 0);
       } catch (Exception e) {
-        e.printStackTrace(System.out);
         actualError = e;
       }
       assertNull(actualError);
@@ -136,13 +133,13 @@ public class TestAdminOps extends AbstractTest {
         actualError = e;
       }
       assertNotNull(actualError);
+      assertTrue(actualError instanceof NullPointerException);
       actualError = null;
 
       try {
         HTableDescriptor[] descriptors = admin.getTableDescriptors(ImmutableList.<String>of());
         assertTrue(descriptors.length > 0);
       } catch (Exception e) {
-        e.printStackTrace(System.out);
         actualError = e;
       }
       assertNull(actualError);

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
@@ -24,6 +24,7 @@ import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
+  TestAdminOps.class,
   TestAppend.class,
   TestAuth.class,
   TestBasicOps.class,

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
@@ -36,6 +36,7 @@ import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
+  TestAdminOps.class,
   TestAppend.class,
   TestBasicOps.class,
   TestBatch.class,


### PR DESCRIPTION
Reopened the PR from #2267.
This change addresses the gap between this Bigtable & HBase Data API.

This also introduces a private method `Admin.getTableDescriptorIgnoreFailure`, which returns TableDescriptor[]. It is to address the `TableNotFoundException` & `FAILED_PRECONDITION` failure while fetching Table details of the list(HBase also throws TableNotFoundException when table not found).

This change updates below methods:
- listTables()
- deleteTables()
- enableTables()
- disableTables()
- isTableEnabled()
- isTableDisabled()
- getTableDescriptors()
- getTableDescriptorsByTableName()


Note: Have run IT test with both clients for H1 & H2 implementation.