### PR TITLE
chore: fix opencensus transitive deps

### DIFF
--- a/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
@@ -47,6 +47,10 @@ limitations under the License.
           <groupId>${project.groupId}</groupId>
           <artifactId>bigtable-hbase-1.x</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.opencensus</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -90,6 +94,16 @@ limitations under the License.
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
       <version>${beam.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.cloud.bigtable</groupId>
+          <artifactId>bigtable-client-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.api.grpc</groupId>
+          <artifactId>grpc-google-cloud-bigtable-v2</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- TODO: remove these dependencies when upgraded through transitive dependency (beam-runners-google-cloud-dataflow-java)

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/pom.xml
@@ -53,6 +53,10 @@ limitations under the License.
                     <groupId>${project.groupId}</groupId>
                     <artifactId>bigtable-hbase-1.x</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.opencensus</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
@@ -47,6 +47,10 @@ limitations under the License.
           <groupId>${project.groupId}</groupId>
           <artifactId>bigtable-hbase-1.x</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.opencensus</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -50,13 +50,30 @@ limitations under the License.
   </dependencyManagement>
 
 <dependencies>
+  <!-- Internal dependencies that will be shaded along with their transitive dependencies.
+   When adding new internal dependencies, make sure to exclude them from the reactor in direct dependents.
+   See the *-hadoop/pom.xml and bigtable-hbase-beam/pom.xml for more details-->
   <dependency>
     <groupId>${project.groupId}</groupId>
     <artifactId>bigtable-hbase-1.x</artifactId>
     <version>${project.version}</version>
   </dependency>
+  <!-- Since opencensus-api is a transitive dep, we have to shade its impl as well.
+  Otherwise the -api will be permanently severed from the impl and exporters -->
+  <dependency>
+    <groupId>io.opencensus</groupId>
+    <artifactId>opencensus-impl</artifactId>
+  </dependency>
+  <dependency>
+    <groupId>io.opencensus</groupId>
+    <artifactId>opencensus-contrib-zpages</artifactId>
+  </dependency>
+  <dependency>
+    <groupId>io.opencensus</groupId>
+    <artifactId>opencensus-exporter-trace-stackdriver</artifactId>
+  </dependency>
 
-  <!-- Manually promote dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
+  <!-- Manually promote public dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
   <dependency>
     <groupId>org.apache.hbase</groupId>
     <artifactId>hbase-shaded-client</artifactId>
@@ -76,24 +93,6 @@ limitations under the License.
     <groupId>io.dropwizard.metrics</groupId>
     <artifactId>metrics-core</artifactId>
     <version>${dropwizard.metrics.version}</version>
-  </dependency>
-  <dependency>
-    <groupId>org.checkerframework</groupId>
-    <artifactId>checker-compat-qual</artifactId>
-    <version>${checkerframework.version}</version>
-  </dependency>
-
-  <dependency>
-    <groupId>io.opencensus</groupId>
-    <artifactId>opencensus-impl</artifactId>
-  </dependency>
-  <dependency>
-    <groupId>io.opencensus</groupId>
-    <artifactId>opencensus-contrib-zpages</artifactId>
-  </dependency>
-  <dependency>
-    <groupId>io.opencensus</groupId>
-    <artifactId>opencensus-exporter-trace-stackdriver</artifactId>
   </dependency>
  </dependencies>
 
@@ -148,7 +147,6 @@ limitations under the License.
                   <exclude>org.hamcrest:hamcrest-core</exclude>
                   <exclude>javax.inject:javax.inject</exclude>
                   <exclude>javax.annotation:javax.annotation-api</exclude>
-                  <exclude>org.checkerframework:checker-compat-qual</exclude>
                 </excludes>
               </artifactSet>
               <relocations>
@@ -230,6 +228,14 @@ limitations under the License.
                   <shadedPattern>com.google.bigtable.repackaged.org.apache.commons.codec</shadedPattern>
                 </relocation>
                 <relocation>
+                  <pattern>org.apache.commons.lang3</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.org.apache.commons.lang3</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.conscrypt</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.org.conscrypt</shadedPattern>
+                </relocation>
+                <relocation>
                   <pattern>org.threeten</pattern>
                   <shadedPattern>com.google.bigtable.repackaged.org.threeten</shadedPattern>
                 </relocation>
@@ -247,7 +253,7 @@ limitations under the License.
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
           <!-- Manually promote dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
-          <usedDependencies>com.google.cloud.bigtable:bigtable-hbase-1.x,org.apache.hbase:hbase-shaded-client,com.google.code.findbugs:jsr305,commons-logging:commons-logging,io.dropwizard.metrics:metrics-core,org.checkerframework:checker-compat-qual,io.opencensus:opencensus-impl,io.opencensus:opencensus-contrib-zpages,io.opencensus:opencensus-exporter-trace-stackdriver</usedDependencies>
+          <usedDependencies>com.google.cloud.bigtable:bigtable-hbase-1.x,org.apache.hbase:hbase-shaded-client,com.google.code.findbugs:jsr305,commons-logging:commons-logging,io.dropwizard.metrics:metrics-core,io.opencensus:opencensus-impl,io.opencensus:opencensus-contrib-zpages,io.opencensus:opencensus-exporter-trace-stackdriver</usedDependencies>
         </configuration>
       </plugin>
     </plugins>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
@@ -51,6 +51,10 @@ limitations under the License.
           <groupId>${project.groupId}</groupId>
           <artifactId>bigtable-hbase-2.x</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.opencensus</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
@@ -54,10 +54,27 @@ limitations under the License.
   </dependencyManagement>
 
 <dependencies>
+  <!-- Internal dependencies that will be shaded along with their transitive dependencies.
+   When adding new internal dependencies, make sure to exclude them from the reactor in direct dependents.
+   See the *-hadoop/pom.xml and bigtable-hbase-beam/pom.xml for more details-->
   <dependency>
     <groupId>${project.groupId}</groupId>
     <artifactId>bigtable-hbase-2.x</artifactId>
     <version>${project.version}</version>
+  </dependency>
+  <!-- Since opencensus-api is a transitive dep, we have to shade its impl as well.
+  Otherwise the -api will be permanently severed from the impl and exporters -->
+  <dependency>
+    <groupId>io.opencensus</groupId>
+    <artifactId>opencensus-impl</artifactId>
+  </dependency>
+  <dependency>
+    <groupId>io.opencensus</groupId>
+    <artifactId>opencensus-contrib-zpages</artifactId>
+  </dependency>
+  <dependency>
+    <groupId>io.opencensus</groupId>
+    <artifactId>opencensus-exporter-trace-stackdriver</artifactId>
   </dependency>
 
   <!-- Manually promote dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
@@ -80,24 +97,6 @@ limitations under the License.
     <groupId>io.dropwizard.metrics</groupId>
     <artifactId>metrics-core</artifactId>
     <version>${dropwizard.metrics.version}</version>
-  </dependency>
-    <dependency>
-        <groupId>org.checkerframework</groupId>
-        <artifactId>checker-compat-qual</artifactId>
-        <version>${checkerframework.version}</version>
-    </dependency>
-
-  <dependency>
-    <groupId>io.opencensus</groupId>
-    <artifactId>opencensus-impl</artifactId>
-  </dependency>
-  <dependency>
-    <groupId>io.opencensus</groupId>
-    <artifactId>opencensus-contrib-zpages</artifactId>
-  </dependency>
-  <dependency>
-    <groupId>io.opencensus</groupId>
-    <artifactId>opencensus-exporter-trace-stackdriver</artifactId>
   </dependency>
  </dependencies>
 
@@ -165,7 +164,6 @@ limitations under the License.
                   <exclude>org.apache.htrace:htrace-core4</exclude>
                   <exclude>org.apache.yetus:audience-annotations</exclude>
                   <exclude>javax.annotation:javax.annotation-api</exclude>
-                  <exclude>org.checkerframework:checker-compat-qual</exclude>
                 </excludes>
               </artifactSet>
               <relocations>
@@ -248,6 +246,14 @@ limitations under the License.
                   <shadedPattern>com.google.bigtable.repackaged.org.apache.commons.codec</shadedPattern>
                 </relocation>
                 <relocation>
+                  <pattern>org.apache.commons.lang3</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.org.apache.commons.lang3</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.conscrypt</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.org.conscrypt</shadedPattern>
+                </relocation>
+                <relocation>
                   <pattern>org.threeten</pattern>
                   <shadedPattern>com.google.bigtable.repackaged.org.threeten</shadedPattern>
                 </relocation>
@@ -265,7 +271,7 @@ limitations under the License.
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
           <!-- Manually promote dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
-          <usedDependencies>com.google.cloud.bigtable:bigtable-hbase-2.x,org.apache.hbase:hbase-shaded-client,com.google.code.findbugs:jsr305,commons-logging:commons-logging,io.dropwizard.metrics:metrics-core,org.checkerframework:checker-compat-qual,io.opencensus:opencensus-impl,io.opencensus:opencensus-contrib-zpages,io.opencensus:opencensus-exporter-trace-stackdriver</usedDependencies>
+          <usedDependencies>com.google.cloud.bigtable:bigtable-hbase-2.x,org.apache.hbase:hbase-shaded-client,com.google.code.findbugs:jsr305,commons-logging:commons-logging,io.dropwizard.metrics:metrics-core,io.opencensus:opencensus-impl,io.opencensus:opencensus-contrib-zpages,io.opencensus:opencensus-exporter-trace-stackdriver</usedDependencies>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,6 @@ limitations under the License.
         <slf4j.version>1.7.30</slf4j.version>
         <commons-logging.version>1.2</commons-logging.version>
         <jsr305.version>3.0.2</jsr305.version>
-        <checkerframework.version>2.5.5</checkerframework.version>
 
         <!-- hbase dependency versions -->
         <hbase.version.1>1.4.10</hbase.version.1>


### PR DESCRIPTION
Previously opencensus impl deps were added to bigtable-hbase-*-shaded. These were
meant to be relocated along with opencensus-api. Unfortunately workarounds for MSHADE-206
were not put into place, which caused them to bleed through to downstream dependencies.

This PR fixes the situation by transitively excluding them during a full build.
Also,
* metrics overlap in the import job is fixed
* conscrypt and commons-lang3 are relocated
* unnecessary checkerframework dep is removed