### PR TITLE
chore: transition of admin client to new wrappers

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
@@ -26,12 +26,12 @@ import com.google.api.gax.rpc.FailedPreconditionException;
 import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
 import com.google.cloud.bigtable.admin.v2.models.ModifyColumnFamiliesRequest;
 import com.google.cloud.bigtable.admin.v2.models.Table;
-import com.google.cloud.bigtable.core.IBigtableTableAdminClient;
 import com.google.cloud.bigtable.grpc.BigtableInstanceName;
 import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
 import com.google.cloud.bigtable.hbase.adapters.admin.TableAdapter;
 import com.google.cloud.bigtable.hbase.util.Logger;
 import com.google.cloud.bigtable.hbase.util.ModifyTableBuilder;
+import com.google.cloud.bigtable.hbase.wrappers.AdminClientWrapper;
 import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
@@ -92,7 +92,7 @@ public abstract class AbstractBigtableAdmin implements Admin {
   private final Configuration configuration;
   private final BigtableHBaseSettings settings;
   protected final CommonConnection connection;
-  protected final IBigtableTableAdminClient tableAdminClientWrapper;
+  protected final AdminClientWrapper tableAdminClientWrapper;
   protected final BigtableInstanceName bigtableInstanceName;
 
   /**
@@ -109,7 +109,7 @@ public abstract class AbstractBigtableAdmin implements Admin {
     disabledTables = connection.getDisabledTables();
     bigtableInstanceName =
         new BigtableInstanceName(settings.getProjectId(), settings.getInstanceId());
-    tableAdminClientWrapper = connection.getSession().getTableAdminClientWrapper();
+    tableAdminClientWrapper = connection.getBigtableApi().getAdminClient();
   }
 
   /** {@inheritDoc} */

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncAdmin.java
@@ -21,10 +21,10 @@ import static com.google.cloud.bigtable.hbase2_x.FutureUtils.toCompletableFuture
 import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
 import com.google.cloud.bigtable.admin.v2.models.Table;
-import com.google.cloud.bigtable.core.IBigtableTableAdminClient;
 import com.google.cloud.bigtable.grpc.BigtableInstanceName;
 import com.google.cloud.bigtable.hbase.util.Logger;
 import com.google.cloud.bigtable.hbase.util.ModifyTableBuilder;
+import com.google.cloud.bigtable.hbase.wrappers.AdminClientWrapper;
 import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
 import com.google.cloud.bigtable.hbase2_x.adapters.admin.TableAdapter2x;
 import com.google.common.base.Preconditions;
@@ -88,14 +88,14 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
   private final Logger LOG = new Logger(getClass());
 
   private final Set<TableName> disabledTables;
-  private final IBigtableTableAdminClient bigtableTableAdminClient;
+  private final AdminClientWrapper bigtableTableAdminClient;
   private final BigtableInstanceName bigtableInstanceName;
   private final CommonConnection asyncConnection;
 
   public BigtableAsyncAdmin(CommonConnection asyncConnection) throws IOException {
     LOG.debug("Creating BigtableAsyncAdmin");
     BigtableHBaseSettings settings = asyncConnection.getBigtableSettings();
-    this.bigtableTableAdminClient = asyncConnection.getSession().getTableAdminClientWrapper();
+    this.bigtableTableAdminClient = asyncConnection.getBigtableApi().getAdminClient();
     this.disabledTables = asyncConnection.getDisabledTables();
     this.bigtableInstanceName =
         new BigtableInstanceName(settings.getProjectId(), settings.getInstanceId());


### PR DESCRIPTION
Towards #2454 

This change updates the `AbstractBigtableAdmin` and `BigtableAsyncAdmin` to adapt all admin operation against new `AdminClientWrapper` interface.