### PR TITLE
chore: replacing Data Client with new wrappers (Part-2) 

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableRegionLocator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableRegionLocator.java
@@ -20,13 +20,13 @@ import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.ApiFutures;
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.core.IBigtableDataClient;
 import com.google.cloud.bigtable.data.v2.internal.NameUtil;
 import com.google.cloud.bigtable.data.v2.models.KeyOffset;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.hbase.adapters.SampledRowKeysAdapter;
 import com.google.cloud.bigtable.hbase.util.Logger;
 import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
+import com.google.cloud.bigtable.hbase.wrappers.DataClientWrapper;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.util.List;
@@ -51,13 +51,13 @@ public abstract class AbstractBigtableRegionLocator {
 
   protected final TableName tableName;
   private ApiFuture<List<HRegionLocation>> regionsFuture;
-  private final IBigtableDataClient client;
+  private final DataClientWrapper client;
   private final SampledRowKeysAdapter adapter;
   private final BigtableTableName bigtableTableName;
   private long regionsFetchTimeMillis;
 
   public AbstractBigtableRegionLocator(
-      TableName tableName, BigtableHBaseSettings settings, IBigtableDataClient client) {
+      TableName tableName, BigtableHBaseSettings settings, DataClientWrapper client) {
     this.tableName = tableName;
     this.client = client;
     this.bigtableTableName =

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableRegionLocator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableRegionLocator.java
@@ -16,9 +16,9 @@
 package com.google.cloud.bigtable.hbase;
 
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.core.IBigtableDataClient;
 import com.google.cloud.bigtable.hbase.util.Logger;
 import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
+import com.google.cloud.bigtable.hbase.wrappers.DataClientWrapper;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -45,10 +45,10 @@ public abstract class BigtableRegionLocator extends AbstractBigtableRegionLocato
    *
    * @param tableName a {@link TableName} object.
    * @param settings a {@link BigtableHBaseSettings} object.
-   * @param client a {@link IBigtableDataClient} object.
+   * @param client a {@link DataClientWrapper} object.
    */
   public BigtableRegionLocator(
-      TableName tableName, BigtableHBaseSettings settings, IBigtableDataClient client) {
+      TableName tableName, BigtableHBaseSettings settings, DataClientWrapper client) {
     super(tableName, settings, client);
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
@@ -192,7 +192,7 @@ public abstract class AbstractBigtableConnection
 
     if (locator == null) {
       locator =
-          new BigtableRegionLocator(tableName, settings, getSession().getDataClientWrapper()) {
+          new BigtableRegionLocator(tableName, settings, bigtableApi.getDataClient()) {
 
             @Override
             public SampledRowKeysAdapter getSampledRowKeysAdapter(

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/pom.xml
@@ -114,6 +114,10 @@ limitations under the License.
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-api</artifactId>
     </dependency>
@@ -131,6 +135,12 @@ limitations under the License.
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTableRegionLocator.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTableRegionLocator.java
@@ -16,10 +16,10 @@
 package com.google.cloud.bigtable.hbase2_x;
 
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.core.IBigtableDataClient;
 import com.google.cloud.bigtable.hbase.AbstractBigtableRegionLocator;
 import com.google.cloud.bigtable.hbase.adapters.SampledRowKeysAdapter;
 import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
+import com.google.cloud.bigtable.hbase.wrappers.DataClientWrapper;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.apache.hadoop.hbase.HRegionLocation;
@@ -40,7 +40,7 @@ public class BigtableAsyncTableRegionLocator extends AbstractBigtableRegionLocat
   HRegionLocation hRegionLocation = null;
 
   public BigtableAsyncTableRegionLocator(
-      TableName tableName, BigtableHBaseSettings settings, IBigtableDataClient client) {
+      TableName tableName, BigtableHBaseSettings settings, DataClientWrapper client) {
     super(tableName, settings, client);
   }
 

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
@@ -320,7 +320,7 @@ public class BigtableAsyncConnection implements AsyncConnection, CommonConnectio
 
   @Override
   public AsyncTableRegionLocator getRegionLocator(TableName tableName) {
-    return new BigtableAsyncTableRegionLocator(tableName, settings, session.getDataClientWrapper());
+    return new BigtableAsyncTableRegionLocator(tableName, settings, bigtableApi.getDataClient());
   }
 
   @Override

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase2_x/TestBigtableAsyncTableRegionLocator.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase2_x/TestBigtableAsyncTableRegionLocator.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase2_x;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import com.google.api.core.ApiFutures;
+import com.google.cloud.bigtable.data.v2.models.KeyOffset;
+import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
+import com.google.cloud.bigtable.hbase.wrappers.DataClientWrapper;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HRegionLocation;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@RunWith(JUnit4.class)
+public class TestBigtableAsyncTableRegionLocator {
+
+  @Rule public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  private static final TableName TABLE_NAME = TableName.valueOf("fake-table-name");
+
+  @Mock private DataClientWrapper mockDataClient;
+
+  private BigtableAsyncTableRegionLocator regionLocator;
+
+  @Before
+  public void setUp() throws IOException {
+    Configuration configuration = new Configuration(false);
+    configuration.set(BigtableOptionsFactory.PROJECT_ID_KEY, "fake-project-id");
+    configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, "fake-instance-id");
+    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, "localhost");
+    configuration.set(BigtableOptionsFactory.BIGTABLE_ADMIN_HOST_KEY, "localhost");
+    configuration.set(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, "true");
+    configuration.set(BigtableOptionsFactory.BIGTABLE_DATA_CHANNEL_COUNT_KEY, "1");
+    BigtableHBaseSettings settings = BigtableHBaseSettings.create(configuration);
+    regionLocator = new BigtableAsyncTableRegionLocator(TABLE_NAME, settings, mockDataClient);
+  }
+
+  @Test
+  public void testGetRegionLocation() throws ExecutionException, InterruptedException {
+    List<KeyOffset> keyOffsets =
+        ImmutableList.of(
+            KeyOffset.create(ByteString.copyFromUtf8("a"), 100L),
+            KeyOffset.create(ByteString.copyFromUtf8("b"), 100L),
+            KeyOffset.create(ByteString.copyFromUtf8("y"), 100L),
+            KeyOffset.create(ByteString.copyFromUtf8("z"), 100L));
+    when(mockDataClient.sampleRowKeysAsync(TABLE_NAME.getNameAsString()))
+        .thenReturn(ApiFutures.immediateFuture(keyOffsets));
+
+    HRegionLocation regionLocationFuture =
+        regionLocator.getRegionLocation(Bytes.toBytes("rowKey"), 1, false).get();
+    assertEquals("b", Bytes.toString(regionLocationFuture.getRegion().getStartKey()));
+    assertEquals("y", Bytes.toString(regionLocationFuture.getRegion().getEndKey()));
+
+    assertEquals(TABLE_NAME, regionLocator.getName());
+  }
+}


### PR DESCRIPTION
This change updates `AbstractBigtableRegionLocator` and it's extensions with `DataClientWrapper`. It also includes a fresh unit test for `BigtableAsyncTableRegionLocator`.

Note: This is a part of series of PRs to replace existing references of BigtableSession/Data/Admin clients with new wrappers.

Towards #2454 