### PR TITLE
chore: classic client implementation for wrappers

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/AdminClientClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/AdminClientClassicApi.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers.classic;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.InternalApi;
+import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
+import com.google.cloud.bigtable.admin.v2.models.ModifyColumnFamiliesRequest;
+import com.google.cloud.bigtable.admin.v2.models.Table;
+import com.google.cloud.bigtable.core.IBigtableTableAdminClient;
+import com.google.cloud.bigtable.hbase.wrappers.AdminClientWrapper;
+import java.util.List;
+
+/** For internal use only - public for technical reasons. */
+@InternalApi("For internal usage only")
+public class AdminClientClassicApi implements AdminClientWrapper {
+
+  private final IBigtableTableAdminClient delegate;
+
+  AdminClientClassicApi(IBigtableTableAdminClient delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public ApiFuture<Table> createTableAsync(CreateTableRequest request) {
+    return delegate.createTableAsync(request);
+  }
+
+  @Override
+  public ApiFuture<Table> getTableAsync(String tableId) {
+    return delegate.getTableAsync(tableId);
+  }
+
+  @Override
+  public ApiFuture<List<String>> listTablesAsync() {
+    return delegate.listTablesAsync();
+  }
+
+  @Override
+  public ApiFuture<Void> deleteTableAsync(String tableId) {
+    return delegate.deleteTableAsync(tableId);
+  }
+
+  @Override
+  public ApiFuture<Table> modifyFamiliesAsync(ModifyColumnFamiliesRequest request) {
+    return delegate.modifyFamiliesAsync(request);
+  }
+
+  @Override
+  public ApiFuture<Void> dropRowRangeAsync(String tableId, String rowKeyPrefix) {
+    return delegate.dropRowRangeAsync(tableId, rowKeyPrefix);
+  }
+
+  @Override
+  public ApiFuture<Void> dropAllRowsAsync(String tableId) {
+    return delegate.dropAllRowsAsync(tableId);
+  }
+
+  @Override
+  public void close() {}
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/AdminClientClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/AdminClientClassicApi.java
@@ -17,56 +17,155 @@ package com.google.cloud.bigtable.hbase.wrappers.classic;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.InternalApi;
+import com.google.bigtable.admin.v2.DeleteTableRequest;
+import com.google.bigtable.admin.v2.DropRowRangeRequest;
+import com.google.bigtable.admin.v2.GetTableRequest;
+import com.google.bigtable.admin.v2.ListTablesRequest;
+import com.google.bigtable.admin.v2.ListTablesResponse;
 import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
 import com.google.cloud.bigtable.admin.v2.models.ModifyColumnFamiliesRequest;
 import com.google.cloud.bigtable.admin.v2.models.Table;
-import com.google.cloud.bigtable.core.IBigtableTableAdminClient;
+import com.google.cloud.bigtable.grpc.BigtableInstanceName;
+import com.google.cloud.bigtable.grpc.BigtableTableAdminClient;
 import com.google.cloud.bigtable.hbase.wrappers.AdminClientWrapper;
+import com.google.cloud.bigtable.util.ApiFutureUtil;
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Empty;
 import java.util.List;
+import javax.annotation.Nonnull;
 
 /** For internal use only - public for technical reasons. */
 @InternalApi("For internal usage only")
 public class AdminClientClassicApi implements AdminClientWrapper {
 
-  private final IBigtableTableAdminClient delegate;
+  private final BigtableTableAdminClient delegate;
+  private final BigtableInstanceName instanceName;
 
-  AdminClientClassicApi(IBigtableTableAdminClient delegate) {
+  AdminClientClassicApi(
+      @Nonnull BigtableTableAdminClient delegate, @Nonnull BigtableInstanceName instanceName) {
     this.delegate = delegate;
+    this.instanceName = instanceName;
   }
 
   @Override
   public ApiFuture<Table> createTableAsync(CreateTableRequest request) {
-    return delegate.createTableAsync(request);
+    com.google.bigtable.admin.v2.CreateTableRequest requestProto =
+        request.toProto(instanceName.getProjectId(), instanceName.getInstanceId());
+
+    return ApiFutureUtil.transformAndAdapt(
+        delegate.createTableAsync(requestProto),
+        new Function<com.google.bigtable.admin.v2.Table, Table>() {
+          @Override
+          public Table apply(com.google.bigtable.admin.v2.Table tableProto) {
+            return Table.fromProto(tableProto);
+          }
+        });
   }
 
   @Override
   public ApiFuture<Table> getTableAsync(String tableId) {
-    return delegate.getTableAsync(tableId);
+    GetTableRequest requestProto =
+        GetTableRequest.newBuilder().setName(instanceName.toTableNameStr(tableId)).build();
+
+    return ApiFutureUtil.transformAndAdapt(
+        delegate.getTableAsync(requestProto),
+        new Function<com.google.bigtable.admin.v2.Table, Table>() {
+          @Override
+          public Table apply(com.google.bigtable.admin.v2.Table tableProto) {
+            return Table.fromProto(tableProto);
+          }
+        });
   }
 
   @Override
   public ApiFuture<List<String>> listTablesAsync() {
-    return delegate.listTablesAsync();
+    ListTablesRequest request =
+        ListTablesRequest.newBuilder().setParent(instanceName.toString()).build();
+    ListenableFuture<ListTablesResponse> response = delegate.listTablesAsync(request);
+
+    return ApiFutureUtil.transformAndAdapt(
+        response,
+        new Function<ListTablesResponse, List<String>>() {
+          @Override
+          public List<String> apply(ListTablesResponse input) {
+            ImmutableList.Builder<String> tableIdsBuilder = ImmutableList.builder();
+            for (com.google.bigtable.admin.v2.Table tableProto : input.getTablesList()) {
+              tableIdsBuilder.add(instanceName.toTableId(tableProto.getName()));
+            }
+
+            return tableIdsBuilder.build();
+          }
+        });
   }
 
   @Override
   public ApiFuture<Void> deleteTableAsync(String tableId) {
-    return delegate.deleteTableAsync(tableId);
+    DeleteTableRequest request =
+        DeleteTableRequest.newBuilder().setName(instanceName.toTableNameStr(tableId)).build();
+
+    return ApiFutureUtil.transformAndAdapt(
+        delegate.deleteTableAsync(request),
+        new Function<Empty, Void>() {
+          @Override
+          public Void apply(Empty empty) {
+            return null;
+          }
+        });
   }
 
   @Override
   public ApiFuture<Table> modifyFamiliesAsync(ModifyColumnFamiliesRequest request) {
-    return delegate.modifyFamiliesAsync(request);
+    com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest modifyColumnRequestProto =
+        request.toProto(instanceName.getProjectId(), instanceName.getInstanceId());
+
+    return ApiFutureUtil.transformAndAdapt(
+        delegate.modifyColumnFamilyAsync(modifyColumnRequestProto),
+        new Function<com.google.bigtable.admin.v2.Table, Table>() {
+          @Override
+          public Table apply(com.google.bigtable.admin.v2.Table tableProto) {
+            return Table.fromProto(tableProto);
+          }
+        });
   }
 
   @Override
   public ApiFuture<Void> dropRowRangeAsync(String tableId, String rowKeyPrefix) {
-    return delegate.dropRowRangeAsync(tableId, rowKeyPrefix);
+    Preconditions.checkNotNull(rowKeyPrefix);
+    DropRowRangeRequest protoRequest =
+        DropRowRangeRequest.newBuilder()
+            .setName(instanceName.toTableNameStr(tableId))
+            .setDeleteAllDataFromTable(false)
+            .setRowKeyPrefix(ByteString.copyFromUtf8(rowKeyPrefix))
+            .build();
+    return ApiFutureUtil.transformAndAdapt(
+        delegate.dropRowRangeAsync(protoRequest),
+        new Function<Empty, Void>() {
+          @Override
+          public Void apply(Empty empty) {
+            return null;
+          }
+        });
   }
 
   @Override
   public ApiFuture<Void> dropAllRowsAsync(String tableId) {
-    return delegate.dropAllRowsAsync(tableId);
+    DropRowRangeRequest protoRequest =
+        DropRowRangeRequest.newBuilder()
+            .setName(instanceName.toTableNameStr(tableId))
+            .setDeleteAllDataFromTable(true)
+            .build();
+    return ApiFutureUtil.transformAndAdapt(
+        delegate.dropRowRangeAsync(protoRequest),
+        new Function<Empty, Void>() {
+          @Override
+          public Void apply(Empty empty) {
+            return null;
+          }
+        });
   }
 
   @Override

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BulkMutationClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BulkMutationClassicApi.java
@@ -24,6 +24,8 @@ import com.google.cloud.bigtable.hbase.wrappers.BulkMutationWrapper;
 import com.google.cloud.bigtable.util.ApiFutureUtil;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
+import java.io.IOException;
+import javax.annotation.Nonnull;
 
 /** For internal use only - public for technical reasons. */
 @InternalApi("For internal usage only")
@@ -32,7 +34,7 @@ public class BulkMutationClassicApi implements BulkMutationWrapper {
   private final BulkMutation delegate;
   private boolean isClosed = false;
 
-  BulkMutationClassicApi(BulkMutation delegate) {
+  BulkMutationClassicApi(@Nonnull BulkMutation delegate) {
     this.delegate = delegate;
   }
 
@@ -60,7 +62,12 @@ public class BulkMutationClassicApi implements BulkMutationWrapper {
   }
 
   @Override
-  public void close() {
+  public void close() throws IOException {
     isClosed = true;
+    try {
+      flush();
+    } catch (InterruptedException interruptedException) {
+      throw new IOException(interruptedException);
+    }
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BulkMutationClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BulkMutationClassicApi.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers.classic;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.InternalApi;
+import com.google.bigtable.v2.MutateRowResponse;
+import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
+import com.google.cloud.bigtable.grpc.async.BulkMutation;
+import com.google.cloud.bigtable.hbase.wrappers.BulkMutationWrapper;
+import com.google.cloud.bigtable.util.ApiFutureUtil;
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+
+/** For internal use only - public for technical reasons. */
+@InternalApi("For internal usage only")
+public class BulkMutationClassicApi implements BulkMutationWrapper {
+
+  private final BulkMutation delegate;
+  private boolean isClosed = false;
+
+  BulkMutationClassicApi(BulkMutation delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public ApiFuture<Void> add(RowMutationEntry rowMutation) {
+    Preconditions.checkState(!isClosed, "can't mutate when the bulk mutation is closed.");
+    return ApiFutureUtil.transformAndAdapt(
+        delegate.add(rowMutation.toProto()),
+        new Function<MutateRowResponse, Void>() {
+          @Override
+          public Void apply(MutateRowResponse response) {
+            return null;
+          }
+        });
+  }
+
+  @Override
+  public void sendUnsent() {
+    delegate.sendUnsent();
+  }
+
+  @Override
+  public void flush() throws InterruptedException {
+    delegate.flush();
+  }
+
+  @Override
+  public void close() {
+    isClosed = true;
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BulkReadClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BulkReadClassicApi.java
@@ -26,6 +26,7 @@ import com.google.cloud.bigtable.hbase.adapters.Adapters;
 import com.google.cloud.bigtable.hbase.wrappers.BulkReadWrapper;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.MoreExecutors;
+import javax.annotation.Nonnull;
 import org.apache.hadoop.hbase.client.Result;
 
 /** For internal use only - public for technical reasons. */
@@ -35,13 +36,13 @@ public class BulkReadClassicApi implements BulkReadWrapper {
   private final BulkRead delegate;
   private boolean isClosed = false;
 
-  BulkReadClassicApi(BulkRead delegate) {
+  BulkReadClassicApi(@Nonnull BulkRead delegate) {
     this.delegate = delegate;
   }
 
   @Override
   public ApiFuture<Result> add(Query query) {
-    Preconditions.checkState(!isClosed, "can't mutate when the bulk mutation is closed.");
+    Preconditions.checkState(!isClosed, "can't add request when the bulk read is closed.");
     return ApiFutures.transform(
         delegate.add(query),
         new ApiFunction<FlatRow, Result>() {
@@ -61,5 +62,6 @@ public class BulkReadClassicApi implements BulkReadWrapper {
   @Override
   public void close() {
     isClosed = true;
+    flush();
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BulkReadClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BulkReadClassicApi.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers.classic;
+
+import com.google.api.core.ApiFunction;
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.core.InternalApi;
+import com.google.cloud.bigtable.data.v2.models.Query;
+import com.google.cloud.bigtable.grpc.async.BulkRead;
+import com.google.cloud.bigtable.grpc.scanner.FlatRow;
+import com.google.cloud.bigtable.hbase.adapters.Adapters;
+import com.google.cloud.bigtable.hbase.wrappers.BulkReadWrapper;
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.MoreExecutors;
+import org.apache.hadoop.hbase.client.Result;
+
+/** For internal use only - public for technical reasons. */
+@InternalApi("For internal usage only")
+public class BulkReadClassicApi implements BulkReadWrapper {
+
+  private final BulkRead delegate;
+  private boolean isClosed = false;
+
+  BulkReadClassicApi(BulkRead delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public ApiFuture<Result> add(Query query) {
+    Preconditions.checkState(!isClosed, "can't mutate when the bulk mutation is closed.");
+    return ApiFutures.transform(
+        delegate.add(query),
+        new ApiFunction<FlatRow, Result>() {
+          @Override
+          public Result apply(FlatRow flatRow) {
+            return Adapters.FLAT_ROW_ADAPTER.adaptResponse(flatRow);
+          }
+        },
+        MoreExecutors.directExecutor());
+  }
+
+  @Override
+  public void flush() {
+    delegate.flush();
+  }
+
+  @Override
+  public void close() {
+    isClosed = true;
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestAdminClientClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestAdminClientClassicApi.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers.classic;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.api.core.ApiFutures;
+import com.google.cloud.bigtable.admin.v2.internal.NameUtil;
+import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
+import com.google.cloud.bigtable.admin.v2.models.GCRules;
+import com.google.cloud.bigtable.admin.v2.models.ModifyColumnFamiliesRequest;
+import com.google.cloud.bigtable.admin.v2.models.Table;
+import com.google.cloud.bigtable.core.IBigtableTableAdminClient;
+import com.google.cloud.bigtable.hbase.wrappers.AdminClientWrapper;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@RunWith(JUnit4.class)
+public class TestAdminClientClassicApi {
+
+  private static final String TABLE_ID = "fake-Table-id";
+
+  private static final String TABLE_NAME =
+      NameUtil.formatTableName("fake-project-id", "fake-instance-id", TABLE_ID);
+
+  @Rule public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Mock private IBigtableTableAdminClient delegate;
+
+  private AdminClientWrapper adminClientWrapper;
+
+  @Before
+  public void setUp() {
+    adminClientWrapper = new AdminClientClassicApi(delegate);
+  }
+
+  @Test
+  public void testCreateTableAsync() throws Exception {
+    CreateTableRequest req = CreateTableRequest.of(TABLE_ID);
+    when(delegate.createTableAsync(req))
+        .thenReturn(
+            ApiFutures.immediateFuture(
+                Table.fromProto(
+                    com.google.bigtable.admin.v2.Table.newBuilder().setName(TABLE_NAME).build())));
+    Future<Table> response = adminClientWrapper.createTableAsync(req);
+
+    assertEquals(TABLE_ID, response.get().getId());
+    verify(delegate).createTableAsync(req);
+  }
+
+  @Test
+  public void testGetTableAsync() throws ExecutionException, InterruptedException {
+    when(delegate.getTableAsync(TABLE_ID))
+        .thenReturn(
+            ApiFutures.immediateFuture(
+                Table.fromProto(
+                    com.google.bigtable.admin.v2.Table.newBuilder().setName(TABLE_NAME).build())));
+    Future<Table> response = adminClientWrapper.getTableAsync(TABLE_ID);
+    assertEquals(TABLE_ID, response.get().getId());
+    verify(delegate).getTableAsync(TABLE_ID);
+  }
+
+  @Test
+  public void testListTablesAsync() throws ExecutionException, InterruptedException {
+    List<String> response = ImmutableList.of("a", "b");
+    when(delegate.listTablesAsync()).thenReturn(ApiFutures.immediateFuture(response));
+    assertEquals(response, adminClientWrapper.listTablesAsync().get());
+    verify(delegate).listTablesAsync();
+  }
+
+  @Test
+  public void testDeleteTablesAsync() throws ExecutionException, InterruptedException {
+    when(delegate.deleteTableAsync(TABLE_ID)).thenReturn(ApiFutures.<Void>immediateFuture(null));
+    adminClientWrapper.deleteTableAsync(TABLE_ID).get();
+    verify(delegate).deleteTableAsync(TABLE_ID);
+  }
+
+  @Test
+  public void testModifyFamiliesAsync() throws ExecutionException, InterruptedException {
+    ModifyColumnFamiliesRequest request =
+        ModifyColumnFamiliesRequest.of(TABLE_ID)
+            .addFamily("cf1")
+            .updateFamily("cf2", GCRules.GCRULES.maxVersions(5));
+    Table table =
+        Table.fromProto(
+            com.google.bigtable.admin.v2.Table.newBuilder().setName(TABLE_NAME).build());
+    when(delegate.modifyFamiliesAsync(request)).thenReturn(ApiFutures.immediateFuture(table));
+    assertEquals(table, adminClientWrapper.modifyFamiliesAsync(request).get());
+    verify(delegate).modifyFamiliesAsync(request);
+  }
+
+  @Test
+  public void testDropRowRangeAsync() throws ExecutionException, InterruptedException {
+    when(delegate.dropRowRangeAsync(TABLE_ID, "rowkey"))
+        .thenReturn(ApiFutures.<Void>immediateFuture(null));
+    adminClientWrapper.dropRowRangeAsync(TABLE_ID, "rowkey").get();
+    verify(delegate).dropRowRangeAsync(TABLE_ID, "rowkey");
+  }
+
+  @Test
+  public void testDropAllRowsAsync() throws ExecutionException, InterruptedException {
+    when(delegate.dropAllRowsAsync(TABLE_ID)).thenReturn(ApiFutures.<Void>immediateFuture(null));
+    adminClientWrapper.dropAllRowsAsync(TABLE_ID).get();
+    verify(delegate).dropAllRowsAsync(TABLE_ID);
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBulkMutationClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBulkMutationClassicApi.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers.classic;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.bigtable.v2.MutateRowResponse;
+import com.google.bigtable.v2.MutateRowsRequest;
+import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
+import com.google.cloud.bigtable.grpc.async.BulkMutation;
+import com.google.cloud.bigtable.hbase.wrappers.BulkMutationWrapper;
+import com.google.common.util.concurrent.Futures;
+import java.io.IOException;
+import java.util.concurrent.Future;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+@RunWith(JUnit4.class)
+public class TestBulkMutationClassicApi {
+
+  private BulkMutation mockDelegate;
+  private BulkMutationWrapper bulkWrapper;
+
+  @Before
+  public void setUp() {
+    mockDelegate = Mockito.mock(BulkMutation.class);
+    bulkWrapper = new BulkMutationClassicApi(mockDelegate);
+  }
+
+  @Test
+  public void testFlush() throws InterruptedException {
+    doNothing().when(mockDelegate).flush();
+    bulkWrapper.flush();
+    verify(mockDelegate).flush();
+  }
+
+  @Test
+  public void testSendUnsent() {
+    doNothing().when(mockDelegate).sendUnsent();
+    bulkWrapper.sendUnsent();
+    verify(mockDelegate).sendUnsent();
+  }
+
+  @Test
+  public void testAddMutate() {
+    RowMutationEntry rowMutation = RowMutationEntry.create("key");
+    MutateRowsRequest.Entry requestProto = rowMutation.toProto();
+    when(mockDelegate.add(requestProto))
+        .thenReturn(Futures.immediateFuture(MutateRowResponse.getDefaultInstance()));
+    Future<Void> response = bulkWrapper.add(rowMutation);
+    try {
+      response.get();
+    } catch (Exception ex) {
+      throw new AssertionError("Assertion failed for BulkMutationWrapper#add(RowMutation)");
+    }
+    verify(mockDelegate).add(requestProto);
+  }
+
+  @Test
+  public void testIsClosed() throws IOException {
+    bulkWrapper.close();
+    Exception actualEx = null;
+    try {
+      bulkWrapper.add(RowMutationEntry.create("key"));
+    } catch (Exception e) {
+      actualEx = e;
+    }
+    assertTrue(actualEx instanceof IllegalStateException);
+    assertEquals("can't mutate when the bulk mutation is closed.", actualEx.getMessage());
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBulkReadClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBulkReadClassicApi.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers.classic;
+
+import static com.google.cloud.bigtable.hbase.adapters.Adapters.FLAT_ROW_ADAPTER;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.api.core.ApiFutures;
+import com.google.cloud.bigtable.data.v2.models.Query;
+import com.google.cloud.bigtable.grpc.async.BulkRead;
+import com.google.cloud.bigtable.grpc.scanner.FlatRow;
+import com.google.cloud.bigtable.hbase.wrappers.BulkReadWrapper;
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import org.apache.hadoop.hbase.client.Result;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+@RunWith(JUnit4.class)
+public class TestBulkReadClassicApi {
+
+  private static final String TABLE_ID = "fake-Table-id";
+  private static final FlatRow FLAT_ROW =
+      FlatRow.newBuilder()
+          .withRowKey(ByteString.copyFromUtf8("row-key"))
+          .addCell("cf", ByteString.copyFromUtf8("q1"), 10000L, ByteString.copyFromUtf8("value"))
+          .build();
+
+  private BulkRead delegate;
+  private BulkReadWrapper bulkReadWrapper;
+
+  @Before
+  public void setUp() {
+    delegate = Mockito.mock(BulkRead.class);
+    bulkReadWrapper = new BulkReadClassicApi(delegate);
+  }
+
+  @Test
+  public void testAdd() throws ExecutionException, InterruptedException {
+    Query query = Query.create(TABLE_ID).rowKey("row-key");
+    when(delegate.add(query)).thenReturn(ApiFutures.immediateFuture(FLAT_ROW));
+    Result result = bulkReadWrapper.add(query).get();
+    assertArrayEquals(FLAT_ROW.getRowKey().toByteArray(), result.getRow());
+    assertArrayEquals(FLAT_ROW_ADAPTER.adaptResponse(FLAT_ROW).rawCells(), result.rawCells());
+    verify(delegate).add(query);
+  }
+
+  @Test
+  public void testFlush() {
+    doNothing().when(delegate).flush();
+    bulkReadWrapper.flush();
+    verify(delegate).flush();
+  }
+
+  @Test
+  public void testClose() throws IOException {
+    bulkReadWrapper.close();
+    try {
+      bulkReadWrapper.add(Query.create(TABLE_ID).rowKey("row-key-2"));
+      Assert.fail("BulkRead should be closed");
+    } catch (IllegalStateException actualException) {
+      assertEquals("can't mutate when the bulk mutation is closed.", actualException.getMessage());
+    }
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBulkReadClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBulkReadClassicApi.java
@@ -79,9 +79,9 @@ public class TestBulkReadClassicApi {
     bulkReadWrapper.close();
     try {
       bulkReadWrapper.add(Query.create(TABLE_ID).rowKey("row-key-2"));
-      Assert.fail("BulkRead should be closed");
+      Assert.fail("Bulk read should be closed");
     } catch (IllegalStateException actualException) {
-      assertEquals("can't mutate when the bulk mutation is closed.", actualException.getMessage());
+      assertEquals("can't add request when the bulk read is closed.", actualException.getMessage());
     }
   }
 }


### PR DESCRIPTION
This change contains classic client wrapper implementation of Admin, BulkMutation, BulkRead.

These implementations simply delegate calls to their existing implementation present in `bigtable-core-client`.

Note: I will add `BigtableDataClassicApi` once this PR is merged.