### PR TITLE
chore(deps): update beam version to latest i.e. 2.19.0

### DIFF
--- a/bigtable-dataflow-parent/bigtable-hbase-beam/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/pom.xml
@@ -85,14 +85,6 @@ limitations under the License.
       <version>${slf4j.version}</version>
     </dependency>
 
-    <!--  TODO: remove this dependency when upgraded through transitive dependency (beam-sdks-java-core)
-     this is not used directly, but upgrading due to transitive vulnerabilities in older versions-->
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-compress</artifactId>
-      <version>1.20</version>
-    </dependency>
-
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/pom.xml
@@ -85,6 +85,14 @@ limitations under the License.
       <version>${slf4j.version}</version>
     </dependency>
 
+    <!--  TODO: remove this dependency when upgraded through transitive dependency (beam-sdks-java-core)
+     this is not used directly, but upgrading due to transitive vulnerabilities in older versions-->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.20</version>
+    </dependency>
+
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@ limitations under the License.
     <hamcrest.version>1.3</hamcrest.version>
     <mockito.version>3.2.4</mockito.version>
     <!-- TODO: check if commons-codec was transitively updated to 1.13 and okhttp was updated to 2.7.5 when upgrading-->
-    <beam.version>2.15.0</beam.version>
+    <beam.version>2.19.0</beam.version>
     <!-- referred from bigtable-beam-import and bigtable-emulator -->
     <guava.version>28.0-android</guava.version>
     <beam-guava.version>20.0</beam-guava.version>


### PR DESCRIPTION
Fixes #2379 

Have verified through [CloudBigtableBeamITTest](https://github.com/googleapis/java-bigtable-hbase/blob/41a3d98cb4561917ac91e1ea9207b99e1f3e0067/bigtable-dataflow-parent/bigtable-beam-import/src/test/java/com/google/cloud/bigtable/beam/it/CloudBigtableBeamITTest.java) with **DataflowRunner** & **DirectRunner**.