### PR TITLE
chore: remove unused member from TableAdapter

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/admin/TableAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/admin/TableAdapter.java
@@ -21,8 +21,6 @@ import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.admin.v2.models.ColumnFamily;
 import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
 import com.google.cloud.bigtable.admin.v2.models.Table;
-import com.google.cloud.bigtable.grpc.BigtableInstanceName;
-import com.google.common.base.Preconditions;
 import com.google.protobuf.ByteString;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
@@ -37,7 +35,6 @@ import org.apache.hadoop.hbase.TableName;
 public class TableAdapter {
   private static final ColumnDescriptorAdapter columnDescriptorAdapter =
       ColumnDescriptorAdapter.INSTANCE;
-  protected final BigtableInstanceName bigtableInstanceName;
 
   /**
    * adapt. This method adapts ColumnFamily to CreateTableRequest.
@@ -69,15 +66,7 @@ public class TableAdapter {
     }
   }
 
-  /**
-   * Constructor for TableAdapter.
-   *
-   * @param bigtableInstanceName a {@link BigtableInstanceName} object.
-   */
-  public TableAdapter(BigtableInstanceName bigtableInstanceName) {
-    this.bigtableInstanceName =
-        Preconditions.checkNotNull(bigtableInstanceName, "bigtableInstanceName cannot be null.");
-  }
+  private TableAdapter() {}
 
   /**
    * adapt.
@@ -85,7 +74,7 @@ public class TableAdapter {
    * @param table a {@link Table} object.
    * @return a {@link HTableDescriptor} object.
    */
-  public HTableDescriptor adapt(Table table) {
+  public static HTableDescriptor adapt(Table table) {
     HTableDescriptor tableDescriptor = new HTableDescriptor(TableName.valueOf(table.getId()));
     for (ColumnFamily columnFamily : table.getColumnFamilies()) {
       tableDescriptor.addFamily(columnDescriptorAdapter.adapt(columnFamily));

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
@@ -103,7 +103,6 @@ public abstract class AbstractBigtableAdmin implements Admin {
   protected final IBigtableTableAdminClient tableAdminClientWrapper;
   protected final BigtableInstanceName bigtableInstanceName;
   private BigtableClusterName bigtableSnapshotClusterName;
-  protected final TableAdapter tableAdapter;
 
   /**
    * Constructor for AbstractBigtableAdmin.
@@ -118,7 +117,6 @@ public abstract class AbstractBigtableAdmin implements Admin {
     this.connection = connection;
     disabledTables = connection.getDisabledTables();
     bigtableInstanceName = options.getInstanceName();
-    tableAdapter = new TableAdapter(bigtableInstanceName);
     tableAdminClientWrapper = connection.getSession().getTableAdminClientWrapper();
 
     String clusterId =
@@ -288,7 +286,7 @@ public abstract class AbstractBigtableAdmin implements Admin {
     }
 
     try {
-      return tableAdapter.adapt(tableAdminClientWrapper.getTable(tableName.getNameAsString()));
+      return TableAdapter.adapt(tableAdminClientWrapper.getTable(tableName.getNameAsString()));
     } catch (Throwable throwable) {
       if (Status.fromThrowable(throwable).getCode() == Status.Code.NOT_FOUND) {
         throw new TableNotFoundException(tableName);

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/admin/TestTableAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/admin/TestTableAdapter.java
@@ -21,13 +21,11 @@ import com.google.bigtable.admin.v2.ColumnFamily;
 import com.google.bigtable.admin.v2.Table;
 import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
 import com.google.cloud.bigtable.admin.v2.models.GCRules.GCRule;
-import com.google.cloud.bigtable.grpc.BigtableInstanceName;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -42,14 +40,6 @@ public class TestTableAdapter {
       "projects/" + PROJECT_ID + "/instances/" + INSTANCE_ID;
   private static final String TABLE_NAME = INSTANCE_NAME + "/tables/" + TABLE_ID;
   private static final String COLUMN_FAMILY = "myColumnFamily";
-
-  private TableAdapter tableAdapter;
-
-  @Before
-  public void setUp() {
-    BigtableInstanceName bigtableInstanceName = new BigtableInstanceName(PROJECT_ID, INSTANCE_ID);
-    tableAdapter = new TableAdapter(bigtableInstanceName);
-  }
 
   @Test
   public void testAdaptWithHTableDescriptor() {
@@ -106,7 +96,7 @@ public class TestTableAdapter {
             .putColumnFamilies(COLUMN_FAMILY, columnFamily)
             .build();
     HTableDescriptor actualTableDesc =
-        tableAdapter.adapt(com.google.cloud.bigtable.admin.v2.models.Table.fromProto(table));
+        TableAdapter.adapt(com.google.cloud.bigtable.admin.v2.models.Table.fromProto(table));
 
     HTableDescriptor expected = new HTableDescriptor(TableName.valueOf(TABLE_ID));
     expected.addFamily(new HColumnDescriptor(COLUMN_FAMILY));

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncAdmin.java
@@ -100,7 +100,6 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
   private final Set<TableName> disabledTables;
   private final IBigtableTableAdminClient bigtableTableAdminClient;
   private final BigtableInstanceName bigtableInstanceName;
-  private final TableAdapter2x tableAdapter2x;
   private final CommonConnection asyncConnection;
   private BigtableClusterName bigtableSnapshotClusterName;
 
@@ -110,7 +109,6 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
     this.bigtableTableAdminClient = asyncConnection.getSession().getTableAdminClientWrapper();
     this.disabledTables = asyncConnection.getDisabledTables();
     this.bigtableInstanceName = options.getInstanceName();
-    this.tableAdapter2x = new TableAdapter2x(options);
     this.asyncConnection = asyncConnection;
 
     Configuration configuration = asyncConnection.getConfiguration();
@@ -251,7 +249,7 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
                                 .setName(bigtableInstanceName.toTableNameStr(m))
                                 .build())
                     .map(Table::fromProto)
-                    .map(tableAdapter2x::adapt)
+                    .map(TableAdapter2x::adapt)
                     .collect(Collectors.toList()));
   }
 
@@ -328,7 +326,7 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
                   throw new CompletionException(ex);
                 }
               } else {
-                return tableAdapter2x.adapt(resp);
+                return TableAdapter2x.adapt(resp);
               }
             });
   }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/adapters/admin/TableAdapter2x.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/adapters/admin/TableAdapter2x.java
@@ -18,8 +18,6 @@ package com.google.cloud.bigtable.hbase2_x.adapters.admin;
 import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
 import com.google.cloud.bigtable.admin.v2.models.Table;
-import com.google.cloud.bigtable.config.BigtableOptions;
-import com.google.cloud.bigtable.grpc.BigtableInstanceName;
 import com.google.cloud.bigtable.hbase.adapters.admin.ColumnDescriptorAdapter;
 import com.google.cloud.bigtable.hbase.adapters.admin.TableAdapter;
 import org.apache.hadoop.hbase.HColumnDescriptor;
@@ -40,8 +38,6 @@ import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
  */
 @InternalApi("For internal usage only")
 public class TableAdapter2x {
-  protected static final ColumnDescriptorAdapter columnDescriptorAdapter =
-      new ColumnDescriptorAdapter();
 
   public static CreateTableRequest adapt(TableDescriptor desc, byte[][] splitKeys) {
     return TableAdapter.adapt(new HTableDescriptor(desc), splitKeys);
@@ -53,11 +49,7 @@ public class TableAdapter2x {
     return new HTableDescriptor(desc).getColumnFamilies()[0];
   }
 
-  protected final BigtableInstanceName bigtableInstanceName;
-
-  public TableAdapter2x(BigtableOptions options) {
-    bigtableInstanceName = options.getInstanceName();
-  }
+  private TableAdapter2x() {}
 
   /**
    * adapt.
@@ -65,7 +57,7 @@ public class TableAdapter2x {
    * @param table a {@link Table} object.
    * @return a {@link TableDescriptor} object.
    */
-  public TableDescriptor adapt(Table table) {
-    return new TableAdapter(bigtableInstanceName).adapt(table);
+  public static TableDescriptor adapt(Table table) {
+    return TableAdapter.adapt(table);
   }
 }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase/com/google/cloud/bigtable/hbase2_x/adapters/admin/TestTableAdapter2x.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase/com/google/cloud/bigtable/hbase2_x/adapters/admin/TestTableAdapter2x.java
@@ -21,7 +21,6 @@ import com.google.bigtable.admin.v2.ColumnFamily;
 import com.google.bigtable.admin.v2.Table;
 import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
 import com.google.cloud.bigtable.admin.v2.models.GCRules;
-import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.hbase.adapters.admin.TableAdapter;
 import com.google.cloud.bigtable.hbase2_x.adapters.admin.TableAdapter2x;
 import org.apache.hadoop.hbase.HColumnDescriptor;
@@ -33,7 +32,6 @@ import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -48,15 +46,6 @@ public class TestTableAdapter2x {
       "projects/" + PROJECT_ID + "/instances/" + INSTANCE_ID;
   private static final String TABLE_NAME = INSTANCE_NAME + "/tables/" + TABLE_ID;
   private static final String COLUMN_FAMILY = "myColumnFamily";
-
-  private TableAdapter2x tableAdapter2x;
-
-  @Before
-  public void setUp() {
-    BigtableOptions bigtableOptions =
-        BigtableOptions.builder().setProjectId(PROJECT_ID).setInstanceId(INSTANCE_ID).build();
-    tableAdapter2x = new TableAdapter2x(bigtableOptions);
-  }
 
   @Test
   public void testAdaptWithSplitKeys() {
@@ -87,7 +76,7 @@ public class TestTableAdapter2x {
             .putColumnFamilies(COLUMN_FAMILY, columnFamily)
             .build();
     TableDescriptor actualTableDesc =
-        tableAdapter2x.adapt(com.google.cloud.bigtable.admin.v2.models.Table.fromProto(table));
+        TableAdapter2x.adapt(com.google.cloud.bigtable.admin.v2.models.Table.fromProto(table));
 
     TableDescriptor expected =
         new HTableDescriptor(TableName.valueOf(TABLE_ID))


### PR DESCRIPTION
`TableAdapter#adapt` does not need `BigtableInstanceName`, So this change will remove the member variable and update adapt() to be a static method.