### PR TITLE
chore: replacing bulk read with new wrapper (Part-4)

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
@@ -697,9 +697,7 @@ public abstract class AbstractBigtableTable implements Table {
     if (batchExecutor == null) {
       batchExecutor =
           new BatchExecutor(
-              bigtableConnection.getSession(),
-              bigtableConnection.getBigtableHBaseSettings(),
-              hbaseAdapter);
+              bigtableConnection.getSession(), bigtableConnection.getBigtableApi(), hbaseAdapter);
     }
     return batchExecutor;
   }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTable.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTable.java
@@ -93,8 +93,7 @@ public class BigtableAsyncTable implements AsyncTable<ScanResultConsumer> {
   protected synchronized BatchExecutor getBatchExecutor() {
     if (batchExecutor == null) {
       batchExecutor =
-          new BatchExecutor(
-              connection.getSession(), connection.getBigtableHBaseSettings(), hbaseAdapter);
+          new BatchExecutor(connection.getSession(), connection.getBigtableApi(), hbaseAdapter);
     }
     return batchExecutor;
   }


### PR DESCRIPTION
Towards #2454 

This change includes the transition of BulkRead to BulkReadWrapper in BatchExecutor.

Note: This is part 4 of the series of PRs to replace references of BigtableSession/Data/Admin clients with new wrappers.