### PR TITLE
chore: updated return type to HBase ResultScanner

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/DataClientWrapper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/DataClientWrapper.java
@@ -22,10 +22,10 @@ import com.google.cloud.bigtable.data.v2.models.KeyOffset;
 import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
-import com.google.cloud.bigtable.grpc.scanner.ResultScanner;
 import io.grpc.stub.StreamObserver;
 import java.util.List;
 import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
 
 /**
  * Common API surface for data operation.
@@ -57,7 +57,7 @@ public interface DataClientWrapper extends AutoCloseable {
   ApiFuture<List<KeyOffset>> sampleRowKeysAsync(String tableId);
 
   /** Perform a scan over {@link Result}s, in key order. */
-  ResultScanner<Result> readRows(Query request);
+  ResultScanner readRows(Query request);
 
   /** Read multiple {@link Result}s into an in-memory list, in key order. */
   ApiFuture<List<Result>> readRowsAsync(Query request);

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/DataClientClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/DataClientClassicApi.java
@@ -245,10 +245,6 @@ public class DataClientClassicApi implements DataClientWrapper {
   }
 
   private static Result transformRowToResult(Row row) {
-    if (row == null) {
-      return Result.EMPTY_RESULT;
-    }
-
     List<org.apache.hadoop.hbase.Cell> hbaseCells = new ArrayList<>();
     byte[] rowKeyBytes = ByteStringer.extract(row.getKey());
 


### PR DESCRIPTION
This change updates return type of DataClientWrapper#readRows to `org.apache.hadoop.hbase.client.ResultScanner`.