### PR TITLE
chore: disable parallelism in integration tests

### DIFF
--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
@@ -33,7 +33,6 @@ limitations under the License.
     <properties>
         <google.bigtable.connection.impl>com.google.cloud.bigtable.hbase1_x.BigtableConnection</google.bigtable.connection.impl>
         <test.timeout>1800</test.timeout>
-        <thread.count>10</thread.count>
     </properties>
 
     <profiles>
@@ -68,8 +67,6 @@ limitations under the License.
                                         <google.bigtable.connection.impl>${google.bigtable.connection.impl}</google.bigtable.connection.impl>
                                     </systemPropertyVariables>
                                     <forkedProcessTimeoutInSeconds>${test.timeout}</forkedProcessTimeoutInSeconds>
-                                    <parallel>classesAndMethods</parallel>
-                                    <threadCount>${thread.count}</threadCount>
                                     <!-- Make sure to fail the build when the suite fails to initialize -->
                                     <failIfNoTests>true</failIfNoTests>
                                 </configuration>
@@ -114,8 +111,6 @@ limitations under the License.
                                     </systemPropertyVariables>
                                     <forkedProcessTimeoutInSeconds>${test.timeout}</forkedProcessTimeoutInSeconds>
                                     <trimStackTrace>false</trimStackTrace>
-                                    <parallel>classesAndMethods</parallel>
-                                    <threadCount>${thread.count}</threadCount>
                                     <!-- Make sure to fail the build when the suite fails to initialize -->
                                     <failIfNoTests>true</failIfNoTests>
                                 </configuration>
@@ -154,8 +149,6 @@ limitations under the License.
                                     <reportNameSuffix>local-mini-cluster</reportNameSuffix>
                                     <forkedProcessTimeoutInSeconds>${test.timeout}</forkedProcessTimeoutInSeconds>
                                     <trimStackTrace>false</trimStackTrace>
-                                    <parallel>classesAndMethods</parallel>
-                                    <threadCount>${thread.count}</threadCount>
                                     <!-- Make sure to fail the build when the suite fails to initialize -->
                                     <failIfNoTests>true</failIfNoTests>
                                 </configuration>
@@ -253,8 +246,6 @@ limitations under the License.
                                         <BIGTABLE_EMULATOR_HOST>${bigtable.emulator.endpoint}</BIGTABLE_EMULATOR_HOST>
                                     </environmentVariables>
                                     <trimStackTrace>false</trimStackTrace>
-                                    <parallel>classesAndMethods</parallel>
-                                    <threadCount>${thread.count}</threadCount>
                                     <!-- Make sure to fail the build when the suite fails to initialize -->
                                     <failIfNoTests>true</failIfNoTests>
                                 </configuration>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
@@ -16,9 +16,7 @@
 package com.google.cloud.bigtable.hbase;
 
 import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
-import java.util.concurrent.TimeUnit;
 import org.junit.ClassRule;
-import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
@@ -50,10 +50,5 @@ import org.junit.runners.Suite;
   TestModifyTable.class,
 })
 public class IntegrationTests {
-  private static final int TIME_OUT_MINUTES =
-      Integer.getInteger("integration.test.timeout.minutes", 3);
-
-  @ClassRule public static Timeout timeoutRule = new Timeout(TIME_OUT_MINUTES, TimeUnit.MINUTES);
-
   @ClassRule public static SharedTestEnvRule sharedTestEnvRule = SharedTestEnvRule.getInstance();
 }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
@@ -36,7 +36,6 @@ limitations under the License.
         <google.bigtable.async.connection.impl>org.apache.hadoop.hbase.client.BigtableAsyncConnection</google.bigtable.async.connection.impl>
         <google.bigtable.registry.impl>org.apache.hadoop.hbase.client.BigtableAsyncRegistry</google.bigtable.registry.impl>
         <test.timeout>1800</test.timeout>
-        <thread.count>10</thread.count>
     </properties>
 
     <profiles>
@@ -73,8 +72,6 @@ limitations under the License.
                                     </systemPropertyVariables>
                                     <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
                                     <forkedProcessTimeoutInSeconds>${test.timeout}</forkedProcessTimeoutInSeconds>
-                                    <parallel>classesAndMethods</parallel>
-                                    <threadCount>${thread.count}</threadCount>
                                     <!-- Make sure to fail the build when the suite fails to initialize -->
                                     <failIfNoTests>true</failIfNoTests>
                                 </configuration>
@@ -117,8 +114,6 @@ limitations under the License.
                                         <google.bigtable.connection.impl>${google.bigtable.connection.impl}</google.bigtable.connection.impl>
                                     </systemPropertyVariables>
                                     <forkedProcessTimeoutInSeconds>${test.timeout}</forkedProcessTimeoutInSeconds>
-                                    <parallel>classesAndMethods</parallel>
-                                    <threadCount>${thread.count}</threadCount>
                                     <!-- Make sure to fail the build when the suite fails to initialize -->
                                     <failIfNoTests>true</failIfNoTests>
                                 </configuration>
@@ -170,8 +165,6 @@ limitations under the License.
                                     <trimStackTrace>false</trimStackTrace>
                                     <reportNameSuffix>local-mini-cluster</reportNameSuffix>
                                     <forkedProcessTimeoutInSeconds>${test.timeout}</forkedProcessTimeoutInSeconds>
-                                    <parallel>classesAndMethods</parallel>
-                                    <threadCount>${thread.count}</threadCount>
                                     <!-- Make sure to fail the build when the suite fails to initialize -->
                                     <failIfNoTests>true</failIfNoTests>
                                 </configuration>
@@ -272,8 +265,6 @@ limitations under the License.
                                     </environmentVariables>
                                     <trimStackTrace>false</trimStackTrace>
                                     <forkedProcessTimeoutInSeconds>${test.timeout}</forkedProcessTimeoutInSeconds>
-                                    <parallel>classesAndMethods</parallel>
-                                    <threadCount>${thread.count}</threadCount>
                                 </configuration>
                             </execution>
                         </executions>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
@@ -28,9 +28,7 @@ import com.google.cloud.bigtable.hbase.async.TestAsyncTruncateTable;
 import com.google.cloud.bigtable.hbase.async.TestBasicAsyncOps;
 import com.google.cloud.bigtable.hbase.async.TestModifyTableAsync;
 import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
-import java.util.concurrent.TimeUnit;
 import org.junit.ClassRule;
-import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
@@ -79,11 +79,5 @@ import org.junit.runners.Suite;
   TestModifyTableAsync.class
 })
 public class IntegrationTests {
-
-  private static final int TIME_OUT_MINUTES =
-      Integer.getInteger("integration.test.timeout.minutes", 3);
-
-  @ClassRule public static Timeout timeoutRule = new Timeout(TIME_OUT_MINUTES, TimeUnit.MINUTES);
-
   @ClassRule public static SharedTestEnvRule sharedTestEnvRule = SharedTestEnvRule.getInstance();
 }


### PR DESCRIPTION
Parallel test execution doesn't play well with suites that have failing ClassRules.

Also remove the Timeout ClassRule, it causes undefined behavior:
https://junit.org/junit4/javadoc/4.12/org/junit/ClassRule.html

We have timeouts defined in maven