### PR TITLE
chore: part 1 of replacing BigtableOptions to BigtableHBaseSettings

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
@@ -73,7 +73,7 @@ public abstract class AbstractBigtableConnection
   private BigtableSession session;
 
   private volatile boolean cleanupPool = false;
-  private final BigtableHBaseSettings baseSettings;
+  private final BigtableHBaseSettings settings;
 
   // A set of tables that have been disabled via BigtableAdmin.
   private Set<TableName> disabledTables = new HashSet<>();
@@ -111,7 +111,7 @@ public abstract class AbstractBigtableConnection
     }
 
     try {
-      this.baseSettings = BigtableHBaseSettings.create(conf);
+      this.settings = BigtableHBaseSettings.create(conf);
     } catch (IOException ioe) {
       LOG.error("Error loading BigtableOptions from Configuration.", ioe);
       throw ioe;
@@ -121,13 +121,13 @@ public abstract class AbstractBigtableConnection
     this.closed = false;
     this.session =
         new BigtableSession(
-            ((BigtableHBaseClassicSettings) this.baseSettings).getBigtableOptions());
+            ((BigtableHBaseClassicSettings) this.settings).getBigtableOptions());
   }
 
   /** {@inheritDoc} */
   @Override
   public Configuration getConfiguration() {
-    return this.baseSettings.getConfiguration();
+    return this.settings.getConfiguration();
   }
 
   /** {@inheritDoc} */
@@ -275,10 +275,10 @@ public abstract class AbstractBigtableConnection
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(AbstractBigtableConnection.class)
-        .add("project", baseSettings.getProjectId())
-        .add("instance", baseSettings.getInstanceId())
-        .add("dataHost", baseSettings.getDataHost())
-        .add("tableAdminHost", baseSettings.getAdminHost())
+        .add("project", settings.getProjectId())
+        .add("instance", settings.getInstanceId())
+        .add("dataHost", settings.getDataHost())
+        .add("tableAdminHost", settings.getAdminHost())
         .toString();
   }
 
