### PR TITLE
chore: adding Admin and BulkMutation veneer implementation

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/AdminClientVeneerApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/AdminClientVeneerApi.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers.veneer;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.InternalApi;
+import com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient;
+import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
+import com.google.cloud.bigtable.admin.v2.models.ModifyColumnFamiliesRequest;
+import com.google.cloud.bigtable.admin.v2.models.Table;
+import com.google.cloud.bigtable.hbase.wrappers.AdminClientWrapper;
+import java.util.List;
+
+/** For internal use only - public for technical reasons. */
+@InternalApi("For internal usage only")
+public class AdminClientVeneerApi implements AdminClientWrapper {
+
+  private final BigtableTableAdminClient delegate;
+
+  AdminClientVeneerApi(BigtableTableAdminClient delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public ApiFuture<Table> createTableAsync(CreateTableRequest request) {
+    return delegate.createTableAsync(request);
+  }
+
+  @Override
+  public ApiFuture<Table> getTableAsync(String tableId) {
+    return delegate.getTableAsync(tableId);
+  }
+
+  @Override
+  public ApiFuture<List<String>> listTablesAsync() {
+    return delegate.listTablesAsync();
+  }
+
+  @Override
+  public ApiFuture<Void> deleteTableAsync(String tableId) {
+    return delegate.deleteTableAsync(tableId);
+  }
+
+  @Override
+  public ApiFuture<Table> modifyFamiliesAsync(ModifyColumnFamiliesRequest request) {
+    return delegate.modifyFamiliesAsync(request);
+  }
+
+  @Override
+  public ApiFuture<Void> dropRowRangeAsync(String tableId, String rowKeyPrefix) {
+    return delegate.dropRowRangeAsync(tableId, rowKeyPrefix);
+  }
+
+  @Override
+  public ApiFuture<Void> dropAllRowsAsync(String tableId) {
+    return delegate.dropAllRowsAsync(tableId);
+  }
+
+  @Override
+  public void close() throws Exception {
+    delegate.close();
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BulkMutationVeneerApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BulkMutationVeneerApi.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers.veneer;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.InternalApi;
+import com.google.api.gax.batching.Batcher;
+import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
+import com.google.cloud.bigtable.hbase.wrappers.BulkMutationWrapper;
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+
+/** For internal use only - public for technical reasons. */
+@InternalApi("For internal usage only")
+public class BulkMutationVeneerApi implements BulkMutationWrapper {
+
+  private final Batcher<RowMutationEntry, Void> bulkMutateBatcher;
+
+  BulkMutationVeneerApi(Batcher<RowMutationEntry, Void> bulkMutateBatcher) {
+    this.bulkMutateBatcher = bulkMutateBatcher;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public synchronized ApiFuture<Void> add(RowMutationEntry rowMutation) {
+    Preconditions.checkNotNull(rowMutation, "mutation details cannot be null");
+    return bulkMutateBatcher.add(rowMutation);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void sendUnsent() {
+    bulkMutateBatcher.sendOutstanding();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void flush() {
+    try {
+      bulkMutateBatcher.flush();
+    } catch (InterruptedException ex) {
+      throw new RuntimeException("Could not complete RPC for current Batch", ex);
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      bulkMutateBatcher.close();
+    } catch (InterruptedException e) {
+      throw new IOException("Could not close the bulk mutation Batcher", e);
+    }
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestAdminClientVeneerApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestAdminClientVeneerApi.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers.veneer;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.bigtable.admin.v2.BigtableTableAdminGrpc;
+import com.google.bigtable.admin.v2.DeleteTableRequest;
+import com.google.bigtable.admin.v2.DropRowRangeRequest;
+import com.google.bigtable.admin.v2.GetTableRequest;
+import com.google.bigtable.admin.v2.ListTablesRequest;
+import com.google.bigtable.admin.v2.ListTablesResponse;
+import com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient;
+import com.google.cloud.bigtable.admin.v2.BigtableTableAdminSettings;
+import com.google.cloud.bigtable.admin.v2.internal.NameUtil;
+import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
+import com.google.cloud.bigtable.admin.v2.models.ModifyColumnFamiliesRequest;
+import com.google.cloud.bigtable.admin.v2.models.Table;
+import com.google.common.collect.Queues;
+import com.google.protobuf.Empty;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.stub.StreamObserver;
+import java.net.ServerSocket;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TestAdminClientVeneerApi {
+
+  private static final String PROJECT_ID = "fake-project-id";
+  private static final String INSTANCE_ID = "fake-instance-id";
+  private static final String TABLE_ID_1 = "fake-Table-id-1";
+  private static final String TABLE_ID_2 = "fake-Table-id-2";
+
+  private FakeBigtableAdmin fakeAdminService = new FakeBigtableAdmin();
+  private Server server;
+  private BigtableTableAdminClient adminClientV2;
+  private AdminClientVeneerApi adminClientWrapper;
+
+  @Before
+  public void setUp() throws Exception {
+    final int port;
+    try (ServerSocket serverSocket = new ServerSocket(0)) {
+      port = serverSocket.getLocalPort();
+    }
+
+    server = ServerBuilder.forPort(port).addService(fakeAdminService).build();
+    server.start();
+    adminClientV2 =
+        BigtableTableAdminClient.create(
+            BigtableTableAdminSettings.newBuilderForEmulator(port)
+                .setProjectId(PROJECT_ID)
+                .setInstanceId(INSTANCE_ID)
+                .build());
+    adminClientWrapper = new AdminClientVeneerApi(adminClientV2);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    adminClientWrapper.close();
+    adminClientV2.close();
+
+    if (server != null) {
+      server.shutdown();
+      server.awaitTermination();
+    }
+  }
+
+  @Test
+  public void testCreateTableAsync() throws Exception {
+    CreateTableRequest req = CreateTableRequest.of(TABLE_ID_1);
+    Future<Table> response = adminClientWrapper.createTableAsync(req);
+    assertEquals(TABLE_ID_1, response.get().getId());
+  }
+
+  @Test
+  public void testGetTableAsync() throws Exception {
+    Future<Table> response = adminClientWrapper.getTableAsync("test-async-table");
+    assertEquals(TABLE_ID_1, response.get().getId());
+  }
+
+  @Test
+  public void testListTablesAsync() throws Exception {
+    Future<List<String>> tableIds = adminClientWrapper.listTablesAsync();
+    assertEquals(Arrays.asList(TABLE_ID_1, TABLE_ID_2), tableIds.get());
+  }
+
+  @Test
+  public void testDeleteTableAsync() throws Exception {
+    Future<Void> deleteResponse = adminClientWrapper.deleteTableAsync("deleteAsyncTableID");
+    deleteResponse.get();
+    DeleteTableRequest deleteTableReq = fakeAdminService.popLastRequest();
+    assertEquals(
+        "deleteAsyncTableID", NameUtil.extractTableIdFromTableName(deleteTableReq.getName()));
+  }
+
+  @Test
+  public void testModifyFamilyAsync() throws Exception {
+    ModifyColumnFamiliesRequest request =
+        ModifyColumnFamiliesRequest.of(TABLE_ID_1)
+            .addFamily("first-family")
+            .addFamily("another-family");
+    Future<Table> response = adminClientWrapper.modifyFamiliesAsync(request);
+    assertEquals(TABLE_ID_1, response.get().getId());
+  }
+
+  @Test
+  public void dropRowRangeAsync() throws Exception {
+    String rowKey = "cf-dropRange-async";
+    adminClientWrapper.dropRowRangeAsync(TABLE_ID_1, rowKey).get();
+    DropRowRangeRequest rangeRequest = fakeAdminService.popLastRequest();
+    assertEquals(TABLE_ID_1, NameUtil.extractTableIdFromTableName(rangeRequest.getName()));
+    assertEquals(rowKey, rangeRequest.getRowKeyPrefix().toStringUtf8());
+  }
+
+  @Test
+  public void dropAllRowsAsync() throws Exception {
+    String tableId = "tableWithNoDataId";
+    adminClientWrapper.dropAllRowsAsync(tableId).get();
+    DropRowRangeRequest rangeRequest = fakeAdminService.popLastRequest();
+    assertEquals(tableId, NameUtil.extractTableIdFromTableName(rangeRequest.getName()));
+  }
+
+  private static class FakeBigtableAdmin extends BigtableTableAdminGrpc.BigtableTableAdminImplBase {
+
+    final BlockingQueue<Object> requests = Queues.newLinkedBlockingDeque();
+
+    @SuppressWarnings("unchecked")
+    <T> T popLastRequest() throws InterruptedException {
+      return (T) requests.poll(1, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void createTable(
+        com.google.bigtable.admin.v2.CreateTableRequest request,
+        StreamObserver<com.google.bigtable.admin.v2.Table> responseObserver) {
+      requests.add(request);
+      responseObserver.onNext(
+          com.google.bigtable.admin.v2.Table.newBuilder()
+              .setName(NameUtil.formatTableName(PROJECT_ID, INSTANCE_ID, TABLE_ID_1))
+              .build());
+      responseObserver.onCompleted();
+    }
+
+    @Override
+    public void getTable(
+        GetTableRequest request,
+        StreamObserver<com.google.bigtable.admin.v2.Table> responseObserver) {
+      requests.add(request);
+      responseObserver.onNext(
+          com.google.bigtable.admin.v2.Table.newBuilder()
+              .setName(NameUtil.formatTableName(PROJECT_ID, INSTANCE_ID, TABLE_ID_1))
+              .build());
+      responseObserver.onCompleted();
+    }
+
+    @Override
+    public void listTables(
+        ListTablesRequest request, StreamObserver<ListTablesResponse> responseObserver) {
+      requests.add(request);
+      ListTablesResponse.Builder builder = ListTablesResponse.newBuilder();
+      builder
+          .addTablesBuilder()
+          .setName(NameUtil.formatTableName(PROJECT_ID, INSTANCE_ID, TABLE_ID_1))
+          .build();
+      builder
+          .addTablesBuilder()
+          .setName(NameUtil.formatTableName(PROJECT_ID, INSTANCE_ID, TABLE_ID_2))
+          .build();
+      responseObserver.onNext(builder.build());
+      responseObserver.onCompleted();
+    }
+
+    @Override
+    public void deleteTable(DeleteTableRequest request, StreamObserver<Empty> responseObserver) {
+      requests.add(request);
+      responseObserver.onNext(Empty.newBuilder().build());
+      responseObserver.onCompleted();
+    }
+
+    @Override
+    public void modifyColumnFamilies(
+        com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest request,
+        StreamObserver<com.google.bigtable.admin.v2.Table> responseObserver) {
+      requests.add(request);
+      responseObserver.onNext(
+          com.google.bigtable.admin.v2.Table.newBuilder()
+              .setName(NameUtil.formatTableName(PROJECT_ID, INSTANCE_ID, TABLE_ID_1))
+              .build());
+      responseObserver.onCompleted();
+    }
+
+    @Override
+    public void dropRowRange(DropRowRangeRequest request, StreamObserver<Empty> responseObserver) {
+      requests.add(request);
+      responseObserver.onNext(Empty.newBuilder().build());
+      responseObserver.onCompleted();
+    }
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBulkMutationVeneerApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBulkMutationVeneerApi.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers.veneer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.SettableApiFuture;
+import com.google.api.gax.batching.Batcher;
+import com.google.api.gax.batching.BatcherImpl;
+import com.google.api.gax.batching.BatchingDescriptor;
+import com.google.api.gax.batching.BatchingSettings;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
+import com.google.cloud.bigtable.hbase.wrappers.BulkMutationWrapper;
+import java.io.IOException;
+import java.util.concurrent.ScheduledExecutorService;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.stubbing.Answer;
+
+@RunWith(JUnit4.class)
+public class TestBulkMutationVeneerApi {
+
+  @Rule public MockitoRule rule = MockitoJUnit.rule();
+
+  @Mock private Batcher<RowMutationEntry, Void> batcher;
+
+  @InjectMocks private BulkMutationVeneerApi bulkMutationWrapper;
+
+  private RowMutationEntry rowMutation = RowMutationEntry.create("fake-key");
+
+  @Test
+  public void testAdd() {
+    SettableApiFuture<Void> future = SettableApiFuture.create();
+    when(batcher.add(rowMutation)).thenReturn(future);
+    ApiFuture<Void> result = bulkMutationWrapper.add(rowMutation);
+    assertFalse(result.isDone());
+    future.set(null);
+    assertTrue(result.isDone());
+    verify(batcher).add(rowMutation);
+  }
+
+  @Test
+  public void testAddFailure() throws Exception {
+    RuntimeException exception = new RuntimeException("can not perform mutation");
+    SettableApiFuture<Void> future = SettableApiFuture.create();
+    when(batcher.add(rowMutation)).thenReturn(future);
+    future.setException(exception);
+    try {
+      bulkMutationWrapper.add(rowMutation).get();
+      fail("should throw an exception");
+    } catch (Exception actualException) {
+      assertEquals(exception, actualException.getCause());
+    }
+    verify(batcher).add(rowMutation);
+  }
+
+  @Test
+  public void testFlush() throws Exception {
+    final SettableApiFuture<Void> future = SettableApiFuture.create();
+    final SettableApiFuture<Void> future2 = SettableApiFuture.create();
+    when(batcher.add(rowMutation)).thenReturn(future).thenReturn(future2);
+    doAnswer(
+            new Answer() {
+              @Override
+              public Object answer(InvocationOnMock invocationOnMock) {
+                future.set(null);
+                future2.set(null);
+                return null;
+              }
+            })
+        .when(batcher)
+        .flush();
+    ApiFuture<Void> result1 = bulkMutationWrapper.add(rowMutation);
+    ApiFuture<Void> result2 = bulkMutationWrapper.add(rowMutation);
+    // flush should block until the responses are resolved.
+    bulkMutationWrapper.flush();
+
+    assertTrue(result1.isDone());
+    assertTrue(result2.isDone());
+    verify(batcher, times(2)).add(rowMutation);
+    verify(batcher).flush();
+  }
+
+  @Test
+  public void testIsClosed() throws IOException {
+    @SuppressWarnings("unchecked")
+    Batcher<RowMutationEntry, Void> actualBatcher =
+        new BatcherImpl(
+            mock(BatchingDescriptor.class),
+            mock(UnaryCallable.class),
+            new Object(),
+            mock(BatchingSettings.class),
+            mock(ScheduledExecutorService.class));
+    BulkMutationWrapper underTest = new BulkMutationVeneerApi(actualBatcher);
+    underTest.close();
+
+    Exception actualEx = null;
+    try {
+      underTest.add(rowMutation);
+    } catch (Exception e) {
+      actualEx = e;
+    }
+    assertTrue(actualEx instanceof IllegalStateException);
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBulkMutationVeneerApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBulkMutationVeneerApi.java
@@ -70,7 +70,7 @@ public class TestBulkMutationVeneerApi {
   }
 
   @Test
-  public void testAddFailure() throws Exception {
+  public void testAddFailure() {
     RuntimeException exception = new RuntimeException("can not perform mutation");
     SettableApiFuture<Void> future = SettableApiFuture.create();
     when(batcher.add(rowMutation)).thenReturn(future);
@@ -86,14 +86,14 @@ public class TestBulkMutationVeneerApi {
 
   @Test
   public void testFlush() throws Exception {
-    final SettableApiFuture<Void> future = SettableApiFuture.create();
+    final SettableApiFuture<Void> future1 = SettableApiFuture.create();
     final SettableApiFuture<Void> future2 = SettableApiFuture.create();
-    when(batcher.add(rowMutation)).thenReturn(future).thenReturn(future2);
+    when(batcher.add(rowMutation)).thenReturn(future1).thenReturn(future2);
     doAnswer(
             new Answer() {
               @Override
               public Object answer(InvocationOnMock invocationOnMock) {
-                future.set(null);
+                future1.set(null);
                 future2.set(null);
                 return null;
               }
@@ -112,7 +112,7 @@ public class TestBulkMutationVeneerApi {
   }
 
   @Test
-  public void testIsClosed() throws IOException {
+  public void testWhenBatcherIsClosed() throws IOException {
     @SuppressWarnings("unchecked")
     Batcher<RowMutationEntry, Void> actualBatcher =
         new BatcherImpl(
@@ -127,6 +127,7 @@ public class TestBulkMutationVeneerApi {
     Exception actualEx = null;
     try {
       underTest.add(rowMutation);
+      fail("batcher should throw exception");
     } catch (Exception e) {
       actualEx = e;
     }


### PR DESCRIPTION
Towards #2454

This PR adds veneer specific implementation for `AdminClientWrapper` and `BulkMutationWrapper`.