### PR TITLE
How about using libraries-bom 3.2.0?

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -34,8 +34,15 @@ limitations under the License.
         <dependencies>
             <dependency>
                 <groupId>com.google.cloud</groupId>
-                <artifactId>google-cloud-clients</artifactId>
-                <version>${google-cloud.version}</version>
+                <artifactId>libraries-bom</artifactId>
+                <version>${libraries-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.google.auth</groupId>
+                <artifactId>google-auth-library-bom</artifactId>
+                <version>0.19.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -78,6 +85,7 @@ limitations under the License.
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
+            <version>${jsr305.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -172,11 +180,13 @@ limitations under the License.
         <dependency>
             <groupId>io.opencensus</groupId>
             <artifactId>opencensus-api</artifactId>
+            <version>${opencensus.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.opencensus</groupId>
             <artifactId>opencensus-contrib-grpc-util</artifactId>
+            <version>${opencensus.version}</version>
         </dependency>
 
         <dependency>
@@ -215,6 +225,7 @@ limitations under the License.
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
+            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/bigtable-client-core-parent/bigtable-hbase/pom.xml
+++ b/bigtable-client-core-parent/bigtable-hbase/pom.xml
@@ -34,8 +34,8 @@ limitations under the License.
         <dependencies>
             <dependency>
                 <groupId>com.google.cloud</groupId>
-                <artifactId>google-cloud-clients</artifactId>
-                <version>${google-cloud.version}</version>
+                <artifactId>libraries-bom</artifactId>
+                <version>3.3.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@ limitations under the License.
 
         <!-- google-cloud-java related dependency versions -->
         <!-- TODO: check if commons-codec was upgraded to 1.13 in org.apache.httpcomponents from http-client-->
-        <google-cloud.version>0.116.0-alpha</google-cloud.version>
+        <libraries-bom.version>3.2.0</libraries-bom.version>
         <opencensus.version>0.23.0</opencensus.version>
         <checkerframework.version>2.5.5</checkerframework.version>
 


### PR DESCRIPTION
How about using libraries-bom 3.2.0? The BOM includes grpc-bom and protobuf-bom. This is one potential answer to the question in https://github.com/googleapis/java-bigtable-hbase/pull/2336#issuecomment-570612885