### PR TITLE
chore: delegated non-async operations to use async methods

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.hbase;
 
 import com.google.api.core.InternalApi;
+import com.google.api.gax.rpc.ApiExceptions;
 import com.google.cloud.bigtable.core.IBigtableDataClient;
 import com.google.cloud.bigtable.data.v2.models.ConditionalRowMutation;
 import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
@@ -462,7 +463,8 @@ public abstract class AbstractBigtableTable implements Table {
       throws IOException {
     Span span = TRACER.spanBuilder("BigtableTable." + type).startSpan();
     try (Scope scope = TRACER.withSpan(span)) {
-      Boolean wasApplied = clientWrapper.checkAndMutateRow(request);
+      Boolean wasApplied =
+          ApiExceptions.callAndTranslateApiException(clientWrapper.checkAndMutateRowAsync(request));
       return CheckAndMutateUtil.wasMutationApplied(request, wasApplied);
     } catch (Throwable t) {
       span.setStatus(Status.UNKNOWN);
@@ -476,7 +478,7 @@ public abstract class AbstractBigtableTable implements Table {
       throws IOException {
     Span span = TRACER.spanBuilder("BigtableTable." + type).startSpan();
     try (Scope scope = TRACER.withSpan(span)) {
-      clientWrapper.mutateRow(rowMutation);
+      ApiExceptions.callAndTranslateApiException(clientWrapper.mutateRowAsync(rowMutation));
     } catch (Throwable t) {
       span.setStatus(Status.UNKNOWN);
       throw logAndCreateIOException(type, mutation.getRow(), t);
@@ -494,7 +496,8 @@ public abstract class AbstractBigtableTable implements Table {
     }
     Span span = TRACER.spanBuilder("BigtableTable.mutateRow").startSpan();
     try (Scope scope = TRACER.withSpan(span)) {
-      clientWrapper.mutateRow(hbaseAdapter.adapt(rowMutations));
+      ApiExceptions.callAndTranslateApiException(
+          clientWrapper.mutateRowAsync(hbaseAdapter.adapt(rowMutations)));
     } catch (Throwable t) {
       span.setStatus(Status.UNKNOWN);
       throw logAndCreateIOException("mutateRow", rowMutations.getRow(), t);

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/pom.xml
@@ -88,6 +88,10 @@ limitations under the License.
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>com.google.api</groupId>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableTable.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableTable.java
@@ -16,6 +16,8 @@
 package com.google.cloud.bigtable.hbase2_x;
 
 import com.google.api.core.InternalApi;
+import com.google.api.gax.rpc.ApiExceptions;
+import com.google.cloud.bigtable.data.v2.models.ConditionalRowMutation;
 import com.google.cloud.bigtable.hbase.AbstractBigtableTable;
 import com.google.cloud.bigtable.hbase.adapters.CheckAndMutateUtil;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
@@ -223,8 +225,11 @@ public class BigtableTable extends AbstractBigtableTable {
       }
 
       private boolean call() {
-        Boolean response = clientWrapper.checkAndMutateRow(builder.build());
-        return CheckAndMutateUtil.wasMutationApplied(builder.build(), response);
+        ConditionalRowMutation conditionalRowMutation = builder.build();
+        Boolean response =
+            ApiExceptions.callAndTranslateApiException(
+                clientWrapper.checkAndMutateRowAsync(conditionalRowMutation));
+        return CheckAndMutateUtil.wasMutationApplied(conditionalRowMutation, response);
       }
     };
   }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
@@ -16,6 +16,7 @@
 package org.apache.hadoop.hbase.client;
 
 import com.google.api.core.InternalApi;
+import com.google.api.gax.rpc.ApiExceptions;
 import com.google.bigtable.v2.SampleRowKeysRequest;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.data.v2.internal.NameUtil;
@@ -384,7 +385,8 @@ public class BigtableAsyncConnection implements AsyncConnection, CommonConnectio
         NameUtil.formatTableName(
             settings.getProjectId(), settings.getInstanceId(), tableName.getQualifierAsString()));
     List<KeyOffset> sampleRowKeyResponse =
-        this.session.getDataClientWrapper().sampleRowKeys(tableName.getNameAsString());
+        ApiExceptions.callAndTranslateApiException(
+            this.session.getDataClientWrapper().sampleRowKeysAsync(tableName.getNameAsString()));
 
     return getSampledRowKeysAdapter(tableName, serverName).adaptResponse(sampleRowKeyResponse)
         .stream()


### PR DESCRIPTION
This change delegates Data & Admin client's non-async call from async operations.
 - For AdminClient, all non-async methods are now delegating.
 - For DataClient, only `mutateRow()`, `checkAndMutateRow()` and `sampleRowKeys()` are delegating as the rest of the operation have model changes.