### PR TITLE
chore: introducing bulkRead API with veneer client

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
@@ -210,7 +210,7 @@ public class BatchExecutor {
     } finally {
       // If there is a bulk mutation in progress, then send it.
       bufferedMutatorHelper.sendUnsent();
-      bulkRead.flush();
+      bulkRead.sendAsync();
     }
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
@@ -210,7 +210,7 @@ public class BatchExecutor {
     } finally {
       // If there is a bulk mutation in progress, then send it.
       bufferedMutatorHelper.sendUnsent();
-      bulkRead.sendAsync();
+      bulkRead.sendOutstanding();
     }
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BulkReadWrapper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BulkReadWrapper.java
@@ -40,5 +40,5 @@ public interface BulkReadWrapper {
    * Sends all remaining requests to the server. This method does not wait for the method to
    * complete.
    */
-  void sendAsync();
+  void sendOutstanding();
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BulkReadWrapper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BulkReadWrapper.java
@@ -40,5 +40,5 @@ public interface BulkReadWrapper {
    * Sends all remaining requests to the server. This method does not wait for the method to
    * complete.
    */
-  void flush();
+  void sendAsync();
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BulkReadWrapper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BulkReadWrapper.java
@@ -19,7 +19,6 @@ import com.google.api.core.ApiFuture;
 import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.protobuf.ByteString;
-import java.io.IOException;
 import javax.annotation.Nullable;
 import org.apache.hadoop.hbase.client.Result;
 
@@ -29,7 +28,7 @@ import org.apache.hadoop.hbase.client.Result;
  * <p>For internal use only - public for technical reasons.
  */
 @InternalApi("For internal usage only")
-public interface BulkReadWrapper extends AutoCloseable {
+public interface BulkReadWrapper {
 
   /**
    * Adds a {@code rowKey} to a batch read row request with an optional {@link Filters.Filter}. The
@@ -42,7 +41,4 @@ public interface BulkReadWrapper extends AutoCloseable {
    * complete.
    */
   void flush();
-
-  /** Closes the batch and prevents new keys addition. */
-  void close() throws IOException;
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BulkReadClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BulkReadClassicApi.java
@@ -66,10 +66,4 @@ public class BulkReadClassicApi implements BulkReadWrapper {
   public void flush() {
     delegate.flush();
   }
-
-  @Override
-  public void close() {
-    isClosed = true;
-    flush();
-  }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BulkReadClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BulkReadClassicApi.java
@@ -63,7 +63,7 @@ public class BulkReadClassicApi implements BulkReadWrapper {
   }
 
   @Override
-  public void sendAsync() {
+  public void sendOutstanding() {
     delegate.flush();
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BulkReadClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BulkReadClassicApi.java
@@ -63,7 +63,7 @@ public class BulkReadClassicApi implements BulkReadWrapper {
   }
 
   @Override
-  public void flush() {
+  public void sendAsync() {
     delegate.flush();
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BulkReadVeneerApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BulkReadVeneerApi.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers.veneer;
+
+import com.google.api.core.ApiFunction;
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.gax.batching.Batcher;
+import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.BigtableDataClient;
+import com.google.cloud.bigtable.data.v2.models.Filters;
+import com.google.cloud.bigtable.data.v2.models.Row;
+import com.google.cloud.bigtable.hbase.adapters.Adapters;
+import com.google.cloud.bigtable.hbase.wrappers.BulkReadWrapper;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.protobuf.ByteString;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.Nullable;
+import org.apache.hadoop.hbase.client.Result;
+
+/**
+ * Adapter for sending batch reads.
+ *
+ * <p>This class works with {@link com.google.cloud.bigtable.hbase.BatchExecutor} to enable bulk
+ * reads from the hbase api.
+ *
+ * <p>This class is not thread safe. It must be used on a single thread
+ */
+public class BulkReadVeneerApi implements BulkReadWrapper {
+
+  private final BigtableDataClient client;
+  private final String tableId;
+  private final Map<RowFilter, Batcher<ByteString, Row>> batchers;
+
+  // TODO: remove this once gax-java's Batcher supports asyncClose(). This will eliminate the need
+  private final AtomicLong cleanupBarrier;
+
+  BulkReadVeneerApi(BigtableDataClient client, String tableId) {
+    this.client = client;
+    this.tableId = tableId;
+
+    this.batchers = new HashMap<>();
+    this.cleanupBarrier = new AtomicLong();
+    this.cleanupBarrier
+        .incrementAndGet(); // wait for flush to signal before cleaning up the batcher map
+  }
+
+  @Override
+  public ApiFuture<Result> add(ByteString rowKey, @Nullable Filters.Filter filter) {
+    cleanupBarrier.incrementAndGet();
+
+    ApiFuture<Row> rowFuture = getOrCreateBatcher(filter).add(rowKey);
+    rowFuture.addListener(
+        new Runnable() {
+          @Override
+          public void run() {
+            notifyArrival();
+          }
+        },
+        MoreExecutors.directExecutor());
+
+    return ApiFutures.transform(
+        rowFuture,
+        new ApiFunction<Row, Result>() {
+          @Override
+          public Result apply(Row row) {
+            return Adapters.ROW_ADAPTER.adaptResponse(row);
+          }
+        },
+        MoreExecutors.directExecutor());
+  }
+
+  private void notifyArrival() {
+    if (cleanupBarrier.decrementAndGet() == 0) {
+      cleanUp();
+    }
+  }
+
+  /** close all outstanding Batchers */
+  private void cleanUp() {
+    for (Batcher<ByteString, Row> batcher : batchers.values()) {
+      try {
+        batcher.close();
+      } catch (Throwable ignored) {
+        // Ignored
+      }
+    }
+    batchers.clear();
+  }
+
+  /*
+   * If autoflush is off, elementThreshold is 100, and size is 20MB, Now
+   *  -> user calls Table#batch with 10 entries
+   *     -> none of
+   */
+  @Override
+  public void flush() {
+    for (Batcher<ByteString, Row> batcher : batchers.values()) {
+      batcher.sendOutstanding();
+    }
+    notifyArrival();
+  }
+
+  private Batcher<ByteString, Row> getOrCreateBatcher(@Nullable Filters.Filter filter) {
+    RowFilter proto = filter == null ? null : filter.toProto();
+
+    Batcher<ByteString, Row> batcher = batchers.get(proto);
+    if (batcher == null) {
+      batcher = client.newBulkReadRowsBatcher(tableId, filter);
+      batchers.put(proto, batcher);
+    }
+    return batcher;
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BulkReadVeneerApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BulkReadVeneerApi.java
@@ -58,7 +58,7 @@ public class BulkReadVeneerApi implements BulkReadWrapper {
     this.batchers = new HashMap<>();
     this.cleanupBarrier = new AtomicLong();
     this.cleanupBarrier
-        .incrementAndGet(); // wait for sendAsync to signal before cleaning up the batcher map
+        .incrementAndGet(); // wait for sendOutstanding to signal before cleaning up the batcher map
   }
 
   @Override
@@ -105,7 +105,7 @@ public class BulkReadVeneerApi implements BulkReadWrapper {
   }
 
   @Override
-  public void sendAsync() {
+  public void sendOutstanding() {
     for (Batcher<ByteString, Row> batcher : batchers.values()) {
       batcher.sendOutstanding();
     }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BulkReadVeneerApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BulkReadVeneerApi.java
@@ -103,13 +103,9 @@ public class BulkReadVeneerApi implements BulkReadWrapper {
     batchers.clear();
   }
 
-  /*
-   * If autoflush is off, elementThreshold is 100, and size is 20MB, Now
-   *  -> user calls Table#batch with 10 entries
-   *     -> none of
-   */
   @Override
   public void flush() {
+    // we should send batch in case autoFlush is either switch off or very large
     for (Batcher<ByteString, Row> batcher : batchers.values()) {
       batcher.sendOutstanding();
     }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
@@ -327,7 +327,7 @@ public class TestBatchExecutor {
 
     Result[] results = createExecutor().batch(gets);
     verify(mockBulkRead, times(10)).add(any(ByteString.class), any(Filters.Filter.class));
-    verify(mockBulkRead, times(1)).sendAsync();
+    verify(mockBulkRead, times(1)).sendOutstanding();
     assertTrue(matchesRow(Result.EMPTY_RESULT).matches(results[0]));
     for (int i = 1; i < results.length; i++) {
       assertTrue(

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
@@ -327,7 +327,7 @@ public class TestBatchExecutor {
 
     Result[] results = createExecutor().batch(gets);
     verify(mockBulkRead, times(10)).add(any(ByteString.class), any(Filters.Filter.class));
-    verify(mockBulkRead, times(1)).flush();
+    verify(mockBulkRead, times(1)).sendAsync();
     assertTrue(matchesRow(Result.EMPTY_RESULT).matches(results[0]));
     for (int i = 1; i < results.length; i++) {
       assertTrue(

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBulkReadClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBulkReadClassicApi.java
@@ -81,7 +81,7 @@ public class TestBulkReadClassicApi {
   @Test
   public void testFlush() {
     doNothing().when(delegate).flush();
-    bulkReadWrapper.flush();
+    bulkReadWrapper.sendAsync();
     verify(delegate).flush();
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBulkReadClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBulkReadClassicApi.java
@@ -17,7 +17,6 @@ package com.google.cloud.bigtable.hbase.wrappers.classic;
 
 import static com.google.cloud.bigtable.hbase.adapters.Adapters.FLAT_ROW_ADAPTER;
 import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -29,10 +28,8 @@ import com.google.cloud.bigtable.grpc.async.BulkRead;
 import com.google.cloud.bigtable.grpc.scanner.FlatRow;
 import com.google.cloud.bigtable.hbase.wrappers.BulkReadWrapper;
 import com.google.protobuf.ByteString;
-import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import org.apache.hadoop.hbase.client.Result;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -86,16 +83,5 @@ public class TestBulkReadClassicApi {
     doNothing().when(delegate).flush();
     bulkReadWrapper.flush();
     verify(delegate).flush();
-  }
-
-  @Test
-  public void testClose() throws IOException {
-    bulkReadWrapper.close();
-    try {
-      bulkReadWrapper.add(ByteString.copyFromUtf8("row-key-2"), null);
-      Assert.fail("Bulk read should be closed");
-    } catch (IllegalStateException actualException) {
-      assertEquals("can't add request when the bulk read is closed.", actualException.getMessage());
-    }
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBulkReadClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBulkReadClassicApi.java
@@ -81,7 +81,7 @@ public class TestBulkReadClassicApi {
   @Test
   public void testFlush() {
     doNothing().when(delegate).flush();
-    bulkReadWrapper.sendAsync();
+    bulkReadWrapper.sendOutstanding();
     verify(delegate).flush();
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBulkReadClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBulkReadClassicApi.java
@@ -79,7 +79,7 @@ public class TestBulkReadClassicApi {
   }
 
   @Test
-  public void testFlush() {
+  public void testSendOutstanding() {
     doNothing().when(delegate).flush();
     bulkReadWrapper.sendOutstanding();
     verify(delegate).flush();

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBulkReadVeneerApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBulkReadVeneerApi.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers.veneer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.gax.batching.BatchingSettings;
+import com.google.bigtable.v2.BigtableGrpc;
+import com.google.bigtable.v2.ReadRowsRequest;
+import com.google.bigtable.v2.ReadRowsResponse;
+import com.google.cloud.bigtable.data.v2.BigtableDataClient;
+import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
+import com.google.cloud.bigtable.data.v2.models.Filters;
+import com.google.protobuf.ByteString;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.net.ServerSocket;
+import org.apache.hadoop.hbase.client.Result;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.threeten.bp.Duration;
+
+@RunWith(JUnit4.class)
+public class TestBulkReadVeneerApi {
+
+  private static final String TABLE_ID = "fake-table-id";
+  private FakeDataService fakeDataService = new FakeDataService();
+  private BigtableDataSettings.Builder settingsBuilder;
+
+  @Before
+  public void setUp() throws IOException {
+    final int port;
+    try (ServerSocket s = new ServerSocket(0)) {
+      port = s.getLocalPort();
+    }
+
+    Server server = ServerBuilder.forPort(port).addService(fakeDataService).build();
+    server.start();
+
+    settingsBuilder =
+        BigtableDataSettings.newBuilderForEmulator(port)
+            .setProjectId("fake-project")
+            .setInstanceId("fake-instance");
+  }
+
+  @Test
+  public void testAdd() throws Exception {
+    BulkReadVeneerApi bulkReadWrapper =
+        new BulkReadVeneerApi(BigtableDataClient.create(settingsBuilder.build()), TABLE_ID);
+    ApiFuture<Result> resultFuture1 = bulkReadWrapper.add(ByteString.copyFromUtf8("one"), null);
+    assertFalse(resultFuture1.isDone());
+
+    Filters.Filter filter = Filters.FILTERS.key().regex("cf");
+    ApiFuture<Result> secBatchResult1 = bulkReadWrapper.add(ByteString.copyFromUtf8("1"), filter);
+    ApiFuture<Result> secBatchResult2 = bulkReadWrapper.add(ByteString.copyFromUtf8("2"), filter);
+
+    // Here AutoFlush triggers the batch
+    resultFuture1.get();
+    secBatchResult1.get();
+
+    // If one entry of the batch is resolved then another should also be
+    assertTrue(resultFuture1.isDone());
+    assertTrue(secBatchResult2.isDone());
+
+    assertEquals(2, fakeDataService.getReadRowsCount());
+  }
+
+  @Test
+  public void testFlush() throws Exception {
+    Duration autoFlushTime = Duration.ofSeconds(30);
+    settingsBuilder
+        .stubSettings()
+        .bulkReadRowsSettings()
+        .setBatchingSettings(
+            BatchingSettings.newBuilder()
+                .setDelayThreshold(autoFlushTime)
+                .setElementCountThreshold(10L)
+                .setRequestByteThreshold(10L * 1024L)
+                .build());
+    BulkReadVeneerApi bulkReadWrapper =
+        new BulkReadVeneerApi(BigtableDataClient.create(settingsBuilder.build()), TABLE_ID);
+
+    bulkReadWrapper.add(ByteString.copyFromUtf8("one"), null);
+    bulkReadWrapper.flush();
+
+    bulkReadWrapper.add(ByteString.copyFromUtf8("two"), null);
+    bulkReadWrapper.flush();
+
+    bulkReadWrapper.add(ByteString.copyFromUtf8("three"), null);
+    bulkReadWrapper.flush();
+
+    bulkReadWrapper.add(ByteString.copyFromUtf8("four"), null);
+    bulkReadWrapper.flush();
+
+    bulkReadWrapper.add(ByteString.copyFromUtf8("five"), null).get();
+
+    assertEquals(5, fakeDataService.getReadRowsCount());
+  }
+
+  @Test
+  public void testWhenAutoFlushIsOff() throws Exception {
+    Duration autoFlushTime = Duration.ofSeconds(30);
+    settingsBuilder
+        .stubSettings()
+        .bulkReadRowsSettings()
+        .setBatchingSettings(
+            BatchingSettings.newBuilder()
+                .setDelayThreshold(autoFlushTime)
+                .setElementCountThreshold(10L)
+                .setRequestByteThreshold(10L * 1024L)
+                .build());
+    BulkReadVeneerApi bulkReadWrapper =
+        new BulkReadVeneerApi(BigtableDataClient.create(settingsBuilder.build()), TABLE_ID);
+
+    long startTime = System.currentTimeMillis();
+    ApiFuture<Result> resultFuture = bulkReadWrapper.add(ByteString.copyFromUtf8("row-key"), null);
+    assertFalse(resultFuture.isDone());
+
+    // This does not guarantee instance result but it will take less time then autoFlush.
+    bulkReadWrapper.flush();
+
+    // TODO: investigate if I am not adding this(another) entry then it is not resolving
+    bulkReadWrapper.add(ByteString.copyFromUtf8("two"), null);
+
+    resultFuture.get();
+    long totalTime = System.currentTimeMillis() - startTime;
+    assertTrue(totalTime < autoFlushTime.toMillis());
+    assertTrue(resultFuture.isDone());
+  }
+
+  private static class FakeDataService extends BigtableGrpc.BigtableImplBase {
+
+    int readRowsCount = 0;
+
+    int getReadRowsCount() {
+      return readRowsCount;
+    }
+
+    @Override
+    public void readRows(
+        ReadRowsRequest request, StreamObserver<ReadRowsResponse> responseObserver) {
+      readRowsCount++;
+      responseObserver.onNext(ReadRowsResponse.getDefaultInstance());
+      responseObserver.onCompleted();
+    }
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBulkReadVeneerApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBulkReadVeneerApi.java
@@ -86,7 +86,7 @@ public class TestBulkReadVeneerApi {
   }
 
   @Test
-  public void testFlush() throws Exception {
+  public void testSendOutstanding() throws Exception {
     Duration autoFlushTime = Duration.ofSeconds(30);
     settingsBuilder
         .stubSettings()

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBulkReadVeneerApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBulkReadVeneerApi.java
@@ -101,16 +101,16 @@ public class TestBulkReadVeneerApi {
         new BulkReadVeneerApi(BigtableDataClient.create(settingsBuilder.build()), TABLE_ID);
 
     bulkReadWrapper.add(ByteString.copyFromUtf8("one"), null);
-    bulkReadWrapper.sendAsync();
+    bulkReadWrapper.sendOutstanding();
 
     bulkReadWrapper.add(ByteString.copyFromUtf8("two"), null);
-    bulkReadWrapper.sendAsync();
+    bulkReadWrapper.sendOutstanding();
 
     bulkReadWrapper.add(ByteString.copyFromUtf8("three"), null);
-    bulkReadWrapper.sendAsync();
+    bulkReadWrapper.sendOutstanding();
 
     bulkReadWrapper.add(ByteString.copyFromUtf8("four"), null);
-    bulkReadWrapper.sendAsync();
+    bulkReadWrapper.sendOutstanding();
 
     bulkReadWrapper.add(ByteString.copyFromUtf8("five"), null).get();
 
@@ -137,7 +137,7 @@ public class TestBulkReadVeneerApi {
     assertFalse(resultFuture.isDone());
 
     // This does not guarantee instance result but it will take less time then autoFlush.
-    bulkReadWrapper.sendAsync();
+    bulkReadWrapper.sendOutstanding();
 
     // TODO: investigate if I am not adding this(another) entry then it is not resolving
     bulkReadWrapper.add(ByteString.copyFromUtf8("two"), null);

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBulkReadVeneerApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBulkReadVeneerApi.java
@@ -101,16 +101,16 @@ public class TestBulkReadVeneerApi {
         new BulkReadVeneerApi(BigtableDataClient.create(settingsBuilder.build()), TABLE_ID);
 
     bulkReadWrapper.add(ByteString.copyFromUtf8("one"), null);
-    bulkReadWrapper.flush();
+    bulkReadWrapper.sendAsync();
 
     bulkReadWrapper.add(ByteString.copyFromUtf8("two"), null);
-    bulkReadWrapper.flush();
+    bulkReadWrapper.sendAsync();
 
     bulkReadWrapper.add(ByteString.copyFromUtf8("three"), null);
-    bulkReadWrapper.flush();
+    bulkReadWrapper.sendAsync();
 
     bulkReadWrapper.add(ByteString.copyFromUtf8("four"), null);
-    bulkReadWrapper.flush();
+    bulkReadWrapper.sendAsync();
 
     bulkReadWrapper.add(ByteString.copyFromUtf8("five"), null).get();
 
@@ -137,7 +137,7 @@ public class TestBulkReadVeneerApi {
     assertFalse(resultFuture.isDone());
 
     // This does not guarantee instance result but it will take less time then autoFlush.
-    bulkReadWrapper.flush();
+    bulkReadWrapper.sendAsync();
 
     // TODO: investigate if I am not adding this(another) entry then it is not resolving
     bulkReadWrapper.add(ByteString.copyFromUtf8("two"), null);


### PR DESCRIPTION
Towards #2454

This is an attempt to maintain the same behavior of existing BulkRead with veneer bulk read API.

The Veneer's Batcher API does not accept filter per request whereas existing BulkRead accepts a filter and sends entries with the same filters in batches.