### PR TITLE
Change deprecated example in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ infrequent product and client library announcements.
     @Setup
     public void setup() {
       // for bigtable-core
-      BigtableOptions opts = new BigtableOptions.Builder()
+      BigtableOptions opts = BigtableOptions.builder()
             .enableEmulator("localhost:" + bigtableEmulator.getPort())
             .setUserAgent("fake")
             .setProjectId("fakeproject")


### PR DESCRIPTION
Calling new BigtableOptions.Builder() directly is deprecated, as per the docs:

https://cloud.google.com/bigtable/docs/hbase-client/javadoc/com/google/cloud/bigtable/config/BigtableOptions.Builder

Builder()
Deprecated.
Please use the BigtableOptions.builder() instead.

We should update the example in README according to these instructions.