### PR TITLE
chore: part 3 of replacing BigtableOptions to BigtableHBaseSettings

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableRegionLocator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableRegionLocator.java
@@ -20,12 +20,13 @@ import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.ApiFutures;
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.core.IBigtableDataClient;
+import com.google.cloud.bigtable.data.v2.internal.NameUtil;
 import com.google.cloud.bigtable.data.v2.models.KeyOffset;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.hbase.adapters.SampledRowKeysAdapter;
 import com.google.cloud.bigtable.hbase.util.Logger;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.util.List;
@@ -56,11 +57,16 @@ public abstract class AbstractBigtableRegionLocator {
   private long regionsFetchTimeMillis;
 
   public AbstractBigtableRegionLocator(
-      TableName tableName, BigtableOptions options, IBigtableDataClient client) {
+      TableName tableName, BigtableHBaseSettings settings, IBigtableDataClient client) {
     this.tableName = tableName;
     this.client = client;
-    this.bigtableTableName = options.getInstanceName().toTableName(tableName.getNameAsString());
-    ServerName serverName = ServerName.valueOf(options.getDataHost(), options.getPort(), 0);
+    this.bigtableTableName =
+        new BigtableTableName(
+            NameUtil.formatTableName(
+                settings.getProjectId(),
+                settings.getInstanceId(),
+                tableName.getQualifierAsString()));
+    ServerName serverName = ServerName.valueOf(settings.getDataHost(), settings.getPort(), 0);
     this.adapter = getSampledRowKeysAdapter(tableName, serverName);
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableRegionLocator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableRegionLocator.java
@@ -16,9 +16,9 @@
 package com.google.cloud.bigtable.hbase;
 
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.core.IBigtableDataClient;
 import com.google.cloud.bigtable.hbase.util.Logger;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -44,12 +44,12 @@ public abstract class BigtableRegionLocator extends AbstractBigtableRegionLocato
    * Constructor for BigtableRegionLocator.
    *
    * @param tableName a {@link TableName} object.
-   * @param options a {@link BigtableOptions} object.
+   * @param settings a {@link BigtableHBaseSettings} object.
    * @param client a {@link IBigtableDataClient} object.
    */
   public BigtableRegionLocator(
-      TableName tableName, BigtableOptions options, IBigtableDataClient client) {
-    super(tableName, options, client);
+      TableName tableName, BigtableHBaseSettings settings, IBigtableDataClient client) {
+    super(tableName, settings, client);
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
@@ -188,7 +188,7 @@ public abstract class AbstractBigtableConnection
 
     if (locator == null) {
       locator =
-          new BigtableRegionLocator(tableName, getOptions(), getSession().getDataClientWrapper()) {
+          new BigtableRegionLocator(tableName, settings, getSession().getDataClientWrapper()) {
 
             @Override
             public SampledRowKeysAdapter getSampledRowKeysAdapter(

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
@@ -16,6 +16,8 @@
 package com.google.cloud.bigtable.hbase;
 
 import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -87,8 +89,8 @@ public class TestBigtableTable {
   @Before
   public void setup() throws IOException {
     Configuration config = new Configuration(false);
-    config.set(BigtableOptionsFactory.PROJECT_ID_KEY, "project");
-    config.set(BigtableOptionsFactory.INSTANCE_ID_KEY, "instance");
+    config.set(BigtableOptionsFactory.PROJECT_ID_KEY, TEST_PROJECT);
+    config.set(BigtableOptionsFactory.INSTANCE_ID_KEY, TEST_INSTANCE);
     config.set(BigtableOptionsFactory.BIGTABLE_ADMIN_HOST_KEY, "localhost");
     config.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, "localhost");
     config.set(BigtableOptionsFactory.BIGTABLE_PORT_KEY, "0");
@@ -101,6 +103,7 @@ public class TestBigtableTable {
     HBaseRequestAdapter hbaseAdapter = new HBaseRequestAdapter(settings, tableName);
     when(mockConnection.getConfiguration()).thenReturn(config);
     when(mockConnection.getSession()).thenReturn(mockSession);
+    when(mockConnection.getBigtableHBaseSettings()).thenReturn(settings);
     when(mockSession.getDataClientWrapper()).thenReturn(mockBigtableDataClient);
     when(mockBigtableDataClient.readFlatRows(isA(Query.class))).thenReturn(mockResultScanner);
     table = new AbstractBigtableTable(mockConnection, hbaseAdapter) {};
@@ -239,5 +242,14 @@ public class TestBigtableTable {
 
     verify(mockBigtableDataClient).readFlatRows(isA(Query.class));
     verify(mockResultScanner).next();
+  }
+
+  @Test
+  public void testToString() {
+    String abstractTableToStr = table.toString();
+    assertThat(abstractTableToStr, containsString("project=" + TEST_PROJECT));
+    assertThat(abstractTableToStr, containsString("instance=" + TEST_INSTANCE));
+    assertThat(abstractTableToStr, containsString("table=" + TEST_TABLE));
+    assertThat(abstractTableToStr, containsString("host=" + "localhost"));
   }
 }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTableRegionLocator.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTableRegionLocator.java
@@ -16,10 +16,10 @@
 package com.google.cloud.bigtable.hbase2_x;
 
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.core.IBigtableDataClient;
 import com.google.cloud.bigtable.hbase.AbstractBigtableRegionLocator;
 import com.google.cloud.bigtable.hbase.adapters.SampledRowKeysAdapter;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.apache.hadoop.hbase.HRegionLocation;
@@ -40,8 +40,8 @@ public class BigtableAsyncTableRegionLocator extends AbstractBigtableRegionLocat
   HRegionLocation hRegionLocation = null;
 
   public BigtableAsyncTableRegionLocator(
-      TableName tableName, BigtableOptions options, IBigtableDataClient client) {
-    super(tableName, options, client);
+      TableName tableName, BigtableHBaseSettings settings, IBigtableDataClient client) {
+    super(tableName, settings, client);
   }
 
   @Override

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
@@ -311,8 +311,7 @@ public class BigtableAsyncConnection implements AsyncConnection, CommonConnectio
 
   @Override
   public AsyncTableRegionLocator getRegionLocator(TableName tableName) {
-    return new BigtableAsyncTableRegionLocator(
-        tableName, getOptions(), this.session.getDataClientWrapper());
+    return new BigtableAsyncTableRegionLocator(tableName, settings, session.getDataClientWrapper());
   }
 
   @Override


### PR DESCRIPTION
This change updates `AbstractBigtableRegionLocator` and `AbstractBigtableTable` and it's references.