### PR TITLE
feat: add readRows with veneer Row stream observer

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBigtableDataClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBigtableDataClient.java
@@ -147,18 +147,12 @@ public interface IBigtableDataClient {
    */
   ApiFuture<List<FlatRow>> readFlatRowsAsync(Query request);
 
-  /**
-   * Read {@link FlatRow} asynchronously, and pass them to a stream observer to be processed.
-   *
-   * @param request a {@link Query} object.
-   * @param observer a {@link StreamObserver} object.
-   * @deprecated Please use {@link #readRowsAsync(Query, StreamObserver)}.
-   */
+  /** @deprecated Please use {@link #readRowsAsync(Query, StreamObserver)}. */
   @Deprecated
   void readFlatRowsAsync(Query request, StreamObserver<FlatRow> observer);
 
   /**
-   * Reads {@link Row} asynchronously, and pass them to a stream observer for processing.
+   * Reads rows asynchronously and passes them to the given stream observer for processing.
    *
    * @param request a {@link Query} object.
    * @param observer a {@link StreamObserver} object.

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBigtableDataClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBigtableDataClient.java
@@ -152,6 +152,16 @@ public interface IBigtableDataClient {
    *
    * @param request a {@link Query} object.
    * @param observer a {@link StreamObserver} object.
+   * @deprecated Please use {@link #readRowsAsync(Query, StreamObserver)}.
    */
+  @Deprecated
   void readFlatRowsAsync(Query request, StreamObserver<FlatRow> observer);
+
+  /**
+   * Reads {@link Row} asynchronously, and pass them to a stream observer for processing.
+   *
+   * @param request a {@link Query} object.
+   * @param observer a {@link StreamObserver} object.
+   */
+  void readRowsAsync(Query request, StreamObserver<Row> observer);
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataClientWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataClientWrapper.java
@@ -271,4 +271,26 @@ public class BigtableDataClientWrapper implements IBigtableDataClient {
   public void readFlatRowsAsync(Query request, StreamObserver<FlatRow> observer) {
     delegate.readFlatRows(request.toProto(requestContext), observer);
   }
+
+  @Override
+  public void readRowsAsync(Query request, final StreamObserver<Row> observer) {
+    delegate.readFlatRows(
+        request.toProto(requestContext),
+        new StreamObserver<FlatRow>() {
+          @Override
+          public void onNext(FlatRow flatRow) {
+            observer.onNext(FlatRowConverter.convertToModelRow(flatRow));
+          }
+
+          @Override
+          public void onError(Throwable throwable) {
+            observer.onError(throwable);
+          }
+
+          @Override
+          public void onCompleted() {
+            observer.onCompleted();
+          }
+        });
+  }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGCJClient.java
@@ -133,6 +133,11 @@ public class BigtableDataGCJClient implements IBigtableDataClient, AutoCloseable
   }
 
   @Override
+  public void readRowsAsync(Query request, StreamObserver<Row> observer) {
+    delegate.readRowsAsync(request, new StreamObserverAdapter<>(observer));
+  }
+
+  @Override
   public void close() throws Exception {
     delegate.close();
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGCJClient.java
@@ -52,6 +52,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
 
 @RunWith(JUnit4.class)
 public class TestBigtableDataGCJClient {
@@ -278,6 +279,17 @@ public class TestBigtableDataGCJClient {
     streamOb.onNext(flatRows.get(0));
     verify(dataClientV2).readRowsCallable(any(FlatRowAdapter.class));
     verify(serverStreaming).call(any(Query.class), any(ResponseObserver.class));
+  }
+
+  @Test
+  public void testReadRowsAsyncWithStreamObserver() {
+    StreamObserver<Row> rowStreamOb = Mockito.mock(StreamObserver.class);
+    doNothing()
+        .when(dataClientV2)
+        .readRowsAsync(any(Query.class), Mockito.<ResponseObserver<Row>>any());
+    dataGCJClient.readRowsAsync(request, rowStreamOb);
+
+    verify(dataClientV2).readRowsAsync(any(Query.class), Mockito.<ResponseObserver<Row>>any());
   }
 
   @Test


### PR DESCRIPTION
Towards #2386 

## Background
As of now, Hbase's [BigtableAsyncTable#scan](https://github.com/googleapis/java-bigtable-hbase/blob/41a3d98cb4561917ac91e1ea9207b99e1f3e0067/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTable.java#L389-L406) is based upon `FlatRow`. We needed this operation with abstraction in our common interface to be removed to move away from `FlatRow`.

## What this PR contains

This change contains below changes
   - Introduces a new API in [IBigtableDataClient#readRowsAsync](https://github.com/googleapis/java-bigtable-hbase/blob/41a3d98cb4561917ac91e1ea9207b99e1f3e0067/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBigtableDataClient.java#L150-L156)
   - Deprecates existing API which accept FlatRow as an argument i.e [IBigtableDataClient#readFlatRowsAsync](https://github.com/googleapis/java-bigtable-hbase/blob/41a3d98cb4561917ac91e1ea9207b99e1f3e0067/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBigtableDataClient.java#L142-L148)

**Note:** I believe deprecating existing API should not be an issue as [IBigtableDataClient](https://github.com/googleapis/java-bigtable-hbase/blob/41a3d98cb4561917ac91e1ea9207b99e1f3e0067/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBigtableDataClient.java#L37) is internal only. Also, this operation is available through the public interface [BigtableDataClient](https://github.com/googleapis/java-bigtable-hbase/blob/41a3d98cb4561917ac91e1ea9207b99e1f3e0067/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataClient.java#L176-L183).