### PR TITLE
chore: part 2 of replacing BigtableOptions to BigtableHBaseSettings

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
@@ -696,7 +696,11 @@ public abstract class AbstractBigtableTable implements Table {
    */
   protected synchronized BatchExecutor getBatchExecutor() {
     if (batchExecutor == null) {
-      batchExecutor = new BatchExecutor(bigtableConnection.getSession(), hbaseAdapter);
+      batchExecutor =
+          new BatchExecutor(
+              bigtableConnection.getSession(),
+              bigtableConnection.getBigtableHBaseSettings(),
+              hbaseAdapter);
     }
     return batchExecutor;
   }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
@@ -22,6 +22,7 @@ import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.cloud.bigtable.hbase.util.Logger;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -64,18 +65,18 @@ public class BigtableBufferedMutator implements BufferedMutator {
    * Constructor for BigtableBufferedMutator.
    *
    * @param adapter Converts HBase objects to Bigtable protos
-   * @param configuration For Additional configuration. TODO: move this to options
+   * @param settings For bigtable settings
    * @param listener Handles exceptions. By default, it just throws the exception.
    * @param session a {@link BigtableSession} object.
    */
   public BigtableBufferedMutator(
       HBaseRequestAdapter adapter,
-      Configuration configuration,
+      BigtableHBaseSettings settings,
       BigtableSession session,
       BufferedMutator.ExceptionListener listener) {
-    helper = new BigtableBufferedMutatorHelper(adapter, configuration, session);
+    helper = new BigtableBufferedMutatorHelper(adapter, settings, session);
     this.listener = listener;
-    this.host = session.getOptions().getDataHost();
+    this.host = settings.getDataHost();
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/Adapters.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/Adapters.java
@@ -15,8 +15,6 @@
  */
 package com.google.cloud.bigtable.hbase.adapters;
 
-import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.ALLOW_NO_TIMESTAMP_RETRIES_KEY;
-
 import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.grpc.scanner.FlatRow;
 import com.google.cloud.bigtable.hbase.adapters.filters.BigtableWhileMatchResultScannerAdapter;
@@ -87,7 +85,7 @@ public final class Adapters {
    */
   public static PutAdapter createPutAdapter(BigtableHBaseSettings settings) {
     Configuration config = settings.getConfiguration();
-    boolean setClientTimestamp = !config.getBoolean(ALLOW_NO_TIMESTAMP_RETRIES_KEY, false);
+    boolean setClientTimestamp = !settings.isRetriesWithoutTimestampAllowed();
     return new PutAdapter(config.getInt("hbase.client.keyvalue.maxsize", -1), setClientTimestamp);
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/Adapters.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/Adapters.java
@@ -15,8 +15,9 @@
  */
 package com.google.cloud.bigtable.hbase.adapters;
 
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.ALLOW_NO_TIMESTAMP_RETRIES_KEY;
+
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.grpc.scanner.FlatRow;
 import com.google.cloud.bigtable.hbase.adapters.filters.BigtableWhileMatchResultScannerAdapter;
 import com.google.cloud.bigtable.hbase.adapters.filters.FilterAdapter;
@@ -26,6 +27,7 @@ import com.google.cloud.bigtable.hbase.adapters.read.GetAdapter;
 import com.google.cloud.bigtable.hbase.adapters.read.RowAdapter;
 import com.google.cloud.bigtable.hbase.adapters.read.RowRangeAdapter;
 import com.google.cloud.bigtable.hbase.adapters.read.ScanAdapter;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.Append;
 import org.apache.hadoop.hbase.client.Increment;
@@ -80,12 +82,12 @@ public final class Adapters {
   /**
    * createPutAdapter.
    *
-   * @param config a {@link org.apache.hadoop.conf.Configuration} object.
-   * @param options a {@link com.google.cloud.bigtable.config.BigtableOptions} object.
+   * @param settings a {@link org.apache.hadoop.conf.Configuration} object.
    * @return a {@link com.google.cloud.bigtable.hbase.adapters.PutAdapter} object.
    */
-  public static PutAdapter createPutAdapter(Configuration config, BigtableOptions options) {
-    boolean setClientTimestamp = !options.getRetryOptions().allowRetriesWithoutTimestamp();
+  public static PutAdapter createPutAdapter(BigtableHBaseSettings settings) {
+    Configuration config = settings.getConfiguration();
+    boolean setClientTimestamp = !config.getBoolean(ALLOW_NO_TIMESTAMP_RETRIES_KEY, false);
     return new PutAdapter(config.getInt("hbase.client.keyvalue.maxsize", -1), setClientTimestamp);
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
@@ -16,7 +16,7 @@
 package com.google.cloud.bigtable.hbase.adapters;
 
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.data.v2.internal.NameUtil;
 import com.google.cloud.bigtable.data.v2.models.Mutation;
 import com.google.cloud.bigtable.data.v2.models.MutationApi;
 import com.google.cloud.bigtable.data.v2.models.Query;
@@ -26,9 +26,9 @@ import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.hbase.adapters.read.DefaultReadHooks;
 import com.google.cloud.bigtable.hbase.adapters.read.ReadHooks;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Append;
 import org.apache.hadoop.hbase.client.Delete;
@@ -53,8 +53,8 @@ public class HBaseRequestAdapter {
     protected final HBaseMutationAdapter hbaseMutationAdapter;
     protected final RowMutationsAdapter rowMutationsAdapter;
 
-    public MutationAdapters(BigtableOptions options, Configuration config) {
-      this(Adapters.createPutAdapter(config, options));
+    public MutationAdapters(BigtableHBaseSettings settings) {
+      this(Adapters.createPutAdapter(settings));
     }
 
     @VisibleForTesting
@@ -76,26 +76,29 @@ public class HBaseRequestAdapter {
   /**
    * Constructor for HBaseRequestAdapter.
    *
-   * @param options a {@link com.google.cloud.bigtable.config.BigtableOptions} object.
+   * @param settings a {@link BigtableHBaseSettings} object.
    * @param tableName a {@link org.apache.hadoop.hbase.TableName} object.
-   * @param config a {@link org.apache.hadoop.conf.Configuration} object.
    */
-  public HBaseRequestAdapter(BigtableOptions options, TableName tableName, Configuration config) {
-    this(options, tableName, new MutationAdapters(options, config));
+  public HBaseRequestAdapter(BigtableHBaseSettings settings, TableName tableName) {
+    this(settings, tableName, new MutationAdapters(settings));
   }
 
   /**
    * Constructor for HBaseRequestAdapter.
    *
-   * @param options a {@link BigtableOptions} object.
+   * @param settings a {@link BigtableHBaseSettings} object.
    * @param tableName a {@link TableName} object.
    * @param mutationAdapters a {@link MutationAdapters} object.
    */
   public HBaseRequestAdapter(
-      BigtableOptions options, TableName tableName, MutationAdapters mutationAdapters) {
+      BigtableHBaseSettings settings, TableName tableName, MutationAdapters mutationAdapters) {
     this(
         tableName,
-        options.getInstanceName().toTableName(tableName.getQualifierAsString()),
+        new BigtableTableName(
+            NameUtil.formatTableName(
+                settings.getProjectId(),
+                settings.getInstanceId(),
+                tableName.getQualifierAsString())),
         mutationAdapters);
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
@@ -145,19 +145,18 @@ public abstract class AbstractBigtableConnection
 
     HBaseRequestAdapter adapter = createAdapter(tableName);
     ExceptionListener listener = params.getListener();
-    return new BigtableBufferedMutator(adapter, getConfiguration(), session, listener);
+    return new BigtableBufferedMutator(adapter, settings, session, listener);
   }
 
   public HBaseRequestAdapter createAdapter(TableName tableName) {
     if (mutationAdapters == null) {
       synchronized (this) {
         if (mutationAdapters == null) {
-          mutationAdapters =
-              new HBaseRequestAdapter.MutationAdapters(getOptions(), getConfiguration());
+          mutationAdapters = new HBaseRequestAdapter.MutationAdapters(settings);
         }
       }
     }
-    return new HBaseRequestAdapter(getOptions(), tableName, mutationAdapters);
+    return new HBaseRequestAdapter(settings, tableName, mutationAdapters);
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/PutMicroBenchmark.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/PutMicroBenchmark.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.bigtable.hbase;
 
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.CUSTOM_USER_AGENT_KEY;
+
 import com.google.bigtable.v2.MutateRowRequest;
 import com.google.bigtable.v2.MutateRowResponse;
 import com.google.cloud.bigtable.data.v2.internal.RequestContext;
@@ -42,7 +44,7 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.util.Bytes;
 
-// TODO(rahulkql): If possible remove/update this class to bigtable-1.x-benchmark.
+// TODO(rahulkql): If possible move this class to bigtable-1.x-benchmark.
 public class PutMicroBenchmark {
   static final int NUM_CELLS = 10;
   private static final byte[] COLUMN_FAMILY = Bytes.toBytes("test_family");
@@ -58,7 +60,7 @@ public class PutMicroBenchmark {
     String tableId = args.length > 2 ? args[2] : "table";
 
     Configuration configuration = BigtableConfiguration.configure(projectId, instanceId);
-    configuration.set(BigtableOptionsFactory.CUSTOM_USER_AGENT_KEY, "put_microbenchmark");
+    configuration.set(CUSTOM_USER_AGENT_KEY, "put_microbenchmark");
     settings = BigtableHBaseSettings.create(configuration);
 
     boolean useRealConnection = args.length >= 2;

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.api.core.ApiFutures;
 import com.google.api.core.SettableApiFuture;
-import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.core.IBigtableDataClient;
 import com.google.cloud.bigtable.core.IBulkMutation;
 import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
@@ -32,6 +31,7 @@ import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
 import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -95,13 +95,11 @@ public class TestBigtableBufferedMutator {
     configuration.set(BigtableOptionsFactory.PROJECT_ID_KEY, "project");
     configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, "instance");
 
-    BigtableOptions options = BigtableOptionsFactory.fromConfiguration(configuration);
-    HBaseRequestAdapter adapter =
-        new HBaseRequestAdapter(options, TableName.valueOf("TABLE"), configuration);
+    BigtableHBaseSettings settings = BigtableHBaseSettings.create(configuration);
+    HBaseRequestAdapter adapter = new HBaseRequestAdapter(settings, TableName.valueOf("TABLE"));
 
     executorService = Executors.newCachedThreadPool();
-    when(mockSession.getOptions()).thenReturn(options);
-    return new BigtableBufferedMutator(adapter, configuration, mockSession, listener);
+    return new BigtableBufferedMutator(adapter, settings, mockSession, listener);
   }
 
   @Test

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
@@ -25,8 +25,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.bigtable.v2.ReadRowsRequest;
-import com.google.cloud.bigtable.config.BigtableOptions;
-import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.cloud.bigtable.core.IBigtableDataClient;
 import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.cloud.bigtable.data.v2.models.Query;
@@ -35,6 +33,7 @@ import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.grpc.scanner.FlatRow;
 import com.google.cloud.bigtable.grpc.scanner.ResultScanner;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.util.Arrays;
@@ -86,25 +85,16 @@ public class TestBigtableTable {
   public AbstractBigtableTable table;
 
   @Before
-  public void setup() {
-    BigtableOptions options =
-        BigtableOptions.builder()
-            .setAdminHost("localhost")
-            .setDataHost("localhost")
-            .setPort(0)
-            .setProjectId(TEST_PROJECT)
-            .setInstanceId(TEST_INSTANCE)
-            .setRetryOptions(RetryOptions.builder().setEnableRetries(false).build())
-            .setCredentialOptions(null)
-            .setUserAgent("testAgent")
-            .build();
-
+  public void setup() throws IOException {
     Configuration config = new Configuration(false);
+    config.set(BigtableOptionsFactory.PROJECT_ID_KEY, "project");
+    config.set(BigtableOptionsFactory.INSTANCE_ID_KEY, "instance");
+
+    BigtableHBaseSettings settings = BigtableHBaseSettings.create(config);
     TableName tableName = TableName.valueOf(TEST_TABLE);
-    HBaseRequestAdapter hbaseAdapter = new HBaseRequestAdapter(options, tableName, config);
+    HBaseRequestAdapter hbaseAdapter = new HBaseRequestAdapter(settings, tableName);
     when(mockConnection.getConfiguration()).thenReturn(config);
     when(mockConnection.getSession()).thenReturn(mockSession);
-    when(mockSession.getOptions()).thenReturn(options);
     when(mockSession.getDataClientWrapper()).thenReturn(mockBigtableDataClient);
     when(mockBigtableDataClient.readFlatRows(isA(Query.class))).thenReturn(mockResultScanner);
     table = new AbstractBigtableTable(mockConnection, hbaseAdapter) {};

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
@@ -89,8 +89,14 @@ public class TestBigtableTable {
     Configuration config = new Configuration(false);
     config.set(BigtableOptionsFactory.PROJECT_ID_KEY, "project");
     config.set(BigtableOptionsFactory.INSTANCE_ID_KEY, "instance");
-
+    config.set(BigtableOptionsFactory.BIGTABLE_ADMIN_HOST_KEY, "localhost");
+    config.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, "localhost");
+    config.set(BigtableOptionsFactory.BIGTABLE_PORT_KEY, "0");
+    config.set(BigtableOptionsFactory.ENABLE_GRPC_RETRIES_KEY, "false");
+    config.set(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, "true");
+    config.set(BigtableOptionsFactory.CUSTOM_USER_AGENT_KEY, "testAgent");
     BigtableHBaseSettings settings = BigtableHBaseSettings.create(config);
+
     TableName tableName = TableName.valueOf(TEST_TABLE);
     HBaseRequestAdapter hbaseAdapter = new HBaseRequestAdapter(settings, tableName);
     when(mockConnection.getConfiguration()).thenReturn(config);

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncBufferedMutator.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncBufferedMutator.java
@@ -21,6 +21,7 @@ import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.hbase.BigtableBufferedMutatorHelper;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -43,12 +44,12 @@ public class BigtableAsyncBufferedMutator implements AsyncBufferedMutator {
    * Constructor for BigtableBufferedMutator.
    *
    * @param adapter Converts HBase objects to Bigtable protos
-   * @param configuration For Additional configuration. TODO: move this to options
+   * @param settings For bigtable settings.
    * @param session a {@link com.google.cloud.bigtable.grpc.BigtableSession}
    */
   public BigtableAsyncBufferedMutator(
-      HBaseRequestAdapter adapter, Configuration configuration, BigtableSession session) {
-    helper = new BigtableBufferedMutatorHelper(adapter, configuration, session);
+      HBaseRequestAdapter adapter, BigtableHBaseSettings settings, BigtableSession session) {
+    helper = new BigtableBufferedMutatorHelper(adapter, settings, session);
   }
 
   /** {@inheritDoc} */

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTable.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTable.java
@@ -92,7 +92,9 @@ public class BigtableAsyncTable implements AsyncTable<ScanResultConsumer> {
 
   protected synchronized BatchExecutor getBatchExecutor() {
     if (batchExecutor == null) {
-      batchExecutor = new BatchExecutor(connection.getSession(), hbaseAdapter);
+      batchExecutor =
+          new BatchExecutor(
+              connection.getSession(), connection.getBigtableHBaseSettings(), hbaseAdapter);
     }
     return batchExecutor;
   }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
@@ -99,12 +99,11 @@ public class BigtableAsyncConnection implements AsyncConnection, CommonConnectio
     if (mutationAdapters == null) {
       synchronized (this) {
         if (mutationAdapters == null) {
-          mutationAdapters =
-              new HBaseRequestAdapter.MutationAdapters(getOptions(), getConfiguration());
+          mutationAdapters = new HBaseRequestAdapter.MutationAdapters(settings);
         }
       }
     }
-    return new HBaseRequestAdapter(getOptions(), tableName, mutationAdapters);
+    return new HBaseRequestAdapter(settings, tableName, mutationAdapters);
   }
 
   public BigtableSession getSession() {
@@ -233,8 +232,7 @@ public class BigtableAsyncConnection implements AsyncConnection, CommonConnectio
 
       @Override
       public AsyncBufferedMutator build() {
-        return new BigtableAsyncBufferedMutator(
-            createAdapter(tableName), getConfiguration(), session);
+        return new BigtableAsyncBufferedMutator(createAdapter(tableName), settings, session);
       }
     };
   }


### PR DESCRIPTION
This change updated `BigtableBufferedMutator`, `BigtableBufferedMutatorHelper`, `HBaseRequestAdapter` constructor to accept `BigtableHBaseSetting` instead of `BigtableOptions`.