### PR TITLE
feat: adding bulkRead wrapper for core client

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBulkRead.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBulkRead.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.core;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.InternalApi;
+import com.google.cloud.bigtable.data.v2.models.Query;
+import com.google.cloud.bigtable.data.v2.models.Row;
+import com.google.cloud.bigtable.grpc.BigtableTableName;
+
+/**
+ * Interface to support bulk read of {@link Query} request into a single grpc request.
+ *
+ * <p>For internal use only - public for technical reasons.
+ *
+ * <p>See {@link com.google.cloud.bigtable.grpc.BigtableSession#createBulkRead(BigtableTableName)}
+ * as a public alternative.
+ */
+@InternalApi("For internal usage only")
+public interface IBulkRead extends AutoCloseable {
+
+  ApiFuture<Row> add(Query request);
+
+  void flush();
+}

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -42,11 +42,13 @@ import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.cloud.bigtable.core.IBigtableDataClient;
 import com.google.cloud.bigtable.core.IBigtableTableAdminClient;
 import com.google.cloud.bigtable.core.IBulkMutation;
+import com.google.cloud.bigtable.core.IBulkRead;
 import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
 import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.cloud.bigtable.grpc.async.BulkMutation;
 import com.google.cloud.bigtable.grpc.async.BulkMutationWrapper;
 import com.google.cloud.bigtable.grpc.async.BulkRead;
+import com.google.cloud.bigtable.grpc.async.BulkReadWrapper;
 import com.google.cloud.bigtable.grpc.async.ResourceLimiter;
 import com.google.cloud.bigtable.grpc.async.ResourceLimiterStats;
 import com.google.cloud.bigtable.grpc.async.ThrottlingClientInterceptor;
@@ -722,6 +724,18 @@ public class BigtableSession implements Closeable {
         tableName,
         options.getBulkOptions().getBulkMaxRowKeyCount(),
         BigtableSessionSharedThreadPools.getInstance().getBatchThreadPool());
