### PR TITLE
chore(deps): update google-cloud-bigtable dependencies

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableVeneerSettingsFactory.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableVeneerSettingsFactory.java
@@ -263,15 +263,15 @@ public class BigtableVeneerSettingsFactory {
         .setRetryableCodes(buildRetryCodes(options.getRetryOptions()));
   }
 
-  // BulkRead only accepts batchSize
   private static void buildBulkReadRowsSettings(Builder builder, BigtableOptions options) {
     RetrySettings retrySettings =
-        buildIdempotentRetrySettings(builder.readRowSettings().getRetrySettings(), options);
-
-    BatchingSettings.Builder batchBuilder =
-        builder.bulkMutateRowsSettings().getBatchingSettings().toBuilder();
+        buildIdempotentRetrySettings(builder.bulkReadRowsSettings().getRetrySettings(), options);
     long bulkMaxRowKeyCount = options.getBulkOptions().getBulkMaxRowKeyCount();
 
+    BatchingSettings.Builder batchBuilder =
+        builder.bulkReadRowsSettings().getBatchingSettings().toBuilder();
+
+    // BulkRead has only manual flushing. Also, kept the veneer's FlowControlSettings default.
     batchBuilder.setElementCountThreshold(bulkMaxRowKeyCount);
 
     builder

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/config/TestBigtableVeneerSettingsFactory.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/config/TestBigtableVeneerSettingsFactory.java
@@ -263,6 +263,12 @@ public class TestBigtableVeneerSettingsFactory {
         DEFAULT_RETRY_CODES,
         dataSettings.getStubSettings().bulkMutateRowsSettings().getRetryableCodes());
 
+    // bulkReadRowsSettings
+    verifyRetry(dataSettings.getStubSettings().bulkReadRowsSettings().getRetrySettings());
+    assertEquals(
+        DEFAULT_RETRY_CODES,
+        dataSettings.getStubSettings().bulkReadRowsSettings().getRetryableCodes());
+
     // Non-streaming operation's verifying RetrySettings & RetryCodes of non-retryable methods.
     // readModifyWriteRowSettings
     verifyDisabledRetry(
@@ -366,5 +372,28 @@ public class TestBigtableVeneerSettingsFactory {
     adminSettings = BigtableVeneerSettingsFactory.createTableAdminSettings(options);
     assertTrue(
         adminSettings.getStubSettings().getCredentialsProvider() instanceof NoCredentialsProvider);
+  }
+
+  @Test
+  public void testBulkReadConfig() throws IOException {
+    int maxRowKeyCount = 1_000_000;
+    BigtableOptions options =
+        BigtableOptions.builder()
+            .setProjectId(TEST_PROJECT_ID)
+            .setInstanceId(TEST_INSTANCE_ID)
+            .setCredentialOptions(CredentialOptions.nullCredential())
+            .setUserAgent("Test-user-agent")
+            .setBulkOptions(BulkOptions.builder().setBulkMaxRowKeyCount(maxRowKeyCount).build())
+            .build();
+    dataSettings = BigtableVeneerSettingsFactory.createBigtableDataSettings(options);
+
+    assertEquals(
+        maxRowKeyCount,
+        dataSettings
+            .getStubSettings()
+            .bulkReadRowsSettings()
+            .getBatchingSettings()
+            .getElementCountThreshold()
+            .intValue());
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@ limitations under the License.
     <compileSource.1.8>1.8</compileSource.1.8>
 
     <!-- core dependency versions -->
-    <bigtable.version>1.9.1</bigtable.version>
+    <bigtable.version>1.10.0</bigtable.version>
     <dropwizard.metrics.version>3.2.6</dropwizard.metrics.version>
     <slf4j.version>1.7.30</slf4j.version>
     <commons-logging.version>1.2</commons-logging.version>


### PR DESCRIPTION

## Background:
The latest release of `google-cloud-bigtable` introduces `BigtableDataClient#newBulkReadRowsBatcher` API. We need this API to wrap existing BulkRead API present in `bigtable-client-core`.

## What this PR contains:
As of now, we are overriding the retryCodes of `BigtableDataSettings#readRowsSettings` with bigtable-client-core-specific codes. 
The [BigtableDataSettings has a check](https://github.com/googleapis/java-bigtable/blob/master/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java#L184-L189) to match it's retryCode between `readRows()` and  `bulkReadRowsBatcher()`that's why to update the `google-cloud-bigtable` version, we needed to override `bulkReadRowsBatcher()`'s retryCodes.

 - Updated `google-cloud-bigtable-bom`, `google-cloud-bigtable-deps-bom`.
 - Override `bulkReadRowsSettings()` with `BulkRead` configuration(bulkMaxRowKeyCount).
 - Added unit test cases.
