### PR TITLE
deps: fix hbaseLocalMiniClusterTestH2 tests

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/pom.xml
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/pom.xml
@@ -57,7 +57,7 @@ limitations under the License.
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>${hadoop.version.1}</version>
+            <version>${hbase1-hadoop.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/pom.xml
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/pom.xml
@@ -57,7 +57,7 @@ limitations under the License.
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>${hadoop.version}</version>
+            <version>${hadoop.version.1}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
@@ -76,7 +76,7 @@ limitations under the License.
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
-      <version>${hadoop.version}</version>
+      <version>${hadoop.version.1}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
@@ -76,7 +76,7 @@ limitations under the License.
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
-      <version>${hadoop.version.1}</version>
+      <version>${hbase1-hadoop.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
@@ -323,7 +323,7 @@ limitations under the License.
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>${hadoop.version.1}</version>
+            <version>${hbase1-hadoop.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
@@ -323,7 +323,7 @@ limitations under the License.
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>${hadoop.version}</version>
+            <version>${hadoop.version.1}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
@@ -80,7 +80,7 @@ limitations under the License.
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
-      <version>${hadoop.version.2}</version>
+      <version>${hbase2-hadoop.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
@@ -80,7 +80,7 @@ limitations under the License.
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
-      <version>${hadoop.version}</version>
+      <version>2.8.5</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
@@ -80,7 +80,7 @@ limitations under the License.
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
-      <version>2.8.5</version>
+      <version>${hadoop.version.2}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
@@ -337,6 +337,12 @@ limitations under the License.
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>${hbase2-hadoop.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-common</artifactId>
             <version>${hbase.version}</version>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/AbstractAsyncTest.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/AbstractAsyncTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigtable.hbase.async;
 import com.google.cloud.bigtable.hbase.AbstractTest;
 import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
 import java.util.concurrent.ExecutionException;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.AsyncConnection;
 import org.apache.hadoop.hbase.client.AsyncTable;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
@@ -32,7 +33,8 @@ public abstract class AbstractAsyncTest extends AbstractTest {
     SharedTestEnvRule sharedEnv = SharedTestEnvRule.getInstance();
     AsyncConnection conn = (AsyncConnection) sharedEnv.getClosable(CONN_KEY);
     if (conn == null) {
-      conn = ConnectionFactory.createAsyncConnection(sharedEnv.getConfiguration()).get();
+      Configuration sharedEnvConfiguration = sharedEnv.getConfiguration();
+      conn = ConnectionFactory.createAsyncConnection(sharedEnvConfiguration).get();
       sharedEnv.registerClosable(CONN_KEY, conn);
     }
     return conn;

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,8 @@ limitations under the License.
         <hbase.version.1>1.4.10</hbase.version.1>
         <hbase.version.2>2.2.0</hbase.version.2>
         <hbase.version>${hbase.version.1}</hbase.version>
-        <hadoop.version>2.7.4</hadoop.version>
+        <hadoop.version.1>2.7.4</hadoop.version.1>
+        <hadoop.version.2>2.8.5</hadoop.version.2>
         <hbase-guava.version>12.0.1</hbase-guava.version>
         <hbase-protobuf.version>2.5.0</hbase-protobuf.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,8 @@ limitations under the License.
         <hbase.version.1>1.4.10</hbase.version.1>
         <hbase.version.2>2.2.0</hbase.version.2>
         <hbase.version>${hbase.version.1}</hbase.version>
-        <hadoop.version.1>2.7.4</hadoop.version.1>
-        <hadoop.version.2>2.8.5</hadoop.version.2>
+        <hbase1-hadoop.version>2.7.4</hbase1-hadoop.version>
+        <hbase2-hadoop.version>2.8.5</hbase2-hadoop.version>
         <hbase-guava.version>12.0.1</hbase-guava.version>
         <hbase-protobuf.version>2.5.0</hbase-protobuf.version>
 


### PR DESCRIPTION
When fixing the 'used but undeclared' dependency issues, the version of hadoop-common was set to 2.7.4 (when it was 2.8.5). This caused the hbaseLocalMiniClusterTestH2 tests to fail because they could not initialize. 