### PR TITLE
chore: update integration tests to use unshaded artifacts

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/pom.xml
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/pom.xml
@@ -33,61 +33,33 @@ limitations under the License.
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-shaded-testing-util</artifactId>
+      <version>${hbase.version.1}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-      <version>${hbase-protobuf.version}</version>
-      <scope>test</scope>
-    </dependency>
+
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
       <version>${commons-lang.version}</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
       <version>${commons-logging.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-common</artifactId>
-      <version>${hbase1-hadoop.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-client</artifactId>
-      <version>${hbase.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-common</artifactId>
-      <version>${hbase.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-protocol</artifactId>
-      <version>${hbase.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-server</artifactId>
-      <version>${hbase.version}</version>
-      <classifier>tests</classifier>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/pom.xml
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/pom.xml
@@ -35,7 +35,7 @@ limitations under the License.
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-shaded-testing-util</artifactId>
-      <version>${hbase.version.1}</version>
+      <version>${hbase.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestPut.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestPut.java
@@ -22,9 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-import com.google.cloud.bigtable.hbase.AbstractTest.QualifierValue;
 import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
-import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -391,10 +389,7 @@ public abstract class AbstractTestPut extends AbstractTest {
         Result result = table.get(new Get(rowKeyWithNullQual));
         assertEquals(1, result.rawCells().length);
         Cell cell = result.getColumnLatestCell(COLUMN_FAMILY, null);
-        assertArrayEquals(
-            testValue,
-            ByteString.copyFrom(cell.getValueArray(), cell.getValueOffset(), cell.getValueLength())
-                .toByteArray());
+        assertArrayEquals(testValue, CellUtil.cloneValue(cell));
 
       } catch (Exception ex) {
         actualError = ex;
@@ -411,10 +406,7 @@ public abstract class AbstractTestPut extends AbstractTest {
         Result result = table.get(new Get(rowKeyWithEmptyQual));
         assertEquals(1, result.rawCells().length);
         Cell cell = result.getColumnLatestCell(COLUMN_FAMILY, emptyQualifier);
-        assertArrayEquals(
-            testValue,
-            ByteString.copyFrom(cell.getValueArray(), cell.getValueOffset(), cell.getValueLength())
-                .toByteArray());
+        assertArrayEquals(testValue, CellUtil.cloneValue(cell));
       } catch (Exception ex) {
         actualError = ex;
       }

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
@@ -167,7 +167,6 @@ limitations under the License.
                   <includes>
                     <include>**/TestKnownHBaseGap.java</include>
                   </includes>
-                  <trimStackTrace>false</trimStackTrace>
                   <reportNameSuffix>local-mini-cluster</reportNameSuffix>
                   <forkedProcessTimeoutInSeconds>
                     ${test.timeout}
@@ -220,7 +219,6 @@ limitations under the License.
                       ${google.bigtable.connection.impl}
                     </google.bigtable.connection.impl>
                   </systemPropertyVariables>
-                  <trimStackTrace>false</trimStackTrace>
                   <!-- Make sure to fail the build when the suite fails to initialize -->
                   <failIfNoTests>true</failIfNoTests>
                 </configuration>
@@ -283,6 +281,9 @@ limitations under the License.
                     </BIGTABLE_EMULATOR_HOST>
                   </environmentVariables>
                   <trimStackTrace>false</trimStackTrace>
+                  <forkedProcessTimeoutInSeconds>
+                    ${test.timeout}
+                  </forkedProcessTimeoutInSeconds>
                   <!-- Make sure to fail the build when the suite fails to initialize -->
                   <failIfNoTests>true</failIfNoTests>
                 </configuration>
@@ -294,20 +295,59 @@ limitations under the License.
     </profile>
   </profiles>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bigtable-bom</artifactId>
+        <version>${bigtable.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bigtable-deps-bom</artifactId>
+        <version>${bigtable.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
+    <!-- Project Modules -->
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>bigtable-hbase-1.x-hadoop</artifactId>
+      <groupId>com.google.cloud.bigtable</groupId>
+      <artifactId>bigtable-client-core</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
+    </dependency>
 
+    <dependency>
+      <groupId>com.google.cloud.bigtable</groupId>
+      <artifactId>bigtable-hbase</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
       <exclusions>
-        <!-- Workaround MNG-5899 & MSHADE-206. Maven >= 3.3.0 doesn't use the dependency reduced
-        pom.xml files when invoking the build from a parent project. So we have to manually exclude
-        the dependencies. -->
+        <!-- included in hbase-shaded-testing-util -->
         <exclusion>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>bigtable-hbase-1.x-shaded</artifactId>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-shaded-client</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>bigtable-hbase-1.x</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <!-- included in hbase-shaded-testing-util -->
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-shaded-client</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -323,11 +363,44 @@ limitations under the License.
           <artifactId>org.apache.hbase</artifactId>
           <groupId>*</groupId>
         </exclusion>
-        <exclusion>
-          <artifactId>${project.groupId}</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
       </exclusions>
+    </dependency>
+
+
+    <!-- java-bigtable Modules -->
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-bigtable</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-cloud-bigtable-v2</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+
+    <!-- HBase testing tools -->
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-shaded-testing-util</artifactId>
+      <version>${hbase.version.1}</version>
+      <scope>test</scope>
+    </dependency>
+
+
+    <!-- Misc -->
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-credentials</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -336,55 +409,60 @@ limitations under the License.
       <version>${jsr305.version}</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>${hbase-guava.version}</version>
+      <version>${guava.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
       <version>${commons-lang.version}</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-common</artifactId>
-      <version>${hbase1-hadoop.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-common</artifactId>
-      <version>${hbase.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-client</artifactId>
-      <version>${hbase.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-server</artifactId>
-      <version>${hbase.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-testing-util</artifactId>
-      <version>${hbase.version}</version>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-alts</artifactId>
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-grpclb</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty-shaded</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+
+    <!-- Testing deps -->
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
       <version>${hamcrest.version}</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -425,10 +503,9 @@ limitations under the License.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
-          <!-- required to force hbase version in common tests-->
           <usedDependencies>
-            <usedDependency>org.apache.hbase:hbase-testing-util</usedDependency>
-            <usedDependency>org.apache.hbase:hbase-server</usedDependency>
+            <usedDependency>${project.groupId}:bigtable-hbase-1.x</usedDependency>
+            <usedDependency>io.grpc:grpc-grpclb</usedDependency>
           </usedDependencies>
         </configuration>
       </plugin>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
@@ -385,7 +385,7 @@ limitations under the License.
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-shaded-testing-util</artifactId>
-      <version>${hbase.version.1}</version>
+      <version>${hbase.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/DirectPathFallbackIT.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/DirectPathFallbackIT.java
@@ -1,22 +1,22 @@
 package com.google.cloud.bigtable.hbase;
 
-import com.google.bigtable.repackaged.com.google.bigtable.v2.ReadRowsRequest;
-import com.google.bigtable.repackaged.com.google.bigtable.v2.RowSet;
-import com.google.bigtable.repackaged.com.google.cloud.bigtable.config.BigtableOptions;
-import com.google.bigtable.repackaged.com.google.cloud.bigtable.config.BigtableOptions.ChannelConfigurator;
-import com.google.bigtable.repackaged.com.google.cloud.bigtable.grpc.BigtableSession;
-import com.google.bigtable.repackaged.com.google.protobuf.ByteString;
-import com.google.bigtable.repackaged.io.grpc.ManagedChannelBuilder;
-import com.google.bigtable.repackaged.io.grpc.alts.ComputeEngineChannelBuilder;
-import com.google.bigtable.repackaged.io.grpc.netty.NettyChannelBuilder;
-import com.google.bigtable.repackaged.io.grpc.netty.shaded.io.netty.channel.ChannelDuplexHandler;
-import com.google.bigtable.repackaged.io.grpc.netty.shaded.io.netty.channel.ChannelFactory;
-import com.google.bigtable.repackaged.io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext;
-import com.google.bigtable.repackaged.io.grpc.netty.shaded.io.netty.channel.ChannelPromise;
-import com.google.bigtable.repackaged.io.grpc.netty.shaded.io.netty.channel.EventLoopGroup;
-import com.google.bigtable.repackaged.io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoopGroup;
-import com.google.bigtable.repackaged.io.grpc.netty.shaded.io.netty.channel.socket.nio.NioSocketChannel;
-import com.google.bigtable.repackaged.io.grpc.netty.shaded.io.netty.util.ReferenceCountUtil;
+import com.google.bigtable.v2.ReadRowsRequest;
+import com.google.bigtable.v2.RowSet;
+import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.config.BigtableOptions.ChannelConfigurator;
+import com.google.cloud.bigtable.grpc.BigtableSession;
+import com.google.protobuf.ByteString;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.alts.ComputeEngineChannelBuilder;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import io.grpc.netty.shaded.io.netty.channel.ChannelDuplexHandler;
+import io.grpc.netty.shaded.io.netty.channel.ChannelFactory;
+import io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext;
+import io.grpc.netty.shaded.io.netty.channel.ChannelPromise;
+import io.grpc.netty.shaded.io.netty.channel.EventLoopGroup;
+import io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoopGroup;
+import io.grpc.netty.shaded.io.netty.channel.socket.nio.NioSocketChannel;
+import io.grpc.netty.shaded.io.netty.util.ReferenceCountUtil;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.Inet6Address;
@@ -177,9 +177,8 @@ public class DirectPathFallbackIT extends AbstractTest {
   }
 
   /**
-   * A netty {@link
-   * com.google.bigtable.repackaged.io.grpc.netty.shaded.io.netty.channel.ChannelHandler} that can
-   * be instructed to make IPv6 packets disappear
+   * A netty {@link io.grpc.netty.shaded.io.netty.channel.ChannelHandler} that can be instructed to
+   * make IPv6 packets disappear
    */
   private class MyChannelHandler extends ChannelDuplexHandler {
     private boolean isIPv6;

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestAuth.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestAuth.java
@@ -15,10 +15,10 @@
  */
 package com.google.cloud.bigtable.hbase;
 
-import com.google.bigtable.repackaged.com.google.auth.Credentials;
-import com.google.bigtable.repackaged.com.google.auth.oauth2.GoogleCredentials;
-import com.google.bigtable.repackaged.com.google.auth.oauth2.ServiceAccountCredentials;
-import com.google.bigtable.repackaged.com.google.auth.oauth2.ServiceAccountJwtAccessCredentials;
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.auth.oauth2.ServiceAccountJwtAccessCredentials;
 import java.io.IOException;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.Get;

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
@@ -17,10 +17,10 @@ package com.google.cloud.bigtable.hbase;
 
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
 
-import com.google.bigtable.repackaged.com.google.cloud.bigtable.data.v2.models.Filters;
-import com.google.bigtable.repackaged.com.google.protobuf.ByteString;
+import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.cloud.bigtable.hbase.filter.BigtableFilter;
 import com.google.cloud.bigtable.hbase.filter.TimestampRangeFilter;
+import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.hadoop.hbase.Cell;

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
@@ -59,11 +59,6 @@ limitations under the License.
     </dependency>
 
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${hbase-guava.version}</version>
-    </dependency>
-    <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
       <version>${commons-logging.version}</version>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/src/main/java/com/google/cloud/bigtable/mapreduce/Import.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/src/main/java/com/google/cloud/bigtable/mapreduce/Import.java
@@ -441,8 +441,6 @@ public class Import extends Configured implements Tool {
         job.setMapOutputKeyClass(ImmutableBytesWritable.class);
         job.setMapOutputValueClass(KeyValue.class);
         HFileOutputFormat2.configureIncrementalLoad(job, table, regionLocator);
-        TableMapReduceUtil.addDependencyJars(
-            job.getConfiguration(), com.google.common.base.Preconditions.class);
       }
     } else {
       // No reducers.  Just write straight to table.  Call initTableReducerJob

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
@@ -385,7 +385,7 @@ limitations under the License.
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-shaded-testing-util</artifactId>
-      <version>${hbase.version.2}</version>
+      <version>${hbase.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
@@ -70,6 +70,7 @@ limitations under the License.
                 </goals>
                 <phase>integration-test</phase>
                 <configuration>
+                  <forkCount>1</forkCount>
                   <includes>
                     <include>**/IntegrationTestsNoKnownGap.java</include>
                   </includes>
@@ -85,9 +86,8 @@ limitations under the License.
                       ${google.bigtable.registry.impl}
                     </google.bigtable.registry.impl>
                   </systemPropertyVariables>
-                  <forkedProcessTimeoutInSeconds>600
-                  </forkedProcessTimeoutInSeconds>
-                  <forkedProcessTimeoutInSeconds>${test.timeout}
+                  <forkedProcessTimeoutInSeconds>
+                    ${test.timeout}
                   </forkedProcessTimeoutInSeconds>
                   <!-- Make sure to fail the build when the suite fails to initialize -->
                   <failIfNoTests>true</failIfNoTests>
@@ -105,6 +105,9 @@ limitations under the License.
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <trimStackTrace>false</trimStackTrace>
+            </configuration>
             <executions>
               <execution>
                 <id>api-integration-test</id>
@@ -123,6 +126,7 @@ limitations under the License.
                   <!-- to enable netty logging, include:
                   -Djava.util.logging.config.file=src/test/resources/logging.properties
                   -->
+                  <forkCount>1</forkCount>
                   <includes>
                     <include>**/IntegrationTestsGap.java</include>
                   </includes>
@@ -135,6 +139,7 @@ limitations under the License.
                   <forkedProcessTimeoutInSeconds>
                     ${test.timeout}
                   </forkedProcessTimeoutInSeconds>
+                  <trimStackTrace>false</trimStackTrace>
                   <!-- Make sure to fail the build when the suite fails to initialize -->
                   <failIfNoTests>true</failIfNoTests>
                 </configuration>
@@ -146,25 +151,14 @@ limitations under the License.
     </profile>
     <profile>
       <id>hbaseLocalMiniClusterTestH2</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.hbase</groupId>
-          <artifactId>hbase-testing-util</artifactId>
-          <version>${hbase.version}</version>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.hbase</groupId>
-          <artifactId>hbase-mapreduce</artifactId>
-          <version>${hbase.version}</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
       <build>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <trimStackTrace>false</trimStackTrace>
+            </configuration>
             <executions>
               <execution>
                 <id>api-integration-test</id>
@@ -183,11 +177,11 @@ limitations under the License.
                   <includes>
                     <include>**/IntegrationTests.java</include>
                   </includes>
-                  <trimStackTrace>false</trimStackTrace>
                   <reportNameSuffix>local-mini-cluster</reportNameSuffix>
                   <forkedProcessTimeoutInSeconds>
                     ${test.timeout}
                   </forkedProcessTimeoutInSeconds>
+                  <trimStackTrace>false</trimStackTrace>
                   <!-- Make sure to fail the build when the suite fails to initialize -->
                   <failIfNoTests>true</failIfNoTests>
                 </configuration>
@@ -204,6 +198,9 @@ limitations under the License.
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <trimStackTrace>false</trimStackTrace>
+            </configuration>
             <executions>
               <execution>
                 <id>api-integration-test</id>
@@ -300,6 +297,8 @@ limitations under the License.
                   <forkedProcessTimeoutInSeconds>
                     ${test.timeout}
                   </forkedProcessTimeoutInSeconds>
+                  <!-- Make sure to fail the build when the suite fails to initialize -->
+                  <failIfNoTests>true</failIfNoTests>
                 </configuration>
               </execution>
             </executions>
@@ -309,20 +308,52 @@ limitations under the License.
     </profile>
   </profiles>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bigtable-bom</artifactId>
+        <version>${bigtable.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bigtable-deps-bom</artifactId>
+        <version>${bigtable.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
+    <!-- Project Modules -->
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>bigtable-hbase-2.x-hadoop</artifactId>
+      <groupId>com.google.cloud.bigtable</groupId>
+      <artifactId>bigtable-hbase</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
-
       <exclusions>
-        <!-- Workaround MNG-5899 & MSHADE-206. Maven >= 3.3.0 doesn't use the dependency reduced
-        pom.xml files when invoking the build from a parent project. So we have to manually exclude
-        the dependencies. -->
+        <!-- included in hbase-shaded-testing-util -->
         <exclusion>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>bigtable-hbase-2.x-shaded</artifactId>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-shaded-client</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>bigtable-hbase-2.x</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <!-- included in hbase-shaded-testing-util -->
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-shaded-client</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -338,48 +369,49 @@ limitations under the License.
           <artifactId>org.apache.hbase</artifactId>
           <groupId>*</groupId>
         </exclusion>
-        <exclusion>
-          <artifactId>${project.groupId}</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
       </exclusions>
     </dependency>
+
+
+    <!-- java-bigtable Modules -->
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-bigtable</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+
+    <!-- HBase testing tools -->
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-shaded-testing-util</artifactId>
+      <version>${hbase.version.2}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Misc -->
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>${jsr305.version}</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>${hbase-guava.version}</version>
+      <version>${guava.version}</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
       <version>${commons-lang.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-common</artifactId>
-      <version>${hbase2-hadoop.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-common</artifactId>
-      <version>${hbase.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-client</artifactId>
-      <version>${hbase.version}</version>
-      <scope>test</scope>
-    </dependency>
+
+    <!-- Testing deps -->
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
@@ -392,6 +424,7 @@ limitations under the License.
       <version>${hamcrest.version}</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -437,6 +470,16 @@ limitations under the License.
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <usedDependencies>
+            <usedDependency>${project.groupId}:bigtable-hbase-2.x
+            </usedDependency>
+          </usedDependencies>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestFilters.java
@@ -17,8 +17,7 @@ package com.google.cloud.bigtable.hbase;
 
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
 
-import com.google.bigtable.repackaged.com.google.cloud.bigtable.data.v2.models.Filters;
-import com.google.bigtable.repackaged.com.google.protobuf.ByteString;
+import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.cloud.bigtable.hbase.filter.BigtableFilter;
 import com.google.cloud.bigtable.hbase.filter.TimestampRangeFilter;
 import java.io.IOException;
@@ -84,8 +83,7 @@ public class TestFilters extends AbstractTestFilters {
               .addColumn(COLUMN_FAMILY, qualA, valA)
               .addColumn(COLUMN_FAMILY, qualB, valB));
 
-      Filters.Filter qualAFilter =
-          Filters.FILTERS.qualifier().exactMatch(ByteString.copyFrom(qualA));
+      Filters.Filter qualAFilter = Filters.FILTERS.qualifier().exactMatch(new String(qualA));
       BigtableFilter bigtableFilter = new BigtableFilter(qualAFilter);
       Result result = table.get(new Get(rowKey).setFilter(bigtableFilter));
 

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncConnection.java
@@ -33,7 +33,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class TestAsyncConnection extends AbstractAsyncTest {
 
-  private static final ExecutorService directExecutorService = MoreExecutors.sameThreadExecutor();
+  private static final ExecutorService directExecutorService =
+      MoreExecutors.newDirectExecutorService();
 
   @Rule public ExpectedException thrown = ExpectedException.none();
 

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncScan.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncScan.java
@@ -17,8 +17,8 @@ package com.google.cloud.bigtable.hbase.async;
 
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
 
-import com.google.bigtable.repackaged.com.google.common.util.concurrent.SettableFuture;
 import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
+import com.google.common.util.concurrent.SettableFuture;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncRegistry.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncRegistry.java
@@ -49,18 +49,8 @@ public class BigtableAsyncRegistry implements AsyncRegistry {
   }
 
   @Override
-  public CompletableFuture<Integer> getCurrentNrHRS() {
-    throw new UnsupportedOperationException("getCurrentNrHRS");
-  }
-
-  @Override
   public CompletableFuture<ServerName> getMasterAddress() {
     throw new UnsupportedOperationException("getMasterAddress");
-  }
-
-  @Override
-  public CompletableFuture<Integer> getMasterInfoPort() {
-    throw new UnsupportedOperationException("getMasterInfoPort");
   }
 
   @Override

--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,6 @@ limitations under the License.
     <hbase.version>${hbase.version.1}</hbase.version>
     <hbase1-hadoop.version>2.7.4</hbase1-hadoop.version>
     <hbase2-hadoop.version>2.8.5</hbase2-hadoop.version>
-    <hbase-guava.version>12.0.1</hbase-guava.version>
-    <hbase-protobuf.version>2.5.0</hbase-protobuf.version>
 
     <!-- testing dependency versions -->
     <commons-lang.version>2.6</commons-lang.version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@ limitations under the License.
     <jsr305.version>3.0.2</jsr305.version>
 
     <!-- hbase dependency versions -->
-    <hbase.version.1>1.4.10</hbase.version.1>
-    <hbase.version.2>2.2.0</hbase.version.2>
+    <hbase.version.1>1.4.12</hbase.version.1>
+    <hbase.version.2>2.2.3</hbase.version.2>
     <hbase.version>${hbase.version.1}</hbase.version>
     <hbase1-hadoop.version>2.7.4</hbase1-hadoop.version>
     <hbase2-hadoop.version>2.8.5</hbase2-hadoop.version>


### PR DESCRIPTION
Migrate integration tests to use hbase-shaded-testing-util, which allows us to use unshaded versions of bigtable-hbase-{1,2}.x.
