### PR TITLE
fix: row adapter when label is present

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/RowAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/RowAdapter.java
@@ -50,6 +50,10 @@ public class RowAdapter implements ResponseAdapter<Row, Result> {
 
     for (com.google.cloud.bigtable.data.v2.models.RowCell rowCell : response.getCells()) {
 
+      if (!rowCell.getLabels().isEmpty()) {
+        continue;
+      }
+
       byte[] familyNameBytes = Bytes.toBytes(rowCell.getFamily());
       byte[] columnQualifier = ByteStringer.extract(rowCell.getQualifier());
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestRowAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestRowAdapter.java
@@ -58,6 +58,7 @@ public class TestRowAdapter {
     byte[] family2Bytes = Bytes.toBytes(family2);
     byte[] qualifier1 = "qualifier1".getBytes();
     byte[] qualifier2 = "qualifier2".getBytes();
+    byte[] qualifier3 = "qualifier2".getBytes();
     byte[] value1 = "value1".getBytes();
     byte[] value2 = "value2".getBytes();
     byte[] value3 = "value3".getBytes();
@@ -110,8 +111,8 @@ public class TestRowAdapter {
                 ByteString.copyFrom(value5)),
             // Contains label, should be ignored.
             RowCell.create(
-                family1,
-                ByteString.copyFrom(qualifier1),
+                "family-name",
+                ByteString.copyFrom(qualifier3),
                 ts2Micros,
                 Collections.singletonList("label"),
                 ByteString.copyFrom(value1)));


### PR DESCRIPTION
Fixes #2384 

This contains small a fix for `labels` check in `RowAdapter`. This was missed by me in the original PR.