### PR TITLE
chore: adds BigtableHBaseSettings with classic and veneer implementation 

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -153,6 +153,13 @@ public class BigtableOptions implements Serializable, Cloneable {
       options.useCachedDataPool = false;
       options.useGCJClient = false;
 
+      options.bulkOptions =
+          BulkOptions.builder()
+              .setMaxInflightRpcs(
+                  BulkOptions.BIGTABLE_MAX_INFLIGHT_RPCS_PER_CHANNEL_DEFAULT
+                      * options.dataChannelCount)
+              .build();
+
       options.retryOptions = new RetryOptions.Builder().build();
       options.callOptionsConfig = CallOptionsConfig.builder().build();
       // CredentialOptions.defaultCredentials() gets credentials from well known locations, such as
@@ -230,9 +237,17 @@ public class BigtableOptions implements Serializable, Cloneable {
       return this;
     }
 
+    public RetryOptions getRetryOptions() {
+      return options.retryOptions;
+    }
+
     public Builder setBulkOptions(BulkOptions bulkOptions) {
       options.bulkOptions = bulkOptions;
       return this;
+    }
+
+    public BulkOptions getBulkOptions() {
+      return options.bulkOptions;
     }
 
     public Builder setUsePlaintextNegotiation(boolean usePlaintextNegotiation) {
@@ -256,6 +271,10 @@ public class BigtableOptions implements Serializable, Cloneable {
     public Builder setCallOptionsConfig(CallOptionsConfig callOptionsConfig) {
       options.callOptionsConfig = callOptionsConfig;
       return this;
+    }
+
+    public CallOptionsConfig getCallOptionsConfig() {
+      return options.callOptionsConfig;
     }
 
     public Builder setUseBatch(boolean useBatch) {
@@ -318,11 +337,7 @@ public class BigtableOptions implements Serializable, Cloneable {
     }
 
     public BigtableOptions build() {
-      if (options.bulkOptions == null) {
-        int maxInflightRpcs =
-            BulkOptions.BIGTABLE_MAX_INFLIGHT_RPCS_PER_CHANNEL_DEFAULT * options.dataChannelCount;
-        options.bulkOptions = BulkOptions.builder().setMaxInflightRpcs(maxInflightRpcs).build();
-      } else if (options.bulkOptions.getMaxInflightRpcs() <= 0) {
+      if (options.bulkOptions.getMaxInflightRpcs() <= 0) {
         int maxInflightRpcs =
             BulkOptions.BIGTABLE_MAX_INFLIGHT_RPCS_PER_CHANNEL_DEFAULT * options.dataChannelCount;
         options.bulkOptions =

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -337,6 +337,7 @@ public class BigtableOptions implements Serializable, Cloneable {
     }
 
     public BigtableOptions build() {
+      Preconditions.checkNotNull(options.bulkOptions, "bulk options cannot be null");
       if (options.bulkOptions.getMaxInflightRpcs() <= 0) {
         int maxInflightRpcs =
             BulkOptions.BIGTABLE_MAX_INFLIGHT_RPCS_PER_CHANNEL_DEFAULT * options.dataChannelCount;

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/config/TestBigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/config/TestBigtableOptions.java
@@ -132,6 +132,20 @@ public class TestBigtableOptions {
     Assert.assertEquals(300_000, options.getRetryOptions().getMaxElapsedBackoffMillis());
   }
 
+  @Test
+  public void testBuilder_getters() {
+    BigtableOptions.Builder optionsBuilder = BigtableOptions.builder();
+    Assert.assertEquals(
+        BulkOptions.builder()
+            .setMaxInflightRpcs(
+                BulkOptions.BIGTABLE_MAX_INFLIGHT_RPCS_PER_CHANNEL_DEFAULT
+                    * optionsBuilder.getDataChannelCount())
+            .build(),
+        optionsBuilder.getBulkOptions());
+    Assert.assertEquals(CallOptionsConfig.builder().build(), optionsBuilder.getCallOptionsConfig());
+    Assert.assertEquals(RetryOptions.builder().build(), optionsBuilder.getRetryOptions());
+  }
+
   /**
    * This is a dirty way to override the environment that is accessible to a test. It only modifies
    * the JVM's view of the environment, not the environment itself. From:

--- a/bigtable-client-core-parent/bigtable-hbase/pom.xml
+++ b/bigtable-client-core-parent/bigtable-hbase/pom.xml
@@ -135,12 +135,6 @@ limitations under the License.
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.http-client</groupId>
-          <artifactId>google-http-client-jackson2</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <!-- TODO: remove this is direct dep, its only used for its Clock interface -->

--- a/bigtable-client-core-parent/bigtable-hbase/pom.xml
+++ b/bigtable-client-core-parent/bigtable-hbase/pom.xml
@@ -123,6 +123,26 @@ limitations under the License.
       <version>${commons-logging.version}</version>
     </dependency>
 
+    <!-- For veneer client settings configurations -->
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax-grpc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.http-client</groupId>
+          <artifactId>google-http-client-jackson2</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
     <!-- TODO: remove this is direct dep, its only used for its Clock interface -->
     <dependency>
       <groupId>com.google.http-client</groupId>

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableExtendedConfiguration.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableExtendedConfiguration.java
@@ -1,16 +1,18 @@
 package com.google.cloud.bigtable.hbase;
 
-import com.google.api.core.InternalExtensionOnly;
+import com.google.api.core.InternalApi;
 import com.google.auth.Credentials;
 import org.apache.hadoop.conf.Configuration;
 
 /**
  * Allows users to set an explicit {@link Credentials} object.
  *
+ * <p>For internal use only - public for technical reasons.
+ *
  * @see BigtableConfiguration#withCredentials(Configuration, Credentials).
  */
-@InternalExtensionOnly
-class BigtableExtendedConfiguration extends Configuration {
+@InternalApi("For internal usage only")
+public class BigtableExtendedConfiguration extends Configuration {
   private Credentials credentials;
 
   BigtableExtendedConfiguration(Configuration conf, Credentials credentials) {

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BigtableHBaseSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BigtableHBaseSettings.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers;
+
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_GCJ_CLIENT;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.INSTANCE_ID_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.PROJECT_ID_KEY;
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+import com.google.api.core.InternalApi;
+import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
+import com.google.cloud.bigtable.hbase.util.Logger;
+import com.google.cloud.bigtable.hbase.wrappers.classic.BigtableHBaseClassicSettings;
+import com.google.cloud.bigtable.hbase.wrappers.veneer.BigtableHBaseVeneerSettings;
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+
+/** For internal use only - public for technical reasons. */
+@InternalApi("For internal usage only")
+public abstract class BigtableHBaseSettings {
+
+  protected static final Logger LOG = new Logger(BigtableOptionsFactory.class);
+
+  private final Configuration configuration;
+  private final String projectId;
+  private final String instanceId;
+
+  public static BigtableHBaseSettings create(Configuration configuration) throws IOException {
+    if (configuration.getBoolean(BIGTABLE_USE_GCJ_CLIENT, false)) {
+      return new BigtableHBaseVeneerSettings(configuration);
+    } else {
+      return new BigtableHBaseClassicSettings(configuration);
+    }
+  }
+
+  public BigtableHBaseSettings(Configuration configuration) {
+    this.configuration = new Configuration(configuration);
+    this.projectId = getRequiredValue(PROJECT_ID_KEY, "Project ID");
+    this.instanceId = getRequiredValue(INSTANCE_ID_KEY, "Instance ID");
+  }
+
+  public Configuration getConfiguration() {
+    return configuration;
+  }
+
+  public String getProjectId() {
+    return projectId;
+  }
+
+  public String getInstanceId() {
+    return instanceId;
+  }
+
+  public abstract String getDataHost();
+
+  public abstract String getAdminHost();
+
+  public abstract int getPort();
+
+  public abstract int getBulkMaxRowCount();
+
+  protected String getRequiredValue(String key, String displayName) {
+    String value = configuration.get(key);
+    Preconditions.checkArgument(
+        !isNullOrEmpty(value), String.format("%s must be supplied via %s", displayName, key));
+    return value;
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BigtableHBaseSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BigtableHBaseSettings.java
@@ -73,6 +73,8 @@ public abstract class BigtableHBaseSettings {
 
   public abstract int getBulkMaxRowCount();
 
+  public abstract long getBatchingMaxRequestSize();
+
   protected String getRequiredValue(String key, String displayName) {
     String value = configuration.get(key);
     Preconditions.checkArgument(

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BigtableHBaseClassicSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BigtableHBaseClassicSettings.java
@@ -132,6 +132,11 @@ public class BigtableHBaseClassicSettings extends BigtableHBaseSettings {
     return bigtableOptions.getBulkOptions().getBulkMaxRowKeyCount();
   }
 
+  @Override
+  public long getBatchingMaxRequestSize() {
+    return bigtableOptions.getBulkOptions().getMaxMemory();
+  }
+
   public BigtableOptions getBigtableOptions() {
     return bigtableOptions;
   }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BigtableHBaseClassicSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BigtableHBaseClassicSettings.java
@@ -1,0 +1,375 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers.classic;
+
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.ADDITIONAL_RETRY_CODES;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.ALLOW_NO_TIMESTAMP_RETRIES_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.APP_PROFILE_ID_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_ADMIN_HOST_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_ASYNC_MUTATOR_COUNT_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BUFFERED_MUTATOR_ENABLE_THROTTLING;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BUFFERED_MUTATOR_MAX_MEMORY_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BUFFERED_MUTATOR_THROTTLING_THRESHOLD_MILLIS;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BULK_AUTOFLUSH_MS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BULK_MAX_REQUEST_SIZE_BYTES;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BULK_MAX_ROW_KEY_COUNT;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_DATA_CHANNEL_COUNT_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_HOST_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_LONG_RPC_TIMEOUT_MS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_MUTATE_RPC_TIMEOUT_MS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_PORT_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_READ_RPC_TIMEOUT_MS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_RPC_TIMEOUT_MS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_SERVICE_ACCOUNT_EMAIL_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_SERVICE_ACCOUNT_JSON_KEYFILE_LOCATION_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_SERVICE_ACCOUNT_JSON_VALUE_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_SERVICE_ACCOUNT_P12_KEYFILE_LOCATION_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_BATCH;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_BULK_API;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_CACHED_DATA_CHANNEL_POOL;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_PLAINTEXT_NEGOTIATION;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_TIMEOUTS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.CUSTOM_USER_AGENT_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.ENABLE_GRPC_RETRIES_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.ENABLE_GRPC_RETRY_DEADLINEEXCEEDED_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.INITIAL_ELAPSED_BACKOFF_MILLIS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.MAX_ELAPSED_BACKOFF_MILLIS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.MAX_INFLIGHT_RPCS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.MAX_SCAN_TIMEOUT_RETRIES;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.READ_BUFFER_SIZE;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.READ_PARTIAL_ROW_TIMEOUT_MS;
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+import com.google.api.core.InternalApi;
+import com.google.auth.Credentials;
+import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.config.BulkOptions;
+import com.google.cloud.bigtable.config.CallOptionsConfig;
+import com.google.cloud.bigtable.config.CredentialOptions;
+import com.google.cloud.bigtable.config.RetryOptions;
+import com.google.cloud.bigtable.hbase.BigtableExtendedConfiguration;
+import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
+import com.google.common.base.Preconditions;
+import io.grpc.Status;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.util.VersionInfo;
+
+/** For internal use only - public for technical reasons. */
+@InternalApi("For internal usage only")
+public class BigtableHBaseClassicSettings extends BigtableHBaseSettings {
+
+  // Keeping the original configuration, this could be an instance of BigtableExtendedConfiguration.
+  private final Configuration configuration;
+  private final BigtableOptions bigtableOptions;
+
+  public BigtableHBaseClassicSettings(Configuration configuration) throws IOException {
+    super(configuration);
+    this.configuration = configuration;
+    BigtableOptions.Builder bigtableOptionsBuilder = BigtableOptions.builder();
+
+    bigtableOptionsBuilder.setProjectId(getProjectId()).setInstanceId(getInstanceId());
+
+    String appProfileId = configuration.get(APP_PROFILE_ID_KEY);
+    if (!isNullOrEmpty(appProfileId)) {
+      bigtableOptionsBuilder.setAppProfileId(appProfileId);
+    }
+
+    buildBulkOptions(bigtableOptionsBuilder);
+    buildChannelOptions(bigtableOptionsBuilder);
+    buildClientCallOptions(bigtableOptionsBuilder);
+    buildCredentialOptions(bigtableOptionsBuilder);
+    buildRetryOptions(bigtableOptionsBuilder);
+
+    String emulatorHost = configuration.get(BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY);
+    if (!isNullOrEmpty(emulatorHost)) {
+      bigtableOptionsBuilder.enableEmulator(emulatorHost);
+    }
+
+    String useBatchStr = configuration.get(BIGTABLE_USE_BATCH);
+    if (!isNullOrEmpty(useBatchStr)) {
+      bigtableOptionsBuilder.setUseBatch(Boolean.parseBoolean(useBatchStr));
+    }
+
+    this.bigtableOptions = bigtableOptionsBuilder.build();
+  }
+
+  @Override
+  public String getDataHost() {
+    return bigtableOptions.getDataHost();
+  }
+
+  @Override
+  public String getAdminHost() {
+    return bigtableOptions.getAdminHost();
+  }
+
+  @Override
+  public int getPort() {
+    return bigtableOptions.getPort();
+  }
+
+  @Override
+  public int getBulkMaxRowCount() {
+    return bigtableOptions.getBulkOptions().getBulkMaxRowKeyCount();
+  }
+
+  public BigtableOptions getBigtableOptions() {
+    return bigtableOptions;
+  }
+
+  // ************** Private Helpers **************
+  private void buildBulkOptions(BigtableOptions.Builder builder) {
+    BulkOptions.Builder bulkOptionsBuilder = builder.getBulkOptions().toBuilder();
+
+    String asyncMutatorCount = configuration.get(BIGTABLE_ASYNC_MUTATOR_COUNT_KEY);
+    if (!isNullOrEmpty(asyncMutatorCount)) {
+      bulkOptionsBuilder.setAsyncMutatorWorkerCount(Integer.parseInt(asyncMutatorCount));
+    }
+
+    String useBulkApiStr = configuration.get(BIGTABLE_USE_BULK_API);
+    if (!isNullOrEmpty(useBulkApiStr)) {
+      bulkOptionsBuilder.setUseBulkApi(Boolean.parseBoolean(useBulkApiStr));
+    }
+
+    String bulkMaxRowKeyCountStr = configuration.get(BIGTABLE_BULK_MAX_ROW_KEY_COUNT);
+    if (!isNullOrEmpty(bulkMaxRowKeyCountStr)) {
+      bulkOptionsBuilder.setBulkMaxRowKeyCount(Integer.parseInt(bulkMaxRowKeyCountStr));
+    }
+
+    String bulkMaxRequestSize = configuration.get(BIGTABLE_BULK_MAX_REQUEST_SIZE_BYTES);
+    if (!isNullOrEmpty(bulkMaxRequestSize)) {
+      bulkOptionsBuilder.setBulkMaxRequestSize(Long.parseLong(bulkMaxRequestSize));
+    }
+
+    String autoFlushMs = configuration.get(BIGTABLE_BULK_AUTOFLUSH_MS_KEY);
+    if (!isNullOrEmpty(autoFlushMs)) {
+      bulkOptionsBuilder.setAutoflushMs(Long.parseLong(autoFlushMs));
+    }
+
+    String maxInFlightRpcStr = configuration.get(MAX_INFLIGHT_RPCS_KEY);
+    if (!isNullOrEmpty(maxInFlightRpcStr)) {
+      bulkOptionsBuilder.setMaxInflightRpcs(Integer.parseInt(maxInFlightRpcStr));
+    }
+
+    String maxMemoryStr = configuration.get(BIGTABLE_BUFFERED_MUTATOR_MAX_MEMORY_KEY);
+    if (!isNullOrEmpty(maxMemoryStr)) {
+      bulkOptionsBuilder.setMaxMemory(Long.parseLong(maxMemoryStr));
+    }
+
+    if (Boolean.parseBoolean(configuration.get(BIGTABLE_BUFFERED_MUTATOR_ENABLE_THROTTLING))) {
+      String bufferedMutatorThresholdMsStr =
+          configuration.get(BIGTABLE_BUFFERED_MUTATOR_THROTTLING_THRESHOLD_MILLIS);
+
+      if (!isNullOrEmpty(bufferedMutatorThresholdMsStr)) {
+        int mutatorThresholdMs = Integer.parseInt(bufferedMutatorThresholdMsStr);
+        LOG.info(
+            "Bigtable mutation latency throttling enabled with threshold %d", mutatorThresholdMs);
+        bulkOptionsBuilder.enableBulkMutationThrottling();
+        bulkOptionsBuilder.setBulkMutationRpcTargetMs(mutatorThresholdMs);
+      }
+    }
+
+    builder.setBulkOptions(bulkOptionsBuilder.build());
+  }
+
+  private void buildChannelOptions(BigtableOptions.Builder builder) {
+
+    String dataHostOverride = configuration.get(BIGTABLE_HOST_KEY);
+    if (!isNullOrEmpty(dataHostOverride)) {
+      LOG.debug("API Data endpoint host %s.", dataHostOverride);
+      builder.setDataHost(dataHostOverride);
+    }
+
+    String adminHostOverride = configuration.get(BIGTABLE_ADMIN_HOST_KEY);
+    if (!isNullOrEmpty(adminHostOverride)) {
+      LOG.debug("Admin endpoint host %s.", adminHostOverride);
+      builder.setAdminHost(adminHostOverride);
+    }
+
+    String portOverrideStr = configuration.get(BIGTABLE_PORT_KEY);
+    if (!isNullOrEmpty(portOverrideStr)) {
+      builder.setPort(Integer.parseInt(portOverrideStr));
+    }
+
+    String usePlaintextStr = configuration.get(BIGTABLE_USE_PLAINTEXT_NEGOTIATION);
+    if (!isNullOrEmpty(usePlaintextStr)) {
+      builder.setUsePlaintextNegotiation(Boolean.parseBoolean(usePlaintextStr));
+    }
+
+    String channelCountStr = configuration.get(BIGTABLE_DATA_CHANNEL_COUNT_KEY);
+    if (!isNullOrEmpty(channelCountStr)) {
+      builder.setDataChannelCount(Integer.parseInt(channelCountStr));
+    }
+
+    // This is primarily used by Dataflow where connections open and close often. This is a
+    // performance optimization that will reduce the cost to open connections.
+    String useCachedDataPoolStr = configuration.get(BIGTABLE_USE_CACHED_DATA_CHANNEL_POOL);
+    if (!isNullOrEmpty(useCachedDataPoolStr)) {
+      builder.setUseCachedDataPool(Boolean.parseBoolean(useCachedDataPoolStr));
+    }
+
+    // This information is in addition to bigtable-client-core version, and jdk version.
+    StringBuilder agentBuilder = new StringBuilder();
+    agentBuilder.append("hbase-").append(VersionInfo.getVersion());
+    String customUserAgent = configuration.get(CUSTOM_USER_AGENT_KEY);
+    if (customUserAgent != null) {
+      agentBuilder.append(',').append(customUserAgent);
+    }
+    builder.setUserAgent(agentBuilder.toString());
+  }
+
+  private void buildClientCallOptions(BigtableOptions.Builder OptionsBuilder) {
+    CallOptionsConfig.Builder callOptionsBuilder =
+        OptionsBuilder.getCallOptionsConfig().toBuilder();
+
+    String useTimeoutStr = configuration.get(BIGTABLE_USE_TIMEOUTS_KEY);
+    if (!isNullOrEmpty(useTimeoutStr)) {
+      callOptionsBuilder.setUseTimeout(Boolean.parseBoolean(useTimeoutStr));
+    }
+
+    String shortRpcTimeoutMs = configuration.get(BIGTABLE_RPC_TIMEOUT_MS_KEY);
+    if (!isNullOrEmpty(shortRpcTimeoutMs)) {
+      callOptionsBuilder.setShortRpcTimeoutMs(Integer.parseInt(shortRpcTimeoutMs));
+    }
+
+    String longTimeoutMs = configuration.get(BIGTABLE_LONG_RPC_TIMEOUT_MS_KEY);
+    if (!isNullOrEmpty(longTimeoutMs)) {
+      callOptionsBuilder.setLongRpcTimeoutMs(Integer.parseInt(longTimeoutMs));
+    }
+
+    String mutateRpcTimeoutMs = configuration.get(BIGTABLE_MUTATE_RPC_TIMEOUT_MS_KEY);
+    if (!isNullOrEmpty(mutateRpcTimeoutMs)) {
+      callOptionsBuilder.setMutateRpcTimeoutMs(Integer.parseInt(mutateRpcTimeoutMs));
+    }
+
+    String readRowsRpcTimeoutMs = configuration.get(BIGTABLE_READ_RPC_TIMEOUT_MS_KEY);
+    if (!isNullOrEmpty(readRowsRpcTimeoutMs)) {
+      callOptionsBuilder.setReadRowsRpcTimeoutMs(Integer.parseInt(readRowsRpcTimeoutMs));
+    }
+
+    OptionsBuilder.setCallOptionsConfig(callOptionsBuilder.build());
+  }
+
+  private void buildCredentialOptions(BigtableOptions.Builder builder)
+      throws FileNotFoundException {
+
+    // This preserves user defined Credentials
+    if (configuration instanceof BigtableExtendedConfiguration) {
+      Credentials credentials = ((BigtableExtendedConfiguration) configuration).getCredentials();
+      builder.setCredentialOptions(CredentialOptions.credential(credentials));
+
+    } else if (Boolean.parseBoolean(configuration.get(BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY))) {
+      builder.setCredentialOptions(CredentialOptions.nullCredential());
+      LOG.info("Enabling the use of null credentials. This should not be used in production.");
+
+    } else if (configuration.get(BIGTABLE_SERVICE_ACCOUNT_JSON_VALUE_KEY) != null) {
+      String jsonValue = configuration.get(BIGTABLE_SERVICE_ACCOUNT_JSON_VALUE_KEY);
+      LOG.debug("Using json value");
+      builder.setCredentialOptions(CredentialOptions.jsonCredentials(jsonValue));
+
+    } else if (configuration.get(BIGTABLE_SERVICE_ACCOUNT_JSON_KEYFILE_LOCATION_KEY) != null) {
+      String keyFileLocation =
+          configuration.get(BIGTABLE_SERVICE_ACCOUNT_JSON_KEYFILE_LOCATION_KEY);
+      LOG.debug("Using json keyfile: %s", keyFileLocation);
+      builder.setCredentialOptions(
+          CredentialOptions.jsonCredentials(new FileInputStream(keyFileLocation)));
+
+    } else if (configuration.get(BIGTABLE_SERVICE_ACCOUNT_EMAIL_KEY) != null) {
+      String serviceAccount = configuration.get(BIGTABLE_SERVICE_ACCOUNT_EMAIL_KEY);
+      LOG.debug("Service account %s specified.", serviceAccount);
+      String keyFileLocation = configuration.get(BIGTABLE_SERVICE_ACCOUNT_P12_KEYFILE_LOCATION_KEY);
+      Preconditions.checkState(
+          !isNullOrEmpty(keyFileLocation),
+          "Key file location must be specified when setting service account email");
+      LOG.debug("Using p12 keyfile: %s", keyFileLocation);
+      builder.setCredentialOptions(
+          CredentialOptions.p12Credential(serviceAccount, keyFileLocation));
+    }
+  }
+
+  private void buildRetryOptions(BigtableOptions.Builder builder) {
+    RetryOptions.Builder retryOptionsBuilder = builder.getRetryOptions().toBuilder();
+
+    String enableRetries = configuration.get(ENABLE_GRPC_RETRIES_KEY);
+    if (!isNullOrEmpty(enableRetries)) {
+      LOG.debug("gRPC retries enabled: %s", enableRetries);
+      retryOptionsBuilder.setEnableRetries(Boolean.parseBoolean(enableRetries));
+    }
+
+    String allowRetriesWithoutTimestamp = configuration.get(ALLOW_NO_TIMESTAMP_RETRIES_KEY);
+    if (!isNullOrEmpty(allowRetriesWithoutTimestamp)) {
+      LOG.debug("allow retries without timestamp: %s", allowRetriesWithoutTimestamp);
+      retryOptionsBuilder.setAllowRetriesWithoutTimestamp(
+          Boolean.parseBoolean(allowRetriesWithoutTimestamp));
+    }
+
+    String retryCodes = configuration.get(ADDITIONAL_RETRY_CODES, "");
+    String[] codes = retryCodes.split(",");
+    for (String stringCode : codes) {
+      String trimmed = stringCode.trim();
+      if (trimmed.isEmpty()) {
+        continue;
+      }
+      Status.Code code = Status.Code.valueOf(trimmed);
+      LOG.debug("gRPC retry on: %s", stringCode);
+      retryOptionsBuilder.addStatusToRetryOn(code);
+    }
+
+    String retryOnDeadlineExceeded = configuration.get(ENABLE_GRPC_RETRY_DEADLINEEXCEEDED_KEY);
+    if (!isNullOrEmpty(retryOnDeadlineExceeded)) {
+      LOG.debug("gRPC retry on deadline exceeded enabled: %s", retryOnDeadlineExceeded);
+      retryOptionsBuilder.setRetryOnDeadlineExceeded(Boolean.parseBoolean(retryOnDeadlineExceeded));
+    }
+
+    String initialElapsedBackoffMs = configuration.get(INITIAL_ELAPSED_BACKOFF_MILLIS_KEY);
+    if (!isNullOrEmpty(initialElapsedBackoffMs)) {
+      LOG.debug("gRPC retry initialElapsedBackoffMillis: %d", initialElapsedBackoffMs);
+      retryOptionsBuilder.setInitialBackoffMillis(Integer.parseInt(initialElapsedBackoffMs));
+    }
+
+    String maxElapsedBackoffMs = configuration.get(MAX_ELAPSED_BACKOFF_MILLIS_KEY);
+    if (!isNullOrEmpty(maxElapsedBackoffMs)) {
+      LOG.debug("gRPC retry maxElapsedBackoffMillis: %s", maxElapsedBackoffMs);
+      retryOptionsBuilder.setMaxElapsedBackoffMillis(Integer.parseInt(maxElapsedBackoffMs));
+    }
+
+    String readPartialRowTimeoutMs = configuration.get(READ_PARTIAL_ROW_TIMEOUT_MS);
+    if (!isNullOrEmpty(readPartialRowTimeoutMs)) {
+      LOG.debug("gRPC read partial row timeout (millis): %d", readPartialRowTimeoutMs);
+      retryOptionsBuilder.setReadPartialRowTimeoutMillis(Integer.parseInt(readPartialRowTimeoutMs));
+    }
+
+    // TODO: remove streamingBufferSize property, its not used anymore.
+    String streamingBufferSize = configuration.get(READ_BUFFER_SIZE);
+    if (!isNullOrEmpty(streamingBufferSize)) {
+      LOG.debug("gRPC read buffer size (count): %d", streamingBufferSize);
+      retryOptionsBuilder.setStreamingBufferSize(Integer.parseInt(streamingBufferSize));
+    }
+
+    String maxScanTimeoutRetries = configuration.get(MAX_SCAN_TIMEOUT_RETRIES);
+    if (!isNullOrEmpty(maxScanTimeoutRetries)) {
+      LOG.debug("gRPC max scan timeout retries (count): %d", maxScanTimeoutRetries);
+      retryOptionsBuilder.setMaxScanTimeoutRetries(Integer.parseInt(maxScanTimeoutRetries));
+    }
+
+    builder.setRetryOptions(retryOptionsBuilder.build());
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BigtableHBaseVeneerSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BigtableHBaseVeneerSettings.java
@@ -1,0 +1,580 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers.veneer;
+
+import static com.google.cloud.bigtable.data.v2.stub.EnhancedBigtableStubSettings.defaultGrpcTransportProviderBuilder;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.ADDITIONAL_RETRY_CODES;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.ALLOW_NO_TIMESTAMP_RETRIES_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.APP_PROFILE_ID_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_ADMIN_HOST_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BUFFERED_MUTATOR_MAX_MEMORY_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BULK_AUTOFLUSH_MS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BULK_MAX_REQUEST_SIZE_BYTES;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BULK_MAX_ROW_KEY_COUNT;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_DATA_CHANNEL_COUNT_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_HOST_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_PORT_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_READ_RPC_TIMEOUT_MS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_RPC_TIMEOUT_MS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_SERVICE_ACCOUNT_EMAIL_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_SERVICE_ACCOUNT_JSON_KEYFILE_LOCATION_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_SERVICE_ACCOUNT_JSON_VALUE_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_SERVICE_ACCOUNT_P12_KEYFILE_LOCATION_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_CACHED_DATA_CHANNEL_POOL;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_PLAINTEXT_NEGOTIATION;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_TIMEOUTS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.CUSTOM_USER_AGENT_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.ENABLE_GRPC_RETRIES_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.INITIAL_ELAPSED_BACKOFF_MILLIS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.MAX_ELAPSED_BACKOFF_MILLIS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.MAX_INFLIGHT_RPCS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.MAX_SCAN_TIMEOUT_RETRIES;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.READ_PARTIAL_ROW_TIMEOUT_MS;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static io.grpc.internal.GrpcUtil.USER_AGENT_KEY;
+import static org.threeten.bp.Duration.ofMillis;
+
+import com.google.api.client.util.SecurityUtils;
+import com.google.api.core.ApiFunction;
+import com.google.api.core.InternalApi;
+import com.google.api.gax.batching.BatchingSettings;
+import com.google.api.gax.batching.FlowControlSettings;
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.rpc.FixedHeaderProvider;
+import com.google.api.gax.rpc.HeaderProvider;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.api.gax.rpc.StubSettings;
+import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.api.gax.rpc.UnaryCallSettings;
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountJwtAccessCredentials;
+import com.google.cloud.bigtable.admin.v2.BigtableInstanceAdminSettings;
+import com.google.cloud.bigtable.admin.v2.BigtableTableAdminSettings;
+import com.google.cloud.bigtable.admin.v2.stub.BigtableInstanceAdminStubSettings;
+import com.google.cloud.bigtable.admin.v2.stub.BigtableTableAdminStubSettings;
+import com.google.cloud.bigtable.config.BigtableVersionInfo;
+import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
+import com.google.cloud.bigtable.data.v2.stub.EnhancedBigtableStubSettings;
+import com.google.cloud.bigtable.hbase.BigtableExtendedConfiguration;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+import io.grpc.ManagedChannelBuilder;
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.PrivateKey;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.util.VersionInfo;
+import org.threeten.bp.Duration;
+
+/** For internal use only - public for technical reasons. */
+@InternalApi("For internal usage only")
+public class BigtableHBaseVeneerSettings extends BigtableHBaseSettings {
+
+  // Identifier to distinguish between CBT or GCJ adapter.
+  private static final String VENEER_ADAPTER =
+      BigtableVersionInfo.CORE_USER_AGENT + "," + "veneer-adapter,";
+
+  // Keeping the original configuration, this could be an instance of BigtableExtendedConfiguration.
+  private final Configuration configuration;
+  private final BigtableDataSettings dataSettings;
+  private final BigtableTableAdminSettings tableAdminSettings;
+  @Nullable private final BigtableInstanceAdminSettings instanceAdminSettings;
+
+  public BigtableHBaseVeneerSettings(Configuration configuration) throws IOException {
+    super(configuration);
+    this.configuration = configuration;
+    this.dataSettings = buildBigtableDataSettings();
+    this.tableAdminSettings = buildBigtableTableAdminSettings();
+
+    if (!isNullOrEmpty(configuration.get(BIGTABLE_EMULATOR_HOST_KEY))) {
+      LOG.info("bigtable emulator does not support Instance Admin client.");
+      instanceAdminSettings = null;
+    } else {
+      instanceAdminSettings = buildBigtableInstanceAdminSettings();
+    }
+  }
+
+  @Override
+  public String getDataHost() {
+    String endpoint = dataSettings.getStubSettings().getEndpoint();
+    return endpoint.substring(0, endpoint.lastIndexOf(":"));
+  }
+
+  @Override
+  public String getAdminHost() {
+    String endpoint = tableAdminSettings.getStubSettings().getEndpoint();
+    return endpoint.substring(0, endpoint.lastIndexOf(":"));
+  }
+
+  @Override
+  public int getPort() {
+    String endpoint = dataSettings.getStubSettings().getEndpoint();
+    return Integer.parseInt(endpoint.substring(endpoint.lastIndexOf(":") + 1));
+  }
+
+  @Override
+  public int getBulkMaxRowCount() {
+    return dataSettings
+        .getStubSettings()
+        .bulkMutateRowsSettings()
+        .getBatchingSettings()
+        .getElementCountThreshold()
+        .intValue();
+  }
+
+  // ************** Getters **************
+  public boolean isChannelPoolCachingEnabled() {
+    // This is primarily used by Dataflow where connections open and close often. This is a
+    // performance optimization that will reduce the cost to open connections.
+    return configuration.getBoolean(BIGTABLE_USE_CACHED_DATA_CHANNEL_POOL, false);
+  }
+
+  /** Utility to convert {@link Configuration} to {@link BigtableDataSettings}. */
+  public BigtableDataSettings getDataSettings() {
+    return dataSettings;
+  }
+
+  /** Utility to convert {@link Configuration} to {@link BigtableTableAdminSettings}. */
+  public BigtableTableAdminSettings getTableAdminSettings() {
+    return tableAdminSettings;
+  }
+
+  /** Utility to convert {@link Configuration} to {@link BigtableInstanceAdminSettings}. */
+  @Nullable
+  public BigtableInstanceAdminSettings getInstanceAdminSettings() {
+    return instanceAdminSettings;
+  }
+
+  // ************** Private Helpers **************
+  private BigtableDataSettings buildBigtableDataSettings() throws IOException {
+    BigtableDataSettings.Builder dataBuilder =
+        BigtableDataSettings.newBuilder()
+            .setProjectId(getProjectId())
+            .setInstanceId(getInstanceId());
+
+    String appProfileId = configuration.get(APP_PROFILE_ID_KEY);
+    if (!isNullOrEmpty(appProfileId)) {
+      dataBuilder.setAppProfileId(appProfileId);
+    }
+
+    EnhancedBigtableStubSettings.Builder stubSettings = dataBuilder.stubSettings();
+
+    buildEndpoints(stubSettings, BIGTABLE_HOST_KEY);
+
+    buildHeaderProvider(stubSettings);
+
+    buildCredentialProvider(stubSettings);
+
+    // RPC methods
+    buildBulkMutationsSettings(stubSettings);
+
+    buildBulkReadRowsSettings(stubSettings);
+
+    buildReadRowsSettings(stubSettings);
+
+    buildNonIdempotentCallSettings(stubSettings.checkAndMutateRowSettings());
+    buildNonIdempotentCallSettings(stubSettings.readModifyWriteRowSettings());
+
+    buildIdempotentCallSettings(stubSettings.readRowSettings());
+    buildIdempotentCallSettings(stubSettings.mutateRowSettings());
+    buildIdempotentCallSettings(stubSettings.sampleRowKeysSettings());
+
+    buildEmulatorSettings(stubSettings);
+
+    return dataBuilder.build();
+  }
+
+  private BigtableTableAdminSettings buildBigtableTableAdminSettings() throws IOException {
+    BigtableTableAdminSettings.Builder adminBuilder =
+        BigtableTableAdminSettings.newBuilder()
+            .setProjectId(getProjectId())
+            .setInstanceId(getInstanceId());
+
+    BigtableTableAdminStubSettings.Builder stubSettings = adminBuilder.stubSettings();
+
+    buildEndpoints(stubSettings, BIGTABLE_ADMIN_HOST_KEY);
+
+    buildHeaderProvider(stubSettings);
+
+    buildCredentialProvider(stubSettings);
+
+    buildEmulatorSettings(stubSettings);
+
+    return adminBuilder.build();
+  }
+
+  private BigtableInstanceAdminSettings buildBigtableInstanceAdminSettings() throws IOException {
+    BigtableInstanceAdminSettings.Builder instanceAdminBuilder =
+        BigtableInstanceAdminSettings.newBuilder().setProjectId(getProjectId());
+
+    BigtableInstanceAdminStubSettings.Builder stubSettings = instanceAdminBuilder.stubSettings();
+
+    buildEndpoints(stubSettings, BIGTABLE_ADMIN_HOST_KEY);
+
+    buildHeaderProvider(stubSettings);
+
+    buildCredentialProvider(stubSettings);
+
+    return instanceAdminBuilder.build();
+  }
+
+  private void buildEndpoints(StubSettings.Builder stubSettings, String endpointKey) {
+    String adminHostOverride = configuration.get(endpointKey);
+    if (!isNullOrEmpty(adminHostOverride)) {
+
+      String port = configuration.get(BIGTABLE_PORT_KEY);
+      if (isNullOrEmpty(port)) {
+        String endpoint = stubSettings.getEndpoint();
+        port = endpoint.substring(endpoint.lastIndexOf(":") + 1);
+      }
+
+      String finalEndpoint = adminHostOverride + ":" + port;
+      LOG.debug("%s is configured at %s", endpointKey, finalEndpoint);
+      stubSettings.setEndpoint(finalEndpoint);
+    }
+
+    if (Boolean.parseBoolean(configuration.get(BIGTABLE_USE_PLAINTEXT_NEGOTIATION))) {
+      stubSettings.setTransportChannelProvider(
+          buildPlainTextChannelProvider(stubSettings.getEndpoint()));
+    }
+  }
+
+  /** Creates {@link HeaderProvider} with VENEER_ADAPTER as prefix for user agent */
+  private void buildHeaderProvider(StubSettings.Builder stubSettings) {
+
+    // This information is in addition to bigtable-client-core version, and jdk version.
+    StringBuilder agentBuilder = new StringBuilder();
+    agentBuilder.append("hbase-").append(VersionInfo.getVersion());
+    String customUserAgent = configuration.get(CUSTOM_USER_AGENT_KEY);
+    if (customUserAgent != null) {
+      agentBuilder.append(',').append(customUserAgent);
+    }
+
+    stubSettings.setHeaderProvider(
+        FixedHeaderProvider.create(
+            USER_AGENT_KEY.name(), VENEER_ADAPTER + agentBuilder.toString()));
+  }
+
+  private void buildCredentialProvider(StubSettings.Builder stubSettings) throws IOException {
+    Credentials credentials = null;
+
+    if (configuration instanceof BigtableExtendedConfiguration) {
+      credentials = ((BigtableExtendedConfiguration) configuration).getCredentials();
+
+    } else if (Boolean.parseBoolean(configuration.get(BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY))) {
+      stubSettings.setCredentialsProvider(NoCredentialsProvider.create());
+      LOG.info("Enabling the use of null credentials. This should not be used in production.");
+
+    } else if (!isNullOrEmpty(configuration.get(BIGTABLE_SERVICE_ACCOUNT_JSON_VALUE_KEY))) {
+      String jsonValue = configuration.get(BIGTABLE_SERVICE_ACCOUNT_JSON_VALUE_KEY);
+      LOG.debug("Using json value");
+      Preconditions.checkState(
+          !isNullOrEmpty(jsonValue), "service account json value is null or empty");
+      credentials =
+          GoogleCredentials.fromStream(
+              new ByteArrayInputStream(jsonValue.getBytes(StandardCharsets.UTF_8)));
+
+    } else if (!isNullOrEmpty(
+        configuration.get(BIGTABLE_SERVICE_ACCOUNT_JSON_KEYFILE_LOCATION_KEY))) {
+      String keyFileLocation =
+          configuration.get(BIGTABLE_SERVICE_ACCOUNT_JSON_KEYFILE_LOCATION_KEY);
+      LOG.debug("Using json keyfile: %s", keyFileLocation);
+      Preconditions.checkState(
+          !isNullOrEmpty(keyFileLocation), "service account location is null or empty");
+      credentials = GoogleCredentials.fromStream(new FileInputStream(keyFileLocation));
+
+    } else if (!isNullOrEmpty(configuration.get(BIGTABLE_SERVICE_ACCOUNT_EMAIL_KEY))) {
+
+      String serviceAccount = configuration.get(BIGTABLE_SERVICE_ACCOUNT_EMAIL_KEY);
+      LOG.debug("Service account %s specified.", serviceAccount);
+      String keyFileLocation = configuration.get(BIGTABLE_SERVICE_ACCOUNT_P12_KEYFILE_LOCATION_KEY);
+      Preconditions.checkState(
+          !isNullOrEmpty(keyFileLocation),
+          "Key file location must be specified when setting service account email");
+      LOG.debug("Using p12 keyfile: %s", keyFileLocation);
+
+      credentials = getCredentialFromPrivateKeyServiceAccount(serviceAccount, keyFileLocation);
+    }
+
+    if (credentials != null) {
+      stubSettings.setCredentialsProvider(FixedCredentialsProvider.create(credentials));
+    }
+  }
+
+  // copied over from CredentialFactory
+  // TODO: Find a better way to convert P12 key into Credentials instance
+  private Credentials getCredentialFromPrivateKeyServiceAccount(
+      String serviceAccountEmail, String privateKeyFile) throws IOException {
+    try {
+      PrivateKey privateKey =
+          SecurityUtils.loadPrivateKeyFromKeyStore(
+              SecurityUtils.getPkcs12KeyStore(),
+              new FileInputStream(privateKeyFile),
+              "notasecret",
+              "privatekey",
+              "notasecret");
+
+      return ServiceAccountJwtAccessCredentials.newBuilder()
+          .setClientEmail(serviceAccountEmail)
+          .setPrivateKey(privateKey)
+          .build();
+    } catch (GeneralSecurityException exception) {
+      throw new RuntimeException("exception while retrieving credentials", exception);
+    }
+  }
+
+  /** Creates {@link TransportChannelProvider} for plaintext negotiation type. */
+  private TransportChannelProvider buildPlainTextChannelProvider(String endpoint) {
+
+    InstantiatingGrpcChannelProvider.Builder channelBuilder =
+        defaultGrpcTransportProviderBuilder()
+            .setEndpoint(endpoint)
+            .setChannelConfigurator(
+                new ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder>() {
+                  @Override
+                  public ManagedChannelBuilder apply(ManagedChannelBuilder channelBuilder) {
+                    return channelBuilder.usePlaintext();
+                  }
+                });
+
+    String channelCount = configuration.get(BIGTABLE_DATA_CHANNEL_COUNT_KEY);
+    if (!isNullOrEmpty(channelCount)) {
+      channelBuilder.setPoolSize(Integer.parseInt(channelCount));
+    }
+
+    return channelBuilder.build();
+  }
+
+  private Set<StatusCode.Code> extractRetryCodesFromConfig() {
+    ImmutableSet.Builder<StatusCode.Code> statusCodeBuilder = ImmutableSet.builder();
+    String retryCodes = configuration.get(ADDITIONAL_RETRY_CODES, "");
+
+    for (String stringCode : retryCodes.split(",")) {
+      String trimmed = stringCode.trim();
+      if (trimmed.isEmpty()) {
+        continue;
+      }
+
+      StatusCode.Code code = StatusCode.Code.valueOf(trimmed);
+      Preconditions.checkNotNull(code, String.format("Unknown status code %s found", stringCode));
+      statusCodeBuilder.add(code);
+      LOG.debug("gRPC retry on: %s", stringCode);
+    }
+    return statusCodeBuilder.build();
+  }
+
+  private <Request, Response> void buildIdempotentCallSettings(
+      UnaryCallSettings.Builder<Request, Response> unaryCallSettings) {
+
+    ImmutableSet.Builder<StatusCode.Code> retryCodeBuilder = ImmutableSet.builder();
+    if (configuration.getBoolean(ENABLE_GRPC_RETRIES_KEY, true)) {
+      retryCodeBuilder
+          .addAll(extractRetryCodesFromConfig())
+          .addAll(unaryCallSettings.getRetryableCodes());
+    }
+
+    unaryCallSettings
+        .setRetryableCodes(retryCodeBuilder.build())
+        .setRetrySettings(buildIdempotentRetrySettings(unaryCallSettings.getRetrySettings()));
+  }
+
+  private void buildNonIdempotentCallSettings(UnaryCallSettings.Builder unaryCallSettings) {
+    String shortRpcTimeoutStr = configuration.get(BIGTABLE_RPC_TIMEOUT_MS_KEY);
+    if (!isNullOrEmpty(shortRpcTimeoutStr)) {
+      unaryCallSettings.setSimpleTimeoutNoRetries(ofMillis(Long.parseLong(shortRpcTimeoutStr)));
+    }
+  }
+
+  /** Creates {@link RetrySettings} for non-streaming VENEER_ADAPTER method. */
+  private RetrySettings buildIdempotentRetrySettings(RetrySettings originalRetrySettings) {
+    RetrySettings.Builder retryBuilder = originalRetrySettings.toBuilder();
+
+    if (configuration.getBoolean(ALLOW_NO_TIMESTAMP_RETRIES_KEY, false)) {
+      throw new UnsupportedOperationException("Retries without Timestamp is not supported yet.");
+    }
+
+    String initialElapsedBackoffMsStr = configuration.get(INITIAL_ELAPSED_BACKOFF_MILLIS_KEY);
+    if (!isNullOrEmpty(initialElapsedBackoffMsStr)) {
+      retryBuilder.setInitialRetryDelay(ofMillis(Long.parseLong(initialElapsedBackoffMsStr)));
+    }
+
+    if (Boolean.parseBoolean(configuration.get(BIGTABLE_USE_TIMEOUTS_KEY))) {
+      String shortRpcTimeoutMsStr = configuration.get(BIGTABLE_RPC_TIMEOUT_MS_KEY);
+
+      if (!isNullOrEmpty(shortRpcTimeoutMsStr)) {
+        Duration rpcTimeoutMs = ofMillis(Long.valueOf(shortRpcTimeoutMsStr));
+        retryBuilder.setInitialRpcTimeout(rpcTimeoutMs).setMaxRpcTimeout(rpcTimeoutMs);
+      }
+    }
+
+    String maxElapsedBackoffMillis = configuration.get(MAX_ELAPSED_BACKOFF_MILLIS_KEY);
+    if (!isNullOrEmpty(maxElapsedBackoffMillis)) {
+      retryBuilder.setTotalTimeout(ofMillis(Long.valueOf(maxElapsedBackoffMillis)));
+    }
+
+    return retryBuilder.build();
+  }
+
+  private void buildBulkMutationsSettings(EnhancedBigtableStubSettings.Builder builder) {
+    BatchingSettings.Builder batchMutateBuilder =
+        builder.bulkMutateRowsSettings().getBatchingSettings().toBuilder();
+
+    String autoFlushStr = configuration.get(BIGTABLE_BULK_AUTOFLUSH_MS_KEY);
+    if (!isNullOrEmpty(autoFlushStr)) {
+      long autoFlushMs = Long.parseLong(autoFlushStr);
+      if (autoFlushMs > 0) {
+        batchMutateBuilder.setDelayThreshold(ofMillis(autoFlushMs));
+      }
+    }
+
+    String bulkMaxRowKeyCountStr = configuration.get(BIGTABLE_BULK_MAX_ROW_KEY_COUNT);
+    if (!isNullOrEmpty(bulkMaxRowKeyCountStr)) {
+      batchMutateBuilder.setElementCountThreshold(Long.parseLong(bulkMaxRowKeyCountStr));
+    }
+
+    long bulkMaxRowKeyCount = batchMutateBuilder.build().getElementCountThreshold();
+
+    String maxInflightRpcStr = configuration.get(MAX_INFLIGHT_RPCS_KEY);
+    if (!isNullOrEmpty(maxInflightRpcStr) && Integer.parseInt(maxInflightRpcStr) > 0) {
+
+      int maxInflightRpcCount = Integer.parseInt(maxInflightRpcStr);
+      FlowControlSettings.Builder flowControlBuilder =
+          FlowControlSettings.newBuilder()
+              // TODO: verify if it should be channelCount instead of maxRowKeyCount
+              .setMaxOutstandingElementCount(maxInflightRpcCount * bulkMaxRowKeyCount);
+
+      String maxMemory = configuration.get(BIGTABLE_BUFFERED_MUTATOR_MAX_MEMORY_KEY);
+      if (!isNullOrEmpty(maxMemory)) {
+        flowControlBuilder.setMaxOutstandingRequestBytes(Long.valueOf(maxMemory));
+      }
+
+      batchMutateBuilder.setFlowControlSettings(flowControlBuilder.build());
+    }
+
+    String requestByteThresholdStr = configuration.get(BIGTABLE_BULK_MAX_REQUEST_SIZE_BYTES);
+    if (!isNullOrEmpty(requestByteThresholdStr)) {
+      batchMutateBuilder.setRequestByteThreshold(Long.valueOf(requestByteThresholdStr));
+    }
+
+    ImmutableSet.Builder<StatusCode.Code> retryCodes = ImmutableSet.builder();
+    if (configuration.getBoolean(ENABLE_GRPC_RETRIES_KEY, true)) {
+      retryCodes
+          .addAll(extractRetryCodesFromConfig())
+          .addAll(builder.bulkMutateRowsSettings().getRetryableCodes());
+    }
+
+    builder
+        .bulkMutateRowsSettings()
+        .setBatchingSettings(batchMutateBuilder.build())
+        .setRetryableCodes(retryCodes.build())
+        .setRetrySettings(
+            buildIdempotentRetrySettings(builder.bulkMutateRowsSettings().getRetrySettings()));
+  }
+
+  private void buildBulkReadRowsSettings(EnhancedBigtableStubSettings.Builder builder) {
+    BatchingSettings.Builder bulkReadBatchingBuilder =
+        builder.bulkReadRowsSettings().getBatchingSettings().toBuilder();
+
+    String bulkMaxRowKeyCountStr = configuration.get(BIGTABLE_BULK_MAX_ROW_KEY_COUNT);
+    if (!isNullOrEmpty(bulkMaxRowKeyCountStr)) {
+      bulkReadBatchingBuilder.setElementCountThreshold(Long.valueOf(bulkMaxRowKeyCountStr));
+    }
+
+    ImmutableSet.Builder<StatusCode.Code> retryCodes = ImmutableSet.builder();
+    if (configuration.getBoolean(ENABLE_GRPC_RETRIES_KEY, true)) {
+      retryCodes
+          .addAll(extractRetryCodesFromConfig())
+          .addAll(builder.bulkReadRowsSettings().getRetryableCodes());
+    }
+
+    builder
+        .bulkReadRowsSettings()
+        .setBatchingSettings(bulkReadBatchingBuilder.build())
+        .setRetryableCodes(retryCodes.build())
+        .setRetrySettings(
+            buildIdempotentRetrySettings(builder.bulkReadRowsSettings().getRetrySettings()));
+  }
+
+  private void buildReadRowsSettings(EnhancedBigtableStubSettings.Builder stubSettings) {
+    RetrySettings.Builder retryBuilder =
+        stubSettings.readRowsSettings().getRetrySettings().toBuilder();
+
+    String initialElapsedBackoffMsStr = configuration.get(INITIAL_ELAPSED_BACKOFF_MILLIS_KEY);
+    if (!isNullOrEmpty(initialElapsedBackoffMsStr)) {
+      retryBuilder.setInitialRetryDelay(ofMillis(Long.valueOf(initialElapsedBackoffMsStr)));
+    }
+
+    String maxScanTimeoutRetriesAttempts = configuration.get(MAX_SCAN_TIMEOUT_RETRIES);
+    if (!isNullOrEmpty(maxScanTimeoutRetriesAttempts)) {
+      LOG.debug("gRPC max scan timeout retries (count): %d", maxScanTimeoutRetriesAttempts);
+      retryBuilder.setMaxAttempts(Integer.valueOf(maxScanTimeoutRetriesAttempts));
+    }
+
+    String rpcTimeoutStr = configuration.get(READ_PARTIAL_ROW_TIMEOUT_MS);
+    if (!isNullOrEmpty(rpcTimeoutStr)) {
+      Duration rpcTimeoutMs = ofMillis(Long.valueOf(rpcTimeoutStr));
+      retryBuilder.setInitialRpcTimeout(rpcTimeoutMs).setMaxRpcTimeout(rpcTimeoutMs);
+    }
+
+    if (Boolean.parseBoolean(configuration.get(BIGTABLE_USE_TIMEOUTS_KEY))) {
+      String readRowsRpcTimeoutMs = configuration.get(BIGTABLE_READ_RPC_TIMEOUT_MS_KEY);
+
+      if (!isNullOrEmpty(readRowsRpcTimeoutMs)) {
+        retryBuilder.setTotalTimeout(ofMillis(Long.valueOf(readRowsRpcTimeoutMs)));
+      }
+    } else {
+
+      String maxElapsedBackoffMillis = configuration.get(MAX_ELAPSED_BACKOFF_MILLIS_KEY);
+      if (!isNullOrEmpty(maxElapsedBackoffMillis)) {
+        retryBuilder.setTotalTimeout(ofMillis(Long.valueOf(maxElapsedBackoffMillis)));
+      }
+    }
+
+    ImmutableSet.Builder<StatusCode.Code> retryCodes = ImmutableSet.builder();
+    if (configuration.getBoolean(ENABLE_GRPC_RETRIES_KEY, true)) {
+      retryCodes
+          .addAll(extractRetryCodesFromConfig())
+          .addAll(stubSettings.readRowsSettings().getRetryableCodes());
+    }
+
+    stubSettings
+        .readRowsSettings()
+        .setRetryableCodes(retryCodes.build())
+        .setRetrySettings(retryBuilder.build());
+  }
+
+  private void buildEmulatorSettings(StubSettings.Builder stubSettings) {
+    String emulatorHostPort = configuration.get(BIGTABLE_EMULATOR_HOST_KEY);
+    if (!isNullOrEmpty(emulatorHostPort)) {
+      stubSettings
+          .setCredentialsProvider(NoCredentialsProvider.create())
+          .setEndpoint(emulatorHostPort)
+          .setTransportChannelProvider(buildPlainTextChannelProvider(emulatorHostPort));
+    }
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BigtableHBaseVeneerSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BigtableHBaseVeneerSettings.java
@@ -105,6 +105,7 @@ public class BigtableHBaseVeneerSettings extends BigtableHBaseSettings {
   private final String adminHost;
   private final int port;
   private final int bulkMaxRowKeyCount;
+  private final long batchingMaxMemory;
   private final boolean isChannelPoolCachingEnabled;
 
   public BigtableHBaseVeneerSettings(Configuration configuration) throws IOException {
@@ -137,6 +138,14 @@ public class BigtableHBaseVeneerSettings extends BigtableHBaseSettings {
             .getElementCountThreshold()
             .intValue();
 
+    this.batchingMaxMemory =
+        dataSettings
+            .getStubSettings()
+            .bulkMutateRowsSettings()
+            .getBatchingSettings()
+            .getFlowControlSettings()
+            .getMaxOutstandingRequestBytes();
+
     // This is primarily used by Dataflow where connections open and close often. This is a
     // performance optimization that will reduce the cost to open connections.
     this.isChannelPoolCachingEnabled =
@@ -161,6 +170,11 @@ public class BigtableHBaseVeneerSettings extends BigtableHBaseSettings {
   @Override
   public int getBulkMaxRowCount() {
     return bulkMaxRowKeyCount;
+  }
+
+  @Override
+  public long getBatchingMaxRequestSize() {
+    return batchingMaxMemory;
   }
 
   // ************** Getters **************

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBigtableHBaseClassicSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBigtableHBaseClassicSettings.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.hbase.wrappers.classic;
 
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BUFFERED_MUTATOR_MAX_MEMORY_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -111,6 +112,7 @@ public class TestBigtableHBaseClassicSettings {
     configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_USE_SERVICE_ACCOUNTS_KEY, false);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, true);
+    configuration.setLong(BIGTABLE_BUFFERED_MUTATOR_MAX_MEMORY_KEY, 100_000L);
 
     BigtableOptions options =
         ((BigtableHBaseClassicSettings) BigtableHBaseSettings.create(configuration))
@@ -119,6 +121,7 @@ public class TestBigtableHBaseClassicSettings {
     assertEquals(TEST_HOST, options.getDataHost());
     assertEquals(TEST_PROJECT_ID, options.getProjectId());
     assertEquals(TEST_INSTANCE_ID, options.getInstanceId());
+    assertEquals(100_000L, options.getBulkOptions().getMaxMemory());
   }
 
   @Test

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBigtableHBaseClassicSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBigtableHBaseClassicSettings.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers.classic;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.auth.Credentials;
+import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.config.CredentialFactory;
+import com.google.cloud.bigtable.config.RetryOptions;
+import com.google.cloud.bigtable.hbase.BigtableConfiguration;
+import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+@RunWith(JUnit4.class)
+public class TestBigtableHBaseClassicSettings {
+
+  private static final String TEST_HOST = "localhost";
+  private static final String TEST_PROJECT_ID = "project-foo";
+  private static final String TEST_INSTANCE_ID = "test-instance";
+
+  private Configuration configuration;
+
+  @Before
+  public void setup() {
+    configuration = new Configuration(false);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
+    configuration.set(BigtableOptionsFactory.PROJECT_ID_KEY, TEST_PROJECT_ID);
+    configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, TEST_INSTANCE_ID);
+  }
+
+  @Test
+  public void testProjectIdIsRequired() {
+    Configuration configuration = new Configuration(false);
+    configuration.unset(BigtableOptionsFactory.PROJECT_ID_KEY);
+
+    try {
+      BigtableHBaseSettings.create(configuration);
+    } catch (IllegalArgumentException | IOException ex) {
+      assertEquals("Project ID must be supplied via google.bigtable.project.id", ex.getMessage());
+    }
+  }
+
+  @Test
+  public void testHostIsRequired() {
+    Configuration configuration = new Configuration(false);
+    configuration.unset(BigtableOptionsFactory.BIGTABLE_HOST_KEY);
+
+    try {
+      BigtableHBaseSettings.create(configuration);
+    } catch (IllegalArgumentException | IOException ex) {
+      assertEquals("Project ID must be supplied via google.bigtable.project.id", ex.getMessage());
+    }
+  }
+
+  @Test
+  public void testInstanceIsRequired() {
+    Configuration configuration = new Configuration(false);
+    configuration.unset(BigtableOptionsFactory.INSTANCE_ID_KEY);
+
+    try {
+      BigtableHBaseSettings.create(configuration);
+    } catch (IllegalArgumentException | IOException ex) {
+      assertEquals("Project ID must be supplied via google.bigtable.project.id", ex.getMessage());
+    }
+  }
+
+  @Test
+  public void testConnectionKeysAreUsed() throws IOException {
+    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, "data-host");
+    configuration.set(BigtableOptionsFactory.BIGTABLE_ADMIN_HOST_KEY, "admin-host");
+    configuration.setInt(BigtableOptionsFactory.BIGTABLE_PORT_KEY, 1234);
+    configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_USE_PLAINTEXT_NEGOTIATION, true);
+    BigtableOptions options =
+        ((BigtableHBaseClassicSettings) BigtableHBaseSettings.create(configuration))
+            .getBigtableOptions();
+
+    assertEquals("data-host", options.getDataHost());
+    assertEquals("admin-host", options.getAdminHost());
+    assertEquals(1234, options.getPort());
+    assertTrue(
+        "BIGTABLE_USE_PLAINTEXT_NEGOTIATION was not propagated", options.usePlaintextNegotiation());
+  }
+
+  @Test
+  public void testOptionsAreConstructedWithValidInput() throws IOException {
+    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
+    configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_USE_SERVICE_ACCOUNTS_KEY, false);
+    configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, true);
+
+    BigtableOptions options =
+        ((BigtableHBaseClassicSettings) BigtableHBaseSettings.create(configuration))
+            .getBigtableOptions();
+
+    assertEquals(TEST_HOST, options.getDataHost());
+    assertEquals(TEST_PROJECT_ID, options.getProjectId());
+    assertEquals(TEST_INSTANCE_ID, options.getInstanceId());
+  }
+
+  @Test
+  public void testDefaultRetryOptions() throws IOException {
+    BigtableOptions options =
+        ((BigtableHBaseClassicSettings) BigtableHBaseSettings.create(configuration))
+            .getBigtableOptions();
+    RetryOptions retryOptions = options.getRetryOptions();
+
+    assertEquals(RetryOptions.DEFAULT_ENABLE_GRPC_RETRIES, retryOptions.enableRetries());
+    assertEquals(
+        RetryOptions.DEFAULT_MAX_ELAPSED_BACKOFF_MILLIS, retryOptions.getMaxElapsedBackoffMillis());
+    assertEquals(
+        RetryOptions.DEFAULT_READ_PARTIAL_ROW_TIMEOUT_MS,
+        retryOptions.getReadPartialRowTimeoutMillis());
+    assertEquals(
+        RetryOptions.DEFAULT_MAX_SCAN_TIMEOUT_RETRIES, retryOptions.getMaxScanTimeoutRetries());
+  }
+
+  @Test
+  public void testSettingRetryOptions() throws IOException {
+    configuration.set(BigtableOptionsFactory.ENABLE_GRPC_RETRIES_KEY, "false");
+    configuration.set(BigtableOptionsFactory.ENABLE_GRPC_RETRY_DEADLINEEXCEEDED_KEY, "false");
+    configuration.set(BigtableOptionsFactory.MAX_ELAPSED_BACKOFF_MILLIS_KEY, "111");
+    configuration.set(BigtableOptionsFactory.READ_PARTIAL_ROW_TIMEOUT_MS, "123");
+
+    BigtableOptions options =
+        ((BigtableHBaseClassicSettings) BigtableHBaseSettings.create(configuration))
+            .getBigtableOptions();
+    RetryOptions retryOptions = options.getRetryOptions();
+
+    assertFalse(retryOptions.enableRetries());
+    assertFalse(retryOptions.retryOnDeadlineExceeded());
+    assertEquals(111, retryOptions.getMaxElapsedBackoffMillis());
+    assertEquals(123, retryOptions.getReadPartialRowTimeoutMillis());
+  }
+
+  @Test
+  public void testExplicitCredentials() throws IOException, GeneralSecurityException {
+    Credentials credentials = Mockito.mock(Credentials.class);
+    configuration = new Configuration(false);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
+    configuration.set(BigtableOptionsFactory.PROJECT_ID_KEY, TEST_PROJECT_ID);
+    configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, TEST_INSTANCE_ID);
+    configuration = BigtableConfiguration.withCredentials(configuration, credentials);
+
+    BigtableOptions options =
+        ((BigtableHBaseClassicSettings) BigtableHBaseSettings.create(configuration))
+            .getBigtableOptions();
+    Credentials actualCreds = CredentialFactory.getCredentials(options.getCredentialOptions());
+
+    Assert.assertSame(credentials, actualCreds);
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBigtableHBaseVeneerSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBigtableHBaseVeneerSettings.java
@@ -1,0 +1,395 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers.veneer;
+
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.ADDITIONAL_RETRY_CODES;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.ALLOW_NO_TIMESTAMP_RETRIES_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.APP_PROFILE_ID_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_ADMIN_HOST_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BUFFERED_MUTATOR_MAX_MEMORY_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BULK_AUTOFLUSH_MS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BULK_MAX_REQUEST_SIZE_BYTES;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BULK_MAX_ROW_KEY_COUNT;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_DATA_CHANNEL_COUNT_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_PORT_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_READ_RPC_TIMEOUT_MS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_RPC_TIMEOUT_MS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_CACHED_DATA_CHANNEL_POOL;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_PLAINTEXT_NEGOTIATION;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_SERVICE_ACCOUNTS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_TIMEOUTS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.CUSTOM_USER_AGENT_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.ENABLE_GRPC_RETRIES_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.INITIAL_ELAPSED_BACKOFF_MILLIS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.MAX_ELAPSED_BACKOFF_MILLIS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.MAX_INFLIGHT_RPCS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.MAX_SCAN_TIMEOUT_RETRIES;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.READ_PARTIAL_ROW_TIMEOUT_MS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.threeten.bp.Duration.ofMillis;
+
+import com.google.api.gax.batching.BatchingSettings;
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.auth.Credentials;
+import com.google.cloud.bigtable.admin.v2.BigtableInstanceAdminSettings;
+import com.google.cloud.bigtable.admin.v2.BigtableTableAdminSettings;
+import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
+import com.google.cloud.bigtable.hbase.BigtableConfiguration;
+import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
+import io.grpc.internal.GrpcUtil;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+@RunWith(JUnit4.class)
+public class TestBigtableHBaseVeneerSettings {
+
+  private static final String TEST_HOST = "localhost";
+  private static final int TEST_PORT = 80;
+  private static final String TEST_PROJECT_ID = "project-foo";
+  private static final String TEST_INSTANCE_ID = "test-instance";
+
+  private Configuration configuration;
+
+  @Before
+  public void setup() {
+    configuration = new Configuration(false);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
+    configuration.set(BIGTABLE_ADMIN_HOST_KEY, TEST_HOST);
+    configuration.set(BigtableOptionsFactory.PROJECT_ID_KEY, TEST_PROJECT_ID);
+    configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, TEST_INSTANCE_ID);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_USE_GCJ_CLIENT, "true");
+  }
+
+  @Test
+  public void testDataSettingsBasicKeys() throws IOException {
+    String appProfileId = "appProfileId";
+    String userAgent = "test-user-agent";
+    Credentials credentials = Mockito.mock(Credentials.class);
+
+    configuration.set(BIGTABLE_PORT_KEY, String.valueOf(TEST_PORT));
+    configuration.set(APP_PROFILE_ID_KEY, appProfileId);
+    configuration.setBoolean(BIGTABLE_USE_PLAINTEXT_NEGOTIATION, true);
+    configuration.set(CUSTOM_USER_AGENT_KEY, userAgent);
+    configuration.setInt(BIGTABLE_DATA_CHANNEL_COUNT_KEY, 3);
+    configuration.set(BIGTABLE_USE_CACHED_DATA_CHANNEL_POOL, "true");
+    configuration.set(BIGTABLE_USE_SERVICE_ACCOUNTS_KEY, "true");
+    configuration = BigtableConfiguration.withCredentials(configuration, credentials);
+
+    BigtableHBaseVeneerSettings settingUtils =
+        (BigtableHBaseVeneerSettings) BigtableHBaseSettings.create(configuration);
+
+    BigtableDataSettings dataSettings = settingUtils.getDataSettings();
+    assertEquals(TEST_PROJECT_ID, dataSettings.getProjectId());
+    assertEquals(TEST_INSTANCE_ID, dataSettings.getInstanceId());
+    assertEquals(appProfileId, dataSettings.getAppProfileId());
+
+    assertEquals(TEST_HOST, settingUtils.getDataHost());
+    assertEquals(TEST_PORT, settingUtils.getPort());
+    assertEquals(TEST_HOST, settingUtils.getAdminHost());
+
+    assertEquals(TEST_HOST + ":" + TEST_PORT, dataSettings.getStubSettings().getEndpoint());
+    Map<String, String> headers = dataSettings.getStubSettings().getHeaderProvider().getHeaders();
+    assertTrue(headers.get(GrpcUtil.USER_AGENT_KEY.name()).contains(userAgent));
+    assertEquals(
+        credentials, dataSettings.getStubSettings().getCredentialsProvider().getCredentials());
+
+    assertTrue(settingUtils.isChannelPoolCachingEnabled());
+  }
+
+  @Test
+  public void testAdminSettingsBasicKeys() throws IOException {
+    String adminHost = "testadmin.example.com";
+    String userAgent = "test-user-agent";
+    Credentials credentials = Mockito.mock(Credentials.class);
+
+    configuration.set(BIGTABLE_ADMIN_HOST_KEY, adminHost);
+    configuration.setInt(BIGTABLE_PORT_KEY, TEST_PORT);
+    configuration.set(CUSTOM_USER_AGENT_KEY, userAgent);
+    configuration.setBoolean(BIGTABLE_USE_PLAINTEXT_NEGOTIATION, true);
+    configuration.set(BIGTABLE_USE_SERVICE_ACCOUNTS_KEY, "true");
+    configuration = BigtableConfiguration.withCredentials(configuration, credentials);
+
+    BigtableHBaseVeneerSettings settings =
+        (BigtableHBaseVeneerSettings) BigtableHBaseSettings.create(configuration);
+    BigtableTableAdminSettings adminSettings = settings.getTableAdminSettings();
+    assertEquals(TEST_PROJECT_ID, adminSettings.getProjectId());
+    assertEquals(TEST_INSTANCE_ID, adminSettings.getInstanceId());
+
+    assertEquals(adminHost + ":" + TEST_PORT, adminSettings.getStubSettings().getEndpoint());
+    Map<String, String> headers = adminSettings.getStubSettings().getHeaderProvider().getHeaders();
+    assertTrue(headers.get(GrpcUtil.USER_AGENT_KEY.name()).contains(userAgent));
+    assertEquals(
+        credentials, adminSettings.getStubSettings().getCredentialsProvider().getCredentials());
+  }
+
+  @Test
+  public void testInstanceAdminSettingsBasicKeys() throws IOException {
+    String userAgent = "test-user-agent";
+    Credentials credentials = Mockito.mock(Credentials.class);
+
+    configuration.set(CUSTOM_USER_AGENT_KEY, userAgent);
+    configuration.set(BIGTABLE_USE_SERVICE_ACCOUNTS_KEY, "true");
+    configuration = BigtableConfiguration.withCredentials(configuration, credentials);
+
+    BigtableHBaseVeneerSettings settings =
+        (BigtableHBaseVeneerSettings) BigtableHBaseSettings.create(configuration);
+    BigtableInstanceAdminSettings instanceAdminSettings = settings.getInstanceAdminSettings();
+    assertEquals(TEST_PROJECT_ID, instanceAdminSettings.getProjectId());
+
+    Map<String, String> headers =
+        instanceAdminSettings.getStubSettings().getHeaderProvider().getHeaders();
+    assertTrue(headers.get(GrpcUtil.USER_AGENT_KEY.name()).contains(userAgent));
+    assertEquals(
+        credentials,
+        instanceAdminSettings.getStubSettings().getCredentialsProvider().getCredentials());
+  }
+
+  @Test
+  public void testTimeoutBeingPassed() throws IOException {
+    int initialElapsedMs = 100;
+    int rpcTimeoutMs = 500;
+    int maxElapsedMs = 1000;
+    int maxAttempt = 10;
+    int readRowStreamTimeout = 30000;
+    configuration.setBoolean(BIGTABLE_USE_TIMEOUTS_KEY, true);
+    configuration.setInt(INITIAL_ELAPSED_BACKOFF_MILLIS_KEY, initialElapsedMs);
+    configuration.setInt(BIGTABLE_RPC_TIMEOUT_MS_KEY, rpcTimeoutMs);
+    configuration.setInt(MAX_ELAPSED_BACKOFF_MILLIS_KEY, maxElapsedMs);
+    configuration.setInt(READ_PARTIAL_ROW_TIMEOUT_MS, rpcTimeoutMs);
+    configuration.setLong(MAX_SCAN_TIMEOUT_RETRIES, maxAttempt);
+    configuration.setInt(BIGTABLE_READ_RPC_TIMEOUT_MS_KEY, readRowStreamTimeout);
+    BigtableDataSettings settings =
+        ((BigtableHBaseVeneerSettings) BigtableHBaseVeneerSettings.create(configuration))
+            .getDataSettings();
+
+    RetrySettings readRowRetrySettings =
+        settings.getStubSettings().readRowSettings().getRetrySettings();
+    assertEquals(initialElapsedMs, readRowRetrySettings.getInitialRetryDelay().toMillis());
+    assertEquals(rpcTimeoutMs, readRowRetrySettings.getInitialRpcTimeout().toMillis());
+    assertEquals(maxElapsedMs, readRowRetrySettings.getTotalTimeout().toMillis());
+
+    RetrySettings checkAndMutateRetrySettings =
+        settings.getStubSettings().checkAndMutateRowSettings().getRetrySettings();
+    assertEquals(0, checkAndMutateRetrySettings.getInitialRetryDelay().toMillis());
+    assertEquals(rpcTimeoutMs, checkAndMutateRetrySettings.getTotalTimeout().toMillis());
+
+    RetrySettings readRowsRetrySettings =
+        settings.getStubSettings().readRowsSettings().getRetrySettings();
+    assertEquals(initialElapsedMs, readRowsRetrySettings.getInitialRetryDelay().toMillis());
+    assertEquals(maxAttempt, readRowsRetrySettings.getMaxAttempts());
+    assertEquals(readRowStreamTimeout, readRowsRetrySettings.getTotalTimeout().toMillis());
+  }
+
+  @Test
+  public void testRetriesWithoutTimestamp() throws IOException {
+    configuration.setBoolean(BIGTABLE_USE_PLAINTEXT_NEGOTIATION, true);
+    configuration.setBoolean(ALLOW_NO_TIMESTAMP_RETRIES_KEY, true);
+
+    try {
+      ((BigtableHBaseVeneerSettings) BigtableHBaseVeneerSettings.create(configuration))
+          .getDataSettings();
+      Assert.fail("BigtableDataSettings should not support retries without timestamp");
+    } catch (UnsupportedOperationException actualException) {
+
+      assertEquals("Retries without Timestamp is not supported yet.", actualException.getMessage());
+    }
+  }
+
+  @Test
+  public void testWhenRetriesAreDisabled() throws IOException {
+    configuration.setBoolean(ENABLE_GRPC_RETRIES_KEY, false);
+    BigtableDataSettings dataSettings =
+        ((BigtableHBaseVeneerSettings) BigtableHBaseVeneerSettings.create(configuration))
+            .getDataSettings();
+    assertTrue(
+        dataSettings.getStubSettings().bulkMutateRowsSettings().getRetryableCodes().isEmpty());
+    assertTrue(dataSettings.getStubSettings().readRowSettings().getRetryableCodes().isEmpty());
+    assertTrue(dataSettings.getStubSettings().readRowsSettings().getRetryableCodes().isEmpty());
+    assertTrue(
+        dataSettings.getStubSettings().sampleRowKeysSettings().getRetryableCodes().isEmpty());
+  }
+
+  @Test
+  public void testWithNullCredentials() throws IOException {
+    configuration.set(ADDITIONAL_RETRY_CODES, "UNAVAILABLE,ABORTED");
+    configuration.setBoolean(BIGTABLE_USE_SERVICE_ACCOUNTS_KEY, false);
+    configuration.setBoolean(BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, true);
+
+    BigtableDataSettings dataSettings =
+        ((BigtableHBaseVeneerSettings) BigtableHBaseVeneerSettings.create(configuration))
+            .getDataSettings();
+    assertTrue(
+        dataSettings.getStubSettings().getCredentialsProvider() instanceof NoCredentialsProvider);
+    assertNull(dataSettings.getStubSettings().getCredentialsProvider().getCredentials());
+
+    BigtableTableAdminSettings adminSettings =
+        ((BigtableHBaseVeneerSettings) BigtableHBaseVeneerSettings.create(configuration))
+            .getTableAdminSettings();
+    assertTrue(
+        adminSettings.getStubSettings().getCredentialsProvider() instanceof NoCredentialsProvider);
+    assertNull(adminSettings.getStubSettings().getCredentialsProvider().getCredentials());
+  }
+
+  @Test
+  public void testVerifyRetrySettings() throws IOException {
+    BigtableDataSettings dataSettings =
+        ((BigtableHBaseVeneerSettings) BigtableHBaseVeneerSettings.create(configuration))
+            .getDataSettings();
+    BigtableDataSettings.Builder defaultDataSettings = BigtableDataSettings.newBuilder();
+
+    assertEquals(
+        defaultDataSettings.stubSettings().readRowsSettings().getRetryableCodes(),
+        dataSettings.getStubSettings().readRowsSettings().getRetryableCodes());
+
+    // Unary operation's RetrySettings & RetryCodes of retryable methods.
+    assertRetrySettings(
+        defaultDataSettings.stubSettings().readRowSettings().getRetrySettings(),
+        dataSettings.getStubSettings().readRowSettings().getRetrySettings());
+    assertEquals(
+        defaultDataSettings.stubSettings().readRowSettings().getRetryableCodes(),
+        dataSettings.getStubSettings().readRowSettings().getRetryableCodes());
+
+    assertRetrySettings(
+        defaultDataSettings.stubSettings().mutateRowSettings().getRetrySettings(),
+        dataSettings.getStubSettings().mutateRowSettings().getRetrySettings());
+    assertEquals(
+        defaultDataSettings.stubSettings().mutateRowSettings().getRetryableCodes(),
+        dataSettings.getStubSettings().mutateRowSettings().getRetryableCodes());
+
+    assertRetrySettings(
+        defaultDataSettings.stubSettings().sampleRowKeysSettings().getRetrySettings(),
+        dataSettings.getStubSettings().sampleRowKeysSettings().getRetrySettings());
+    assertEquals(
+        defaultDataSettings.stubSettings().sampleRowKeysSettings().getRetryableCodes(),
+        dataSettings.getStubSettings().sampleRowKeysSettings().getRetryableCodes());
+
+    // Non-streaming operation's verifying RetrySettings & RetryCodes of non-retryable methods.
+    // readModifyWriteRowSettings
+    assertDisabledRetrySettings(
+        defaultDataSettings.stubSettings().readModifyWriteRowSettings().getRetrySettings(),
+        dataSettings.getStubSettings().readModifyWriteRowSettings().getRetrySettings());
+    assertTrue(
+        dataSettings.getStubSettings().readModifyWriteRowSettings().getRetryableCodes().isEmpty());
+
+    // checkAndMutateRowSettings
+    assertDisabledRetrySettings(
+        defaultDataSettings.stubSettings().readModifyWriteRowSettings().getRetrySettings(),
+        dataSettings.getStubSettings().checkAndMutateRowSettings().getRetrySettings());
+    assertTrue(
+        dataSettings.getStubSettings().checkAndMutateRowSettings().getRetryableCodes().isEmpty());
+  }
+
+  private void assertRetrySettings(RetrySettings expected, RetrySettings actual) {
+    assertEquals(expected.getInitialRetryDelay(), actual.getInitialRetryDelay());
+    assertEquals(expected.getMaxRetryDelay(), actual.getMaxRetryDelay());
+    assertEquals(expected.getMaxAttempts(), actual.getMaxAttempts());
+    assertEquals(expected.getInitialRpcTimeout(), actual.getInitialRpcTimeout());
+    assertEquals(expected.getMaxRpcTimeout(), actual.getMaxRpcTimeout());
+    assertEquals(expected.getTotalTimeout(), actual.getTotalTimeout());
+  }
+
+  private void assertDisabledRetrySettings(RetrySettings expected, RetrySettings actual) {
+    assertEquals(expected.getInitialRetryDelay(), actual.getInitialRetryDelay());
+    assertEquals(expected.getRetryDelayMultiplier(), actual.getRetryDelayMultiplier(), 0);
+    assertEquals(expected.getMaxRetryDelay(), actual.getMaxRetryDelay());
+    assertEquals(expected.getMaxAttempts(), actual.getMaxAttempts());
+    assertEquals(expected.getInitialRpcTimeout(), actual.getInitialRpcTimeout());
+    assertEquals(expected.getMaxRpcTimeout(), actual.getMaxRpcTimeout());
+    assertEquals(expected.getTotalTimeout(), actual.getTotalTimeout());
+  }
+
+  @Test
+  public void testBulkMutationConfiguration() throws IOException {
+    long autoFlushMs = 2000L;
+    long maxRowKeyCount = 100L;
+    long maxInflightRPC = 500L;
+    long maxMemory = 100 * 1024L;
+    long bulkMaxReqSize = 20 * 1024;
+
+    configuration.setLong(BIGTABLE_BULK_AUTOFLUSH_MS_KEY, autoFlushMs);
+    configuration.setLong(BIGTABLE_BULK_MAX_ROW_KEY_COUNT, maxRowKeyCount);
+    configuration.setLong(MAX_INFLIGHT_RPCS_KEY, maxInflightRPC);
+    configuration.setLong(BIGTABLE_BULK_MAX_REQUEST_SIZE_BYTES, bulkMaxReqSize);
+    configuration.setLong(MAX_ELAPSED_BACKOFF_MILLIS_KEY, autoFlushMs);
+    configuration.setLong(BIGTABLE_BUFFERED_MUTATOR_MAX_MEMORY_KEY, maxMemory);
+
+    BigtableHBaseVeneerSettings settingUtils =
+        ((BigtableHBaseVeneerSettings) BigtableHBaseVeneerSettings.create(configuration));
+    BigtableDataSettings settings = settingUtils.getDataSettings();
+
+    BatchingSettings batchingSettings =
+        settings.getStubSettings().bulkMutateRowsSettings().getBatchingSettings();
+    assertEquals(ofMillis(autoFlushMs), batchingSettings.getDelayThreshold());
+    assertEquals(Long.valueOf(bulkMaxReqSize), batchingSettings.getRequestByteThreshold());
+    assertEquals(maxRowKeyCount, settingUtils.getBulkMaxRowCount());
+    assertEquals(Long.valueOf(maxRowKeyCount), batchingSettings.getElementCountThreshold());
+    assertEquals(
+        Long.valueOf(maxInflightRPC * maxRowKeyCount),
+        batchingSettings.getFlowControlSettings().getMaxOutstandingElementCount());
+    assertEquals(
+        Long.valueOf(maxMemory),
+        batchingSettings.getFlowControlSettings().getMaxOutstandingRequestBytes());
+  }
+
+  @Test
+  public void testDataSettingsWithEmulator() throws IOException {
+    ServerSocket serverSocket = new ServerSocket(0);
+    final int availablePort = serverSocket.getLocalPort();
+    serverSocket.close();
+    String emulatorHost = "localhost:" + availablePort;
+    configuration.set(BIGTABLE_EMULATOR_HOST_KEY, emulatorHost);
+
+    BigtableDataSettings dataSettings =
+        ((BigtableHBaseVeneerSettings) BigtableHBaseVeneerSettings.create(configuration))
+            .getDataSettings();
+
+    assertEquals(emulatorHost, dataSettings.getStubSettings().getEndpoint());
+    CredentialsProvider credProvider = dataSettings.getStubSettings().getCredentialsProvider();
+    assertTrue(credProvider instanceof NoCredentialsProvider);
+  }
+
+  @Test
+  public void testAdminSettingsWithEmulator() throws IOException {
+    ServerSocket serverSocket = new ServerSocket(0);
+    final int availablePort = serverSocket.getLocalPort();
+    serverSocket.close();
+    String emulatorHost = "localhost:" + availablePort;
+    configuration.set(BIGTABLE_EMULATOR_HOST_KEY, emulatorHost);
+
+    BigtableTableAdminSettings adminSettings =
+        ((BigtableHBaseVeneerSettings) BigtableHBaseVeneerSettings.create(configuration))
+            .getTableAdminSettings();
+
+    assertEquals(emulatorHost, adminSettings.getStubSettings().getEndpoint());
+    CredentialsProvider credProvider = adminSettings.getStubSettings().getCredentialsProvider();
+    assertTrue(credProvider instanceof NoCredentialsProvider);
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBigtableHBaseVeneerSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBigtableHBaseVeneerSettings.java
@@ -222,7 +222,7 @@ public class TestBigtableHBaseVeneerSettings {
       Assert.fail("BigtableDataSettings should not support retries without timestamp");
     } catch (UnsupportedOperationException actualException) {
 
-      assertEquals("Retries without Timestamp is not supported yet.", actualException.getMessage());
+      assertEquals("Retries without Timestamp is not supported.", actualException.getMessage());
     }
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBigtableHBaseVeneerSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBigtableHBaseVeneerSettings.java
@@ -328,9 +328,7 @@ public class TestBigtableHBaseVeneerSettings {
     assertEquals(
         Long.valueOf(maxInflightRPC * maxRowKeyCount),
         batchingSettings.getFlowControlSettings().getMaxOutstandingElementCount());
-    assertEquals(
-        Long.valueOf(maxMemory),
-        batchingSettings.getFlowControlSettings().getMaxOutstandingRequestBytes());
+    assertEquals(maxMemory, settingUtils.getBatchingMaxRequestSize());
   }
 
   @Test

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-benchmarks/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-benchmarks/pom.xml
@@ -9,6 +9,17 @@
 
   <artifactId>bigtable-hbase-1.x-benchmarks</artifactId>
 
+  <!--  TODO: remove this dependency when upgraded transitively to 1.34.2 -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-jackson2</artifactId>
+        <version>1.34.2</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <!-- Project related dependencies-->
     <dependency>


### PR DESCRIPTION
This change introduces `BigtableHBaseSettings`, which is then extended for specific implementation(i.e. classic and veneer):
  - `wrappers.BigtableHBaseSettings`:  abstract layer for settings.
  - `wrappers.classic.BigtableHBaseClassicSettings`
  - `wrappers.veneer.BigtableHBaseVeneerSettings`

Along with those, It includes getters for `BigtablOptions.Builder` and exposes `BigtableExtendedConfiguration` as internal public class for technical purpose.

**Assumption:** I think we should keep the BigtableOptionsFactory(this contains configuration keys) in its current state, reason being it is exists in `bigtable-hbase` module and publicly exposed. we would be deprecating & removing the `BigtableOptionsFactory#fromConfiguration()` utility in the future.
updated buildCredentials to preserve user provided credentials