### PR TITLE
chore: add version information utility

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/pom.xml
+++ b/bigtable-client-core-parent/bigtable-hbase/pom.xml
@@ -167,4 +167,14 @@ limitations under the License.
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <!-- enable project.version substitution. -->
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+  </build>
 </project>

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableHBaseVersion.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableHBaseVersion.java
@@ -21,15 +21,19 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
-/** For internal use only - public for technical reasons. */
+/**
+ * The version in this class is project build version specified in the maven. Maven reads the
+ * <strong>bigtable-hbase.properties</strong> file present in the resources directory and replaces
+ * the property placeholder with project version.
+ *
+ * <p>For internal use only - public for technical reasons.
+ */
 @InternalApi("For internal usage only")
 public class BigtableHBaseVersion {
 
   private static final Logger LOG = new Logger(BigtableHBaseVersion.class);
 
   public static final String CLIENT_VERSION = getVersion();
-
-  public static final String USER_AGENT_VALUE = "java-bigtable-hbase-" + getVersion();
 
   /**
    * Gets user agent from bigtable-hbase-version.properties. Returns a default dev user agent with
@@ -38,7 +42,7 @@ public class BigtableHBaseVersion {
   private static String getVersion() {
     final String defaultVersion = "dev-" + System.currentTimeMillis();
     final String fileName = "bigtable-hbase-version.properties";
-    final String versionProperty = "bigtable.version";
+    final String versionProperty = "bigtable-hbase.version";
     try (InputStream stream = BigtableHBaseVersion.class.getResourceAsStream(fileName)) {
       if (stream == null) {
         LOG.error("Could not load properties file %s", fileName);

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableHBaseVersion.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableHBaseVersion.java
@@ -33,13 +33,11 @@ public class BigtableHBaseVersion {
 
   private static final Logger LOG = new Logger(BigtableHBaseVersion.class);
 
-  public static final String CLIENT_VERSION = getVersion();
-
   /**
    * Gets user agent from bigtable-hbase-version.properties. Returns a default dev user agent with
    * current timestamp if not found.
    */
-  private static String getVersion() {
+  public static String getVersion() {
     final String defaultVersion = "dev-" + System.currentTimeMillis();
     final String fileName = "bigtable-hbase-version.properties";
     final String versionProperty = "bigtable-hbase.version";

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableHBaseVersion.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableHBaseVersion.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase;
+
+import com.google.api.core.InternalApi;
+import com.google.cloud.bigtable.hbase.util.Logger;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+/** For internal use only - public for technical reasons. */
+@InternalApi("For internal usage only")
+public class BigtableHBaseVersion {
+
+  private static final Logger LOG = new Logger(BigtableHBaseVersion.class);
+
+  public static final String CLIENT_VERSION = getVersion();
+
+  public static final String USER_AGENT_VALUE = "java-bigtable-hbase-" + getVersion();
+
+  /**
+   * Gets user agent from bigtable-hbase-version.properties. Returns a default dev user agent with
+   * current timestamp if not found.
+   */
+  private static String getVersion() {
+    final String defaultVersion = "dev-" + System.currentTimeMillis();
+    final String fileName = "bigtable-hbase-version.properties";
+    final String versionProperty = "bigtable.version";
+    try (InputStream stream = BigtableHBaseVersion.class.getResourceAsStream(fileName)) {
+      if (stream == null) {
+        LOG.error("Could not load properties file %s", fileName);
+        return defaultVersion;
+      }
+
+      Properties properties = new Properties();
+      properties.load(stream);
+      String value = properties.getProperty(versionProperty);
+      if (value == null) {
+        LOG.error("%s not found in %s.", versionProperty, fileName);
+      } else if (value.startsWith("$")) {
+        LOG.info("%s property is not replaced.", versionProperty);
+      } else {
+        return value;
+      }
+    } catch (IOException e) {
+      LOG.error("Error while trying to get user agent name from %s", e, fileName);
+    }
+    return defaultVersion;
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/resources/com/google/cloud/bigtable/hbase/bigtable-hbase-version.properties
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/resources/com/google/cloud/bigtable/hbase/bigtable-hbase-version.properties
@@ -1,0 +1,1 @@
+bigtable.version=${project.version}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/resources/com/google/cloud/bigtable/hbase/bigtable-hbase-version.properties
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/resources/com/google/cloud/bigtable/hbase/bigtable-hbase-version.properties
@@ -1,1 +1,1 @@
-bigtable.version=${project.version}
+bigtable-hbase.version=${project.version}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/resources/com/google/cloud/bigtable/hbase/bigtable-hbase-version.properties
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/resources/com/google/cloud/bigtable/hbase/bigtable-hbase-version.properties
@@ -1,1 +1,2 @@
+# Please see com.google.cloud.bigtable.hbase.BigtableHBaseVersion for more details
 bigtable-hbase.version=${project.version}

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableHBaseVersion.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableHBaseVersion.java
@@ -30,6 +30,6 @@ public class TestBigtableHBaseVersion {
     // This patterns matches string with "1.14+" versions, The version must have 3 parts i.e. x.y.z
     Pattern versionPattern =
         Pattern.compile("^(([1]\\.([1][4-9]|[2-9]\\d))|([2-9]\\.\\d{1,2}))\\.");
-    assertTrue(versionPattern.matcher(BigtableHBaseVersion.CLIENT_VERSION).find());
+    assertTrue(versionPattern.matcher(BigtableHBaseVersion.getVersion()).find());
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableHBaseVersion.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableHBaseVersion.java
@@ -17,6 +17,8 @@ package com.google.cloud.bigtable.hbase;
 
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ComparisonChain;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,9 +29,19 @@ public class TestBigtableHBaseVersion {
 
   @Test
   public void testVersionNumber() {
-    // This patterns matches string with "1.14+" versions, The version must have 3 parts i.e. x.y.z
-    Pattern versionPattern =
-        Pattern.compile("^(([1]\\.([1][4-9]|[2-9]\\d))|([2-9]\\.\\d{1,2}))\\.");
-    assertTrue(versionPattern.matcher(BigtableHBaseVersion.getVersion()).find());
+    // Version must have 3 parts i.e. x.y.z and can have an optional of -SNAPSHOT suffixed.
+    Pattern versionPattern = Pattern.compile("^(\\d+)\\.(\\d+)\\.(\\d+)(-\\w+)?");
+    Matcher versionMatcher = versionPattern.matcher(BigtableHBaseVersion.getVersion());
+
+    assertTrue("incorrect version format", versionMatcher.matches());
+
+    int result =
+        ComparisonChain.start()
+            .compare(1, Integer.parseInt(versionMatcher.group(1)))
+            .compare(14, Integer.parseInt(versionMatcher.group(2)))
+            .compare(1, Integer.parseInt(versionMatcher.group(3)))
+            .result();
+
+    assertTrue("Expected BigtableHBaseVersion.getVersion() to be at least 1.14.1", result <= 0);
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableHBaseVersion.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableHBaseVersion.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.regex.Pattern;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TestBigtableHBaseVersion {
+
+  @Test
+  public void testVersionNumber() {
+    // This patterns matches string with "1.14+" versions, The version must have 3 parts i.e. x.y.z
+    Pattern versionPattern =
+        Pattern.compile("^(([1]\\.([1][4-9]|[2-9]\\d))|([2-9]\\.\\d{1,2}))\\.");
+    assertTrue(versionPattern.matcher(BigtableHBaseVersion.CLIENT_VERSION).find());
+  }
+}


### PR DESCRIPTION
This contains a utility to fetch current version info(Extracted from existing BigtableVersionInfo.java).

Inspired from [this discussion](https://github.com/googleapis/java-bigtable-hbase/pull/2393#discussion_r391231214).