### PR TITLE
deps(fix): add log4j12 to mincluster h2 tests

### DIFF
--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
@@ -481,8 +481,8 @@ limitations under the License.
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
           <usedDependencies>
-            <usedDependency>${project.groupId}:bigtable-hbase-2.x
-            </usedDependency>
+            <usedDependency>${project.groupId}:bigtable-hbase-2.x</usedDependency>
+            <usedDependency>org.slf4j:slf4j-log4j12</usedDependency>
           </usedDependencies>
         </configuration>
       </plugin>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
@@ -149,13 +149,6 @@ limitations under the License.
     </profile>
     <profile>
       <id>hbaseLocalMiniClusterTestH2</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-          <version>${slf4j.version}</version>
-        </dependency>
-      </dependencies>
       <build>
         <plugins>
           <plugin>
@@ -413,6 +406,13 @@ limitations under the License.
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
       <version>${commons-lang.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>${slf4j.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
@@ -149,6 +149,13 @@ limitations under the License.
     </profile>
     <profile>
       <id>hbaseLocalMiniClusterTestH2</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+          <version>${slf4j.version}</version>
+        </dependency>
+      </dependencies>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
hbaseLocalMiniClusterTestH2 is currently failing with this error:
```
Caused by: java.lang.NoClassDefFoundError: org/slf4j/impl/Log4jLoggerAdapter
        at org.apache.hadoop.hbase.http.HttpRequestLog.getLog4jLogger(HttpRequestLog.java:53)
        at org.apache.hadoop.hbase.http.HttpRequestLog.getRequestLog(HttpRequestLog.java:69)
        at org.apache.hadoop.hbase.http.HttpServer.initializeWebServer(HttpServer.java:545)
```