### PR TITLE
feat: tune default settings to align with java-bigtable

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -94,10 +94,15 @@ public class BigtableOptions implements Serializable, Cloneable {
   private static final Logger LOG = new Logger(BigtableOptions.class);
 
   private static int getDefaultDataChannelCount() {
-    // 20 Channels seemed to work well on a 4 CPU machine, and this ratio seems to scale well for
-    // higher CPU machines. Use no more than 250 Channels by default.
+    // Use no more than 250 Channels by default.
     int availableProcessors = Runtime.getRuntime().availableProcessors();
-    return Math.min(250, Math.max(1, availableProcessors * 4));
+    return Math.min(250, Math.max(1, availableProcessors * 2));
+  }
+
+  private static int getDefaultMaxInflightRpcCount() {
+    int maxInflightRpcCount =
+        BulkOptions.BIGTABLE_MAX_INFLIGHT_RPCS_PER_CHANNEL_DEFAULT * getDefaultDataChannelCount();
+    return Math.min(20_000, maxInflightRpcCount);
   }
 
   public static BigtableOptions getDefaultOptions() {
@@ -154,11 +159,7 @@ public class BigtableOptions implements Serializable, Cloneable {
       options.useGCJClient = false;
 
       options.bulkOptions =
-          BulkOptions.builder()
-              .setMaxInflightRpcs(
-                  BulkOptions.BIGTABLE_MAX_INFLIGHT_RPCS_PER_CHANNEL_DEFAULT
-                      * options.dataChannelCount)
-              .build();
+          BulkOptions.builder().setMaxInflightRpcs(getDefaultMaxInflightRpcCount()).build();
 
       options.retryOptions = new RetryOptions.Builder().build();
       options.callOptionsConfig = CallOptionsConfig.builder().build();
@@ -339,10 +340,12 @@ public class BigtableOptions implements Serializable, Cloneable {
     public BigtableOptions build() {
       Preconditions.checkNotNull(options.bulkOptions, "bulk options cannot be null");
       if (options.bulkOptions.getMaxInflightRpcs() <= 0) {
-        int maxInflightRpcs =
-            BulkOptions.BIGTABLE_MAX_INFLIGHT_RPCS_PER_CHANNEL_DEFAULT * options.dataChannelCount;
         options.bulkOptions =
-            options.bulkOptions.toBuilder().setMaxInflightRpcs(maxInflightRpcs).build();
+            options
+                .bulkOptions
+                .toBuilder()
+                .setMaxInflightRpcs(getDefaultMaxInflightRpcCount())
+                .build();
       }
       applyEmulatorEnvironment();
       options.adminHost = Preconditions.checkNotNull(options.adminHost);

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -94,9 +94,10 @@ public class BigtableOptions implements Serializable, Cloneable {
   private static final Logger LOG = new Logger(BigtableOptions.class);
 
   private static int getDefaultDataChannelCount() {
-    // Use no more than 250 Channels by default.
+    // 20 Channels seemed to work well on a 4 CPU machine, and this ratio seems to scale well for
+    // higher CPU machines. Use no more than 250 Channels by default.
     int availableProcessors = Runtime.getRuntime().availableProcessors();
-    return Math.min(250, Math.max(1, availableProcessors * 2));
+    return Math.min(250, Math.max(1, availableProcessors * 4));
   }
 
   private static int getDefaultMaxInflightRpcCount() {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BulkOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BulkOptions.java
@@ -35,12 +35,12 @@ public class BulkOptions implements Serializable, Cloneable {
 
   /**
    * This describes the maximum size a bulk mutation RPC should be before sending it to the server
-   * and starting the next bulk call. Defaults to 1 MB.
+   * and starting the next bulk call. Defaults to 20 MB.
    *
    * <p>For internal use only - public for technical reasons.
    */
   @InternalApi("For internal usage only")
-  public static final long BIGTABLE_BULK_MAX_REQUEST_SIZE_BYTES_DEFAULT = 1 << 20;
+  public static final long BIGTABLE_BULK_MAX_REQUEST_SIZE_BYTES_DEFAULT = 20 * 1024 * 1024;
 
   /**
    * This describes the maximum number of individual MutateRowsRequest.Entry objects to bundle in a
@@ -50,7 +50,7 @@ public class BulkOptions implements Serializable, Cloneable {
    * <p>For internal use only - public for technical reasons.
    */
   @InternalApi("For internal usage only")
-  public static final int BIGTABLE_BULK_MAX_ROW_KEY_COUNT_DEFAULT = 125;
+  public static final int BIGTABLE_BULK_MAX_ROW_KEY_COUNT_DEFAULT = 100;
 
   /**
    * Whether or not to enable a mechanism that reduces the likelihood that a {@link BulkMutation}
@@ -73,30 +73,29 @@ public class BulkOptions implements Serializable, Cloneable {
   public static final int BIGTABLE_BULK_THROTTLE_TARGET_MS_DEFAULT = 100;
 
   /**
-   * The maximum amount of time a row will be buffered for. By default 0: indefinitely.
+   * The maximum amount of time a row will be buffered for (default value: 1 second).
    *
    * <p>For internal use only - public for technical reasons.
    */
   @InternalApi("For internal usage only")
-  public static long BIGTABLE_BULK_AUTOFLUSH_MS_DEFAULT = 0;
+  public static long BIGTABLE_BULK_AUTOFLUSH_MS_DEFAULT = 1_000;
 
   /**
-   * Default rpc count per channel.
+   * Default rpc count per channel (default value: 1000).
    *
    * <p>For internal use only - public for technical reasons.
    */
   @InternalApi("For internal usage only")
-  public static final int BIGTABLE_MAX_INFLIGHT_RPCS_PER_CHANNEL_DEFAULT = 10;
+  public static final int BIGTABLE_MAX_INFLIGHT_RPCS_PER_CHANNEL_DEFAULT = 10 * 100;
 
   /**
    * This is the maximum accumulated size of uncompleted requests that we allow before throttling.
-   * Default to 10% of available memory with a max of 1GB.
+   * (default value: 100MB).
    *
    * <p>For internal use only - public for technical reasons.
    */
   @InternalApi("For internal usage only")
-  public static final long BIGTABLE_MAX_MEMORY_DEFAULT =
-      (long) Math.min(1 << 30, (Runtime.getRuntime().maxMemory() * 0.1d));
+  public static final long BIGTABLE_MAX_MEMORY_DEFAULT = 100L * 1024L * 1024L;
 
   public static Builder builder() {
     return new Builder();

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BulkOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BulkOptions.java
@@ -81,12 +81,12 @@ public class BulkOptions implements Serializable, Cloneable {
   public static long BIGTABLE_BULK_AUTOFLUSH_MS_DEFAULT = 1_000;
 
   /**
-   * Default rpc count per channel (default value: 1000).
+   * Default rpc count per channel (default value: 10).
    *
    * <p>For internal use only - public for technical reasons.
    */
   @InternalApi("For internal usage only")
-  public static final int BIGTABLE_MAX_INFLIGHT_RPCS_PER_CHANNEL_DEFAULT = 10 * 100;
+  public static final int BIGTABLE_MAX_INFLIGHT_RPCS_PER_CHANNEL_DEFAULT = 10;
 
   /**
    * This is the maximum accumulated size of uncompleted requests that we allow before throttling.

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CallOptionsConfig.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CallOptionsConfig.java
@@ -19,6 +19,7 @@ import com.google.api.core.InternalExtensionOnly;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import java.io.Serializable;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Experimental options to turn on timeout options. {@link io.grpc.CallOptions} supports other
@@ -32,19 +33,19 @@ public class CallOptionsConfig implements Serializable {
   /** Constant <code>USE_TIMEOUT_DEFAULT=false</code> */
   public static final boolean USE_TIMEOUT_DEFAULT = false;
 
-  /**
-   * The default duration to wait before timing out RPCs. 1 minute is probably too long for most
-   * RPCs, but the intent is to have a conservative timeout by default and aim for user overrides.
-   */
-  public static final int SHORT_TIMEOUT_MS_DEFAULT = 60_000;
+  /** The default duration to wait before timing out RPCs (default value: 20 seconds). */
+  public static final int SHORT_TIMEOUT_MS_DEFAULT = 20_000;
 
   /**
-   * The default duration to wait before timing out RPCs. 10 minute is probably too long for most
-   * RPCs, but the intent is to have a conservative timeout by default and aim for user overrides.
-   * There could very well be 10 minute scans, so keep the value conservative for most cases and
-   * allow user overrides as needed.
+   * The default duration to wait before timing out idempotent RPCs operation. 10 minute is probably
+   * too long for most RPCs, but the intent is to have a conservative timeout by default and aim for
+   * user overrides. There could very well be 10 minute scans, so keep the value conservative for
+   * most cases and allow user overrides as needed.
    */
   public static final int LONG_TIMEOUT_MS_DEFAULT = 600_000;
+
+  /** The default duration to wait before timing out read stream RPC (default value: 12 hour). */
+  public static final int READ_ROWS_TIMEOUT_MS_DEFAULT = (int) TimeUnit.HOURS.toMillis(12);
 
   public static Builder builder() {
     return new Builder();
@@ -55,7 +56,7 @@ public class CallOptionsConfig implements Serializable {
     private int shortRpcTimeoutMs = SHORT_TIMEOUT_MS_DEFAULT;
     private int longRpcTimeoutMs = LONG_TIMEOUT_MS_DEFAULT;
     private int mutateRpcTimeoutMs = LONG_TIMEOUT_MS_DEFAULT;
-    private int readRowsRpcTimeoutMs = LONG_TIMEOUT_MS_DEFAULT;
+    private int readRowsRpcTimeoutMs = READ_ROWS_TIMEOUT_MS_DEFAULT;
 
     /** @deprecated Please use {@link CallOptionsConfig#builder()} */
     @Deprecated

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/RetryOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/RetryOptions.java
@@ -60,38 +60,36 @@ public class RetryOptions implements Serializable, Cloneable {
    * <p>For internal use only - public for technical reasons.
    */
   @InternalApi("For internal usage only")
-  public static final int DEFAULT_READ_PARTIAL_ROW_TIMEOUT_MS =
-      (int) TimeUnit.MILLISECONDS.convert(60, TimeUnit.SECONDS);
+  public static final int DEFAULT_READ_PARTIAL_ROW_TIMEOUT_MS = (int) TimeUnit.MINUTES.toMillis(5);
 
   /**
-   * Initial amount of time to wait before retrying failed operations (default value: 5ms).
+   * Initial amount of time to wait before retrying failed operations (default value: 10ms).
    *
    * <p>For internal use only - public for technical reasons.
    */
   @InternalApi("For internal usage only")
-  public static final int DEFAULT_INITIAL_BACKOFF_MILLIS = 5;
+  public static final int DEFAULT_INITIAL_BACKOFF_MILLIS = 10;
   /**
-   * Multiplier to apply to wait times after failed retries (default value: 1.5).
+   * Multiplier to apply to wait times after failed retries (default value: 2.0).
    *
    * <p>For internal use only - public for technical reasons.
    */
   @InternalApi("For internal usage only")
-  public static final double DEFAULT_BACKOFF_MULTIPLIER = 1.5;
+  public static final double DEFAULT_BACKOFF_MULTIPLIER = 2.0;
   /**
-   * Maximum amount of time to retry before failing the operation (default value: 60 seconds).
+   * Maximum amount of time to retry before failing the operation (default value: 600 seconds).
    *
    * <p>For internal use only - public for technical reasons.
    */
   @InternalApi("For internal usage only")
-  public static final int DEFAULT_MAX_ELAPSED_BACKOFF_MILLIS =
-      (int) TimeUnit.MILLISECONDS.convert(60, TimeUnit.SECONDS);
+  public static final int DEFAULT_MAX_ELAPSED_BACKOFF_MILLIS = (int) TimeUnit.MINUTES.toMillis(10);
   /**
-   * Maximum number of times to retry after a scan timeout
+   * Maximum number of times to retry after a scan timeout (default value: 10 retries).
    *
    * <p>For internal use only - public for technical reasons.
    */
   @InternalApi("For internal usage only")
-  public static final int DEFAULT_MAX_SCAN_TIMEOUT_RETRIES = 3;
+  public static final int DEFAULT_MAX_SCAN_TIMEOUT_RETRIES = 10;
 
   public static RetryOptions getDefaultOptions() {
     return builder().build();

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/config/TestBigtableVeneerSettingsFactory.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/config/TestBigtableVeneerSettingsFactory.java
@@ -286,11 +286,10 @@ public class TestBigtableVeneerSettingsFactory {
   private void verifyRetry(RetrySettings retrySettings) {
     assertEquals(DEFAULT_INITIAL_BACKOFF_MILLIS, retrySettings.getInitialRetryDelay().toMillis());
     assertEquals(DEFAULT_BACKOFF_MULTIPLIER, retrySettings.getRetryDelayMultiplier(), 0);
-    assertEquals(DEFAULT_MAX_ELAPSED_BACKOFF_MILLIS, retrySettings.getMaxRetryDelay().toMillis());
     assertEquals(0, retrySettings.getMaxAttempts());
     assertEquals(360_000, retrySettings.getInitialRpcTimeout().toMillis());
     assertEquals(360_000, retrySettings.getMaxRpcTimeout().toMillis());
-    assertEquals(60_000, retrySettings.getTotalTimeout().toMillis());
+    assertEquals(DEFAULT_MAX_ELAPSED_BACKOFF_MILLIS, retrySettings.getTotalTimeout().toMillis());
   }
 
   private void verifyDisabledRetry(RetrySettings retrySettings) {

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutation.java
@@ -76,6 +76,7 @@ public class TestBulkMutation {
       BulkOptions.builder()
           .setBulkMaxRequestSize(1000000L)
           .setBulkMaxRowKeyCount(MAX_ROW_COUNT)
+          .setAutoflushMs(0)
           .build();
 
   static MutateRowsRequest.Entry createEntry() {

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationAwaitCompletion.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationAwaitCompletion.java
@@ -27,7 +27,6 @@ import com.google.bigtable.v2.MutateRowsRequest;
 import com.google.bigtable.v2.MutateRowsResponse;
 import com.google.cloud.bigtable.config.BulkOptions;
 import com.google.cloud.bigtable.config.Logger;
-import com.google.cloud.bigtable.core.IBigtableDataClient;
 import com.google.cloud.bigtable.grpc.BigtableDataClient;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
@@ -71,8 +70,6 @@ public class TestBulkMutationAwaitCompletion {
   @Rule public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
   @Mock private BigtableDataClient mockClient;
-
-  @Mock private IBigtableDataClient mockClientWrapper;
 
   @Mock private ScheduledExecutorService mockScheduler;
 
@@ -302,6 +299,7 @@ public class TestBulkMutationAwaitCompletion {
   protected BulkMutation createBulkMutation(OperationAccountant operationAccountant) {
     BulkOptions options =
         BulkOptions.builder()
+            .setAutoflushMs(0)
             .setBulkMaxRowKeyCount(MUTATIONS_PER_RPC)
             .setBulkMaxRequestSize(1000000000)
             .build();


### PR DESCRIPTION
Towards #2454 

This change updates bigtable-client-core default values to match with veneer counterpart. This is needed to provide a smoother transition to users. 

## Updated fields

|                      Classic configuration                     |                 Existing value                |      Aligned value      | Aligned To                                                                                                      |
|:--------------------------------------------------------------:|:---------------------------------------------:|:-----------------------:|-----------------------------------------------------------------------------------------------------------------|
| DataChannelCount                                               | CPU * 4                                       | CPU * 2                 | transportChannelProvider -> setPoolSize                                                                         |
| BulkOptions -> bulkMaxRowKeyCount                              | 125                                           | 100                     | bulk(mutate/read) -> <br>batchingSettings -> elementCountThreshold                                              |
| BulkOptions -> bulkMaxRequestSize                              | 1MB                                           | 20MB                    | bulkMutate -> batching -> requestByteSize                                                                       |
| BulkOptions -> autoFlushMs                                     | 0 (indefinitely)                              | 1 seconds               | bulkMutate -> batching -> delayThreshold                                                                        |
| BulkOptions -> maxInflightRpcs                                 | 10 * channelCount                             | 10 * 100 * channelCount | bulkMutate -> <br>flowController -> maxOutstandingElementCount                                                  |
| BulkOptions -> maxMemory                                       | 10% of available memory <br>with a max of 1GB | 100 MB                  | bulkMutate -> <br>flowController -> maxOutstandingRequestBytes                                                  |
| RetryOptions -> initialBackoffMillis                           | 5 ms                                          | 10 ms                   | RetrySettings -> initialRetryDelay                                                                              |
| RetryOptions -> maxElapsedBackoffMillis                        | 1 min                                         | 10 mins                 | RetrySettings -> totalTimeout                                                                                   |
| RetryOptions -> backoffMultiplier                              | 1.5                                           | 2.0                     | RetrySettings -> RetryDelayMultiplier                                                                           |
| RetryOptions -> ReadPartialRowTimeoutMillis                    | 1 min                                         | 5 mins                  | readRows -> <br>RetrySettings -> initialRpcTimeout                                                              |
| RetryOptions -> maxScanTimeoutRetries                          | 3                                             | 10                      | readRows -> <br>RetrySettings -> maxAttempts                                                                    |
| CallOptionsConfig -> shortRpcTimeoutMs                         | 60 seconds                                    | 20 seconds              | Idempotent op -> <br>RetrySetting -> initialRpc,maxRpcTimeout<br><br>NonIdempotent Op -> simpleTimeoutNoRetries |
| CallOptionsConfig -> <br>mutateRpcTimeoutMs/longRpcTimeoutMs   | 600 seconds                                   | 600 seconds             | mutateRow -> <br>RetrySettings -> totalTimeout                                                                  |
| CallOptionsConfig -> <br>readRowsRpcTimeoutMs/longRpcTimeoutMs | 600 seconds                                   | 12 hour                 | readRows -> <br>RetrySettings -> totalTimeout                                                                   |