+  }
+
+  /**
+   * For internal use only - public for technical reasons.
+   *
+   * <p>Please use {@link BigtableSession#createBulkRead(BigtableTableName)} as a public
+   * alternative.
+   */
+  @InternalApi("For internal usage only")
+  public IBulkRead createBulkReadWrapper(BigtableTableName tableName) {
+    // TODO(rahulkql): create a bulkRead wrapper which consumes gax Batcher API.
+    return new BulkReadWrapper(createBulkRead(tableName));
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkReadWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkReadWrapper.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc.async;
+
+import com.google.api.core.ApiFunction;
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.core.InternalApi;
+import com.google.cloud.bigtable.core.IBulkRead;
+import com.google.cloud.bigtable.data.v2.models.Query;
+import com.google.cloud.bigtable.data.v2.models.Row;
+import com.google.cloud.bigtable.grpc.BigtableTableName;
+import com.google.cloud.bigtable.grpc.scanner.FlatRow;
+import com.google.cloud.bigtable.grpc.scanner.FlatRowConverter;
+import com.google.common.util.concurrent.MoreExecutors;
+
+/**
+ * This class wraps existing {@link BulkRead} with Google-cloud-java's model.
+ *
+ * <p>For internal use only - public for technical reasons.
+ *
+ * <p>See {@link com.google.cloud.bigtable.grpc.BigtableSession#createBulkRead(BigtableTableName)}
+ * as a public alternative.
+ */
+@InternalApi("For internal usage only - please use BulkRead")
+public class BulkReadWrapper implements IBulkRead {
+
+  private final BulkRead delegate;
+
+  public BulkReadWrapper(BulkRead delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public ApiFuture<Row> add(Query request) {
+    return ApiFutures.transform(
+        delegate.add(request),
+        new ApiFunction<FlatRow, Row>() {
+          @Override
+          public Row apply(FlatRow flatRow) {
+            return FlatRowConverter.convertToModelRow(flatRow);
+          }
+        },
+        MoreExecutors.directExecutor());
+  }
+
+  @Override
+  public void flush() {
+    delegate.flush();
+  }
+
+  @Override
+  public void close() {
+    delegate.flush();
+  }
+}

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkReadWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkReadWrapper.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc.async;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.cloud.bigtable.core.IBulkRead;
+import com.google.cloud.bigtable.data.v2.models.Query;
+import com.google.cloud.bigtable.data.v2.models.Row;
+import com.google.cloud.bigtable.grpc.scanner.FlatRow;
+import com.google.cloud.bigtable.grpc.scanner.FlatRowConverter;
+import com.google.protobuf.ByteString;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+@RunWith(JUnit4.class)
+public class TestBulkReadWrapper {
+
+  private BulkRead mockDelegate;
+  private IBulkRead bulkRead;
+
+  @Before
+  public void setUp() {
+    mockDelegate = Mockito.mock(BulkRead.class);
+    bulkRead = new BulkReadWrapper(mockDelegate);
+  }
+
+  @Test
+  public void testAdd() throws Exception {
+    Query request = Query.create("tableId").rowKey("row-key");
+    FlatRow flatRow =
+        FlatRow.newBuilder()
+            .withRowKey(ByteString.copyFromUtf8("row-key"))
+            .addCell("family", ByteString.EMPTY, 10000L, ByteString.copyFromUtf8("test-value"))
+            .build();
+    when(mockDelegate.add(request)).thenReturn(ApiFutures.immediateFuture(flatRow));
+
+    ApiFuture<Row> rowFuture = bulkRead.add(request);
+
+    assertEquals(FlatRowConverter.convertToModelRow(flatRow), rowFuture.get());
+    verify(mockDelegate).add(request);
+  }
+
+  @Test
+  public void testFlush() {
+    doNothing().when(mockDelegate).flush();
+    bulkRead.flush();
+    verify(mockDelegate).flush();
+  }
+
+  @Test
+  public void testClose() throws Exception {
+    doNothing().when(mockDelegate).flush();
+    bulkRead.close();
+    verify(mockDelegate).flush();
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
@@ -22,8 +22,8 @@ import com.google.api.core.InternalApi;
 import com.google.api.core.SettableApiFuture;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.config.Logger;
+import com.google.cloud.bigtable.core.IBulkRead;
 import com.google.cloud.bigtable.grpc.BigtableSession;
-import com.google.cloud.bigtable.grpc.async.BulkRead;
 import com.google.cloud.bigtable.grpc.scanner.FlatRow;
 import com.google.cloud.bigtable.hbase.adapters.Adapters;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
@@ -51,7 +51,7 @@ import org.apache.hadoop.hbase.util.Bytes;
  * org.apache.hadoop.hbase.client.Table#batch(List, Object[])}. {@link
  * org.apache.hadoop.hbase.client.Table#put(List)} and {@link
  * org.apache.hadoop.hbase.client.Table#get(List)}. This class relies on implementations found in
- * {@link BulkRead} and in {@link BigtableBufferedMutatorHelper}.
+ * {@link IBulkRead} and in {@link BigtableBufferedMutatorHelper}.
  *
  * <p>For internal use only - public for technical reasons.
  */
@@ -133,7 +133,7 @@ public class BatchExecutor {
   protected final Timer batchTimer = BigtableClientMetrics.timer(MetricLevel.Info, "batch.latency");
   // Once the IBigtableDataClient interface is implemented, this will be removed.
   private final BigtableBufferedMutatorHelper bufferedMutatorHelper;
-  private final BulkRead bulkRead;
+  private final IBulkRead bulkRead;
 
   /**
    * Constructor for BatchExecutor.
@@ -145,7 +145,7 @@ public class BatchExecutor {
   public BatchExecutor(BigtableSession session, HBaseRequestAdapter requestAdapter) {
     this.requestAdapter = requestAdapter;
     this.options = session.getOptions();
-    this.bulkRead = session.createBulkRead(requestAdapter.getBigtableTableName());
+    this.bulkRead = session.createBulkReadWrapper(requestAdapter.getBigtableTableName());
     this.bufferedMutatorHelper =
         new BigtableBufferedMutatorHelper(
             requestAdapter,


### PR DESCRIPTION
## Background
Currently BulkRead API returns row details with FlatRow as a logical bigtable row. Going forward we are going to introduce BulkRead API which uses gax's Batcher API to resolve the input entries.

## What this PR contains:
This PR introduces a simple wrapper b/w existing `BulkRead` with veneer's model(i.e. models.Row). Also, updated `BatchExecutor` to adapt against model Row.

**Note:** I will raise a follow up PR with BulkReadGCJClient which would perform batching with Gax's Batcher API when `google-cloud-bigtable` version updates to `1.10.0`.