@@ -307,15 +307,15 @@ public abstract class AbstractBigtableConnection
    * @return a {@link com.google.cloud.bigtable.config.BigtableOptions} object.
    */
   public BigtableOptions getOptions() {
-    if (baseSettings instanceof BigtableHBaseVeneerSettings) {
+    if (settings instanceof BigtableHBaseVeneerSettings) {
       throw new UnsupportedOperationException("veneer client is not yet supported");
     }
-    return ((BigtableHBaseClassicSettings) baseSettings).getBigtableOptions();
+    return ((BigtableHBaseClassicSettings) settings).getBigtableOptions();
   }
 
   @Override
   public BigtableHBaseSettings getBigtableHBaseSettings() {
-    return this.baseSettings;
+    return this.settings;
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
@@ -120,8 +120,7 @@ public abstract class AbstractBigtableConnection
     this.batchPool = pool;
     this.closed = false;
     this.session =
-        new BigtableSession(
-            ((BigtableHBaseClassicSettings) this.settings).getBigtableOptions());
+        new BigtableSession(((BigtableHBaseClassicSettings) this.settings).getBigtableOptions());
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/CommonConnection.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/CommonConnection.java
@@ -18,6 +18,7 @@ package org.apache.hadoop.hbase.client;
 import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.grpc.BigtableSession;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
@@ -55,6 +56,13 @@ public interface CommonConnection extends Closeable {
    * @return a {@link com.google.cloud.bigtable.config.BigtableOptions} object.
    */
   BigtableOptions getOptions();
+
+  /**
+   * Returns instance of bigtable settings for classic or veneer client.
+   *
+   * @return a {@link BigtableHBaseSettings} instance.
+   */
+  BigtableHBaseSettings getBigtableHBaseSettings();
 
   /**
    * Getter for the field <code>disabledTables</code>.

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncAdmin.java
@@ -26,13 +26,13 @@ import com.google.bigtable.admin.v2.Snapshot;
 import com.google.bigtable.admin.v2.SnapshotTableRequest;
 import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
 import com.google.cloud.bigtable.admin.v2.models.Table;
-import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.core.IBigtableTableAdminClient;
 import com.google.cloud.bigtable.grpc.BigtableClusterName;
 import com.google.cloud.bigtable.grpc.BigtableInstanceName;
 import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
 import com.google.cloud.bigtable.hbase.util.Logger;
 import com.google.cloud.bigtable.hbase.util.ModifyTableBuilder;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
 import com.google.cloud.bigtable.hbase2_x.adapters.admin.TableAdapter2x;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -105,10 +105,11 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
 
   public BigtableAsyncAdmin(CommonConnection asyncConnection) throws IOException {
     LOG.debug("Creating BigtableAsyncAdmin");
-    BigtableOptions options = asyncConnection.getOptions();
+    BigtableHBaseSettings settings = asyncConnection.getBigtableHBaseSettings();
     this.bigtableTableAdminClient = asyncConnection.getSession().getTableAdminClientWrapper();
     this.disabledTables = asyncConnection.getDisabledTables();
-    this.bigtableInstanceName = options.getInstanceName();
+    this.bigtableInstanceName =
+        new BigtableInstanceName(settings.getProjectId(), settings.getInstanceId());
     this.asyncConnection = asyncConnection;
 
     Configuration configuration = asyncConnection.getConfiguration();

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
@@ -62,7 +62,7 @@ public class BigtableAsyncConnection implements AsyncConnection, CommonConnectio
   private final Logger LOG = new Logger(getClass());
 
   private final BigtableSession session;
-  private final BigtableHBaseSettings baseSettings;
+  private final BigtableHBaseSettings settings;
   private volatile boolean closed = false;
 
   private final Set<TableName> disabledTables = Collections.synchronizedSet(new HashSet<>());
@@ -84,7 +84,7 @@ public class BigtableAsyncConnection implements AsyncConnection, CommonConnectio
     LOG.debug("Creating BigtableAsyncConnection");
 
     try {
-      baseSettings = BigtableHBaseSettings.create(conf);
+      settings = BigtableHBaseSettings.create(conf);
     } catch (IOException ioe) {
       LOG.error("Error loading BigtableOptions from Configuration.", ioe);
       throw ioe;
@@ -92,7 +92,7 @@ public class BigtableAsyncConnection implements AsyncConnection, CommonConnectio
 
     this.closed = false;
     this.session =
-        new BigtableSession(((BigtableHBaseClassicSettings) baseSettings).getBigtableOptions());
+        new BigtableSession(((BigtableHBaseClassicSettings) settings).getBigtableOptions());
   }
 
   public HBaseRequestAdapter createAdapter(TableName tableName) {
@@ -112,15 +112,15 @@ public class BigtableAsyncConnection implements AsyncConnection, CommonConnectio
   }
 
   public BigtableOptions getOptions() {
-    if (baseSettings instanceof BigtableHBaseVeneerSettings) {
+    if (settings instanceof BigtableHBaseVeneerSettings) {
       throw new UnsupportedOperationException("veneer client is not yet supported");
     }
-    return ((BigtableHBaseClassicSettings) this.baseSettings).getBigtableOptions();
+    return ((BigtableHBaseClassicSettings) this.settings).getBigtableOptions();
   }
 
   @Override
   public BigtableHBaseSettings getBigtableHBaseSettings() {
-    return this.baseSettings;
+    return this.settings;
   }
 
   public Set<TableName> getDisabledTables() {
@@ -138,7 +138,7 @@ public class BigtableAsyncConnection implements AsyncConnection, CommonConnectio
 
   @Override
   public Configuration getConfiguration() {
-    return this.baseSettings.getConfiguration();
+    return this.settings.getConfiguration();
   }
 
   @Override
@@ -382,12 +382,12 @@ public class BigtableAsyncConnection implements AsyncConnection, CommonConnectio
   @Override
   public List<HRegionInfo> getAllRegionInfos(TableName tableName) throws IOException {
     ServerName serverName =
-        ServerName.valueOf(baseSettings.getDataHost(), baseSettings.getPort(), 0);
+        ServerName.valueOf(settings.getDataHost(), settings.getPort(), 0);
     SampleRowKeysRequest.Builder request = SampleRowKeysRequest.newBuilder();
     request.setTableName(
         NameUtil.formatTableName(
-            baseSettings.getProjectId(),
-            baseSettings.getInstanceId(),
+            settings.getProjectId(),
+            settings.getInstanceId(),
             tableName.getQualifierAsString()));
     List<KeyOffset> sampleRowKeyResponse =
         this.session.getDataClientWrapper().sampleRowKeys(tableName.getNameAsString());

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
@@ -381,14 +381,11 @@ public class BigtableAsyncConnection implements AsyncConnection, CommonConnectio
 
   @Override
   public List<HRegionInfo> getAllRegionInfos(TableName tableName) throws IOException {
-    ServerName serverName =
-        ServerName.valueOf(settings.getDataHost(), settings.getPort(), 0);
+    ServerName serverName = ServerName.valueOf(settings.getDataHost(), settings.getPort(), 0);
     SampleRowKeysRequest.Builder request = SampleRowKeysRequest.newBuilder();
     request.setTableName(
         NameUtil.formatTableName(
-            settings.getProjectId(),
-            settings.getInstanceId(),
-            tableName.getQualifierAsString()));
+            settings.getProjectId(), settings.getInstanceId(), tableName.getQualifierAsString()));
     List<KeyOffset> sampleRowKeyResponse =
         this.session.getDataClientWrapper().sampleRowKeys(tableName.getNameAsString());
 


### PR DESCRIPTION
This is part-1 of series of pull requests.

This change introduces a getter in the `CommonConnection` interface, which would be used across `bigtable-hbase` and it's child module to fetch bigtable settings.