### PR TITLE
chore: add new getter for allowRetriesWithoutTimestamp

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BigtableHBaseSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BigtableHBaseSettings.java
@@ -75,11 +75,8 @@ public abstract class BigtableHBaseSettings {
 
   public abstract long getBatchingMaxRequestSize();
 
-  /**
-   * This represents settings to allows mutation retries without timestamp. This is equivalent to
-   * allow server-side timestamp.
-   */
-  public abstract boolean allowRetriesWithoutTimestamp();
+  // This is equivalent to allow server-side timestamp.
+  public abstract boolean isRetriesWithoutTimestampAllowed();
 
   protected String getRequiredValue(String key, String displayName) {
     String value = configuration.get(key);

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BigtableHBaseSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BigtableHBaseSettings.java
@@ -75,6 +75,12 @@ public abstract class BigtableHBaseSettings {
 
   public abstract long getBatchingMaxRequestSize();
 
+  /**
+   * This represents settings to allows mutation retries without timestamp. This is equivalent to
+   * allow server-side timestamp.
+   */
+  public abstract boolean allowRetriesWithoutTimestamp();
+
   protected String getRequiredValue(String key, String displayName) {
     String value = configuration.get(key);
     Preconditions.checkArgument(

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BigtableHBaseClassicSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BigtableHBaseClassicSettings.java
@@ -137,6 +137,11 @@ public class BigtableHBaseClassicSettings extends BigtableHBaseSettings {
     return bigtableOptions.getBulkOptions().getMaxMemory();
   }
 
+  @Override
+  public boolean allowRetriesWithoutTimestamp() {
+    return bigtableOptions.getRetryOptions().allowRetriesWithoutTimestamp();
+  }
+
   public BigtableOptions getBigtableOptions() {
     return bigtableOptions;
   }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BigtableHBaseClassicSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BigtableHBaseClassicSettings.java
@@ -138,7 +138,7 @@ public class BigtableHBaseClassicSettings extends BigtableHBaseSettings {
   }
 
   @Override
-  public boolean allowRetriesWithoutTimestamp() {
+  public boolean isRetriesWithoutTimestampAllowed() {
     return bigtableOptions.getRetryOptions().allowRetriesWithoutTimestamp();
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BigtableHBaseVeneerSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BigtableHBaseVeneerSettings.java
@@ -118,6 +118,7 @@ public class BigtableHBaseVeneerSettings extends BigtableHBaseSettings {
   private final int bulkMaxRowKeyCount;
   private final long batchingMaxMemory;
   private final boolean isChannelPoolCachingEnabled;
+  private final boolean allowRetriesWithoutTimestamp;
 
   public BigtableHBaseVeneerSettings(Configuration configuration) throws IOException {
     super(configuration);
@@ -165,6 +166,9 @@ public class BigtableHBaseVeneerSettings extends BigtableHBaseSettings {
     } else {
       this.isChannelPoolCachingEnabled = false;
     }
+
+    this.allowRetriesWithoutTimestamp =
+        Boolean.parseBoolean(configuration.get(ALLOW_NO_TIMESTAMP_RETRIES_KEY));
   }
 
   @Override
@@ -190,6 +194,11 @@ public class BigtableHBaseVeneerSettings extends BigtableHBaseSettings {
   @Override
   public long getBatchingMaxRequestSize() {
     return batchingMaxMemory;
+  }
+
+  @Override
+  public boolean allowRetriesWithoutTimestamp() {
+    return allowRetriesWithoutTimestamp;
   }
 
   // ************** Getters **************
@@ -223,11 +232,6 @@ public class BigtableHBaseVeneerSettings extends BigtableHBaseSettings {
     String appProfileId = configuration.get(APP_PROFILE_ID_KEY);
     if (!isNullOrEmpty(appProfileId)) {
       dataBuilder.setAppProfileId(appProfileId);
-    }
-
-    // added this check here to fail fast
-    if (Boolean.parseBoolean(configuration.get(ALLOW_NO_TIMESTAMP_RETRIES_KEY))) {
-      throw new UnsupportedOperationException("Retries without Timestamp is not supported.");
     }
 
     EnhancedBigtableStubSettings.Builder stubSettings = dataBuilder.stubSettings();

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BigtableHBaseVeneerSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BigtableHBaseVeneerSettings.java
@@ -197,7 +197,7 @@ public class BigtableHBaseVeneerSettings extends BigtableHBaseSettings {
   }
 
   @Override
-  public boolean allowRetriesWithoutTimestamp() {
+  public boolean isRetriesWithoutTimestampAllowed() {
     return allowRetriesWithoutTimestamp;
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBigtableHBaseClassicSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBigtableHBaseClassicSettings.java
@@ -176,4 +176,31 @@ public class TestBigtableHBaseClassicSettings {
 
     Assert.assertSame(credentials, actualCreds);
   }
+
+  @Test
+  public void testClassicSettingsGetters() throws IOException {
+    configuration.set(BigtableOptionsFactory.BIGTABLE_ADMIN_HOST_KEY, "localhost");
+    configuration.set(BigtableOptionsFactory.BIGTABLE_PORT_KEY, "8080");
+    configuration.set(BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:8080");
+    configuration.set(BigtableOptionsFactory.APP_PROFILE_ID_KEY, "test");
+    configuration.set(BigtableOptionsFactory.BIGTABLE_BULK_MAX_ROW_KEY_COUNT, "100");
+    configuration.set(BigtableOptionsFactory.BIGTABLE_BUFFERED_MUTATOR_MAX_MEMORY_KEY, "2000");
+    configuration.set(BigtableOptionsFactory.ALLOW_NO_TIMESTAMP_RETRIES_KEY, "true");
+    configuration.set(BigtableOptionsFactory.BIGTABLE_BUFFERED_MUTATOR_ENABLE_THROTTLING, "true");
+    configuration.set(
+        BigtableOptionsFactory.BIGTABLE_BUFFERED_MUTATOR_THROTTLING_THRESHOLD_MILLIS, "500");
+    BigtableHBaseSettings settings = BigtableHBaseSettings.create(configuration);
+
+    assertEquals(TEST_HOST, settings.getDataHost());
+    assertEquals("localhost", settings.getAdminHost());
+    assertEquals(8080, settings.getPort());
+    assertEquals(100, settings.getBulkMaxRowCount());
+    assertEquals(2000, settings.getBatchingMaxRequestSize());
+    assertTrue(settings.isRetriesWithoutTimestampAllowed());
+
+    BigtableOptions options = ((BigtableHBaseClassicSettings) settings).getBigtableOptions();
+    assertEquals("test", options.getAppProfileId());
+    assertTrue(options.getBulkOptions().isEnableBulkMutationThrottling());
+    assertEquals(500, options.getBulkOptions().getBulkMutationRpcTargetMs());
+  }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBigtableHBaseClassicSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBigtableHBaseClassicSettings.java
@@ -116,7 +116,7 @@ public class TestBigtableHBaseClassicSettings {
     configuration.setLong(BIGTABLE_BUFFERED_MUTATOR_MAX_MEMORY_KEY, 100_000L);
 
     BigtableHBaseSettings settings = BigtableHBaseSettings.create(configuration);
-    assertTrue(settings.allowRetriesWithoutTimestamp());
+    assertTrue(settings.isRetriesWithoutTimestampAllowed());
 
     BigtableOptions options = ((BigtableHBaseClassicSettings) settings).getBigtableOptions();
     assertEquals(TEST_HOST, options.getDataHost());

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBigtableHBaseClassicSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBigtableHBaseClassicSettings.java
@@ -112,12 +112,13 @@ public class TestBigtableHBaseClassicSettings {
     configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_USE_SERVICE_ACCOUNTS_KEY, false);
     configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, true);
+    configuration.setBoolean(BigtableOptionsFactory.ALLOW_NO_TIMESTAMP_RETRIES_KEY, true);
     configuration.setLong(BIGTABLE_BUFFERED_MUTATOR_MAX_MEMORY_KEY, 100_000L);
 
-    BigtableOptions options =
-        ((BigtableHBaseClassicSettings) BigtableHBaseSettings.create(configuration))
-            .getBigtableOptions();
+    BigtableHBaseSettings settings = BigtableHBaseSettings.create(configuration);
+    assertTrue(settings.allowRetriesWithoutTimestamp());
 
+    BigtableOptions options = ((BigtableHBaseClassicSettings) settings).getBigtableOptions();
     assertEquals(TEST_HOST, options.getDataHost());
     assertEquals(TEST_PROJECT_ID, options.getProjectId());
     assertEquals(TEST_INSTANCE_ID, options.getInstanceId());

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBigtableHBaseVeneerSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBigtableHBaseVeneerSettings.java
@@ -125,7 +125,7 @@ public class TestBigtableHBaseVeneerSettings {
         credentials, dataSettings.getStubSettings().getCredentialsProvider().getCredentials());
 
     assertTrue(settingUtils.isChannelPoolCachingEnabled());
-    assertTrue(settingUtils.allowRetriesWithoutTimestamp());
+    assertTrue(settingUtils.isRetriesWithoutTimestampAllowed());
   }
 
   @Test

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBigtableHBaseVeneerSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBigtableHBaseVeneerSettings.java
@@ -63,7 +63,6 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -104,6 +103,7 @@ public class TestBigtableHBaseVeneerSettings {
     configuration.setInt(BIGTABLE_DATA_CHANNEL_COUNT_KEY, 3);
     configuration.set(BIGTABLE_USE_CACHED_DATA_CHANNEL_POOL, "true");
     configuration.set(BIGTABLE_USE_SERVICE_ACCOUNTS_KEY, "true");
+    configuration.set(ALLOW_NO_TIMESTAMP_RETRIES_KEY, "true");
     configuration = BigtableConfiguration.withCredentials(configuration, credentials);
 
     BigtableHBaseVeneerSettings settingUtils =
@@ -125,6 +125,7 @@ public class TestBigtableHBaseVeneerSettings {
         credentials, dataSettings.getStubSettings().getCredentialsProvider().getCredentials());
 
     assertTrue(settingUtils.isChannelPoolCachingEnabled());
+    assertTrue(settingUtils.allowRetriesWithoutTimestamp());
   }
 
   @Test
@@ -209,21 +210,6 @@ public class TestBigtableHBaseVeneerSettings {
     assertEquals(initialElapsedMs, readRowsRetrySettings.getInitialRetryDelay().toMillis());
     assertEquals(maxAttempt, readRowsRetrySettings.getMaxAttempts());
     assertEquals(readRowStreamTimeout, readRowsRetrySettings.getTotalTimeout().toMillis());
-  }
-
-  @Test
-  public void testRetriesWithoutTimestamp() throws IOException {
-    configuration.setBoolean(BIGTABLE_USE_PLAINTEXT_NEGOTIATION, true);
-    configuration.setBoolean(ALLOW_NO_TIMESTAMP_RETRIES_KEY, true);
-
-    try {
-      ((BigtableHBaseVeneerSettings) BigtableHBaseVeneerSettings.create(configuration))
-          .getDataSettings();
-      Assert.fail("BigtableDataSettings should not support retries without timestamp");
-    } catch (UnsupportedOperationException actualException) {
-
-      assertEquals("Retries without Timestamp is not supported.", actualException.getMessage());
-    }
   }
 
   @Test


### PR DESCRIPTION
This change introduces a new getter in `BigtableHBaseSetting` for `allowRetriesWithoutTimestamp()`. Both classic & veneer supports mutation with server side timestamp.