### PR TITLE
fix: fixes missed AsyncBufferedMutator#close 

### DIFF
--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncBufferedMutator.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncBufferedMutator.java
@@ -22,6 +22,7 @@ import com.google.cloud.bigtable.hbase.BigtableBufferedMutatorHelper;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.cloud.bigtable.hbase.wrappers.BigtableApi;
 import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -56,6 +57,11 @@ public class BigtableAsyncBufferedMutator implements AsyncBufferedMutator {
   @Override
   public void close() {
     flush();
+    try {
+      helper.close();
+    } catch (IOException ioException) {
+      throw new RuntimeException("could not close buffered mutator", ioException);
+    }
   }
 
   /** {@inheritDoc} */
@@ -86,7 +92,7 @@ public class BigtableAsyncBufferedMutator implements AsyncBufferedMutator {
   @Override
   public List<CompletableFuture<Void>> mutate(List<? extends Mutation> mutations) {
     return helper.mutate(mutations).stream()
-        .map(listenableFuture -> toCompletableFuture(listenableFuture).thenApply(r -> (Void) null))
+        .map(apiFuture -> toCompletableFuture(apiFuture).thenApply(r -> (Void) null))
         .collect(Collectors.toList());
   }
 

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase2_x/TestBigtableAsyncBufferedMutator.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase2_x/TestBigtableAsyncBufferedMutator.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase2_x;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.api.core.ApiFutures;
+import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
+import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
+import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableApi;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
+import com.google.cloud.bigtable.hbase.wrappers.BulkMutationWrapper;
+import com.google.cloud.bigtable.hbase.wrappers.DataClientWrapper;
+import java.util.Arrays;
+import java.util.concurrent.ExecutionException;
+import org.apache.hadoop.hbase.client.Append;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@RunWith(JUnit4.class)
+public class TestBigtableAsyncBufferedMutator {
+
+  @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  private static final String TABLE_ID = "fake-table";
+
+  @Mock private BigtableApi mockBigtableApi;
+
+  @Mock private BigtableHBaseSettings mockBigtableSettings;
+
+  @Mock private HBaseRequestAdapter mockRequestAdapter;
+
+  @Mock private DataClientWrapper mockDataClient;
+
+  @Mock private BulkMutationWrapper mockBulkMutation;
+
+  private BigtableAsyncBufferedMutator asyncBufferedMutator;
+
+  @Before
+  public void setUp() {
+    when(mockBigtableApi.getDataClient()).thenReturn(mockDataClient);
+    when(mockRequestAdapter.getTableId()).thenReturn(TABLE_ID);
+    when(mockDataClient.createBulkMutation(TABLE_ID)).thenReturn(mockBulkMutation);
+    asyncBufferedMutator =
+        new BigtableAsyncBufferedMutator(mockBigtableApi, mockBigtableSettings, mockRequestAdapter);
+  }
+
+  @After
+  public void tearDown() {
+    asyncBufferedMutator.close();
+  }
+
+  @Test
+  public void testClose() throws Exception {
+    doNothing().when(mockBulkMutation).sendUnsent();
+    doNothing().when(mockBulkMutation).flush();
+    doNothing().when(mockBulkMutation).close();
+
+    asyncBufferedMutator.close();
+
+    verify(mockBulkMutation).sendUnsent();
+    verify(mockBulkMutation).flush();
+    verify(mockBulkMutation).close();
+  }
+
+  @Test
+  public void testFlush() {
+    doNothing().when(mockBulkMutation).sendUnsent();
+    asyncBufferedMutator.flush();
+    verify(mockBulkMutation).sendUnsent();
+  }
+
+  @Test
+  public void testMutate() throws ExecutionException, InterruptedException {
+    Put put = new Put(Bytes.toBytes("rowKey"));
+    RowMutationEntry entry = RowMutationEntry.create("rowKey");
+
+    when(mockRequestAdapter.adaptEntry(put)).thenReturn(entry);
+    when(mockBulkMutation.add(entry)).thenReturn(ApiFutures.immediateFuture(null));
+    asyncBufferedMutator.mutate(put).get();
+
+    verify(mockRequestAdapter).adaptEntry(put);
+    verify(mockBulkMutation).add(entry);
+  }
+
+  @Test
+  public void testMutateWithList() {
+    Put put = new Put(Bytes.toBytes("rowKey"));
+    Delete delete = new Delete(Bytes.toBytes("to-be-deleted-row"));
+    Append append = new Append(Bytes.toBytes("appended-row"));
+
+    RowMutationEntry rowEntryForPut = RowMutationEntry.create("rowKey");
+    RowMutationEntry rowEntryForDelete = RowMutationEntry.create("to-be-deleted-row");
+    ReadModifyWriteRow readModifyWriteRow = ReadModifyWriteRow.create(TABLE_ID, "appended-row");
+
+    when(mockRequestAdapter.adaptEntry(put)).thenReturn(rowEntryForPut);
+    when(mockRequestAdapter.adaptEntry(delete)).thenReturn(rowEntryForDelete);
+    when(mockRequestAdapter.adapt(append)).thenReturn(readModifyWriteRow);
+
+    when(mockBulkMutation.add(rowEntryForPut)).thenReturn(ApiFutures.immediateFuture(null));
+    when(mockBulkMutation.add(rowEntryForDelete)).thenReturn(ApiFutures.immediateFuture(null));
+    when(mockDataClient.readModifyWriteRowAsync(readModifyWriteRow))
+        .thenReturn(ApiFutures.immediateFuture(Result.EMPTY_RESULT));
+
+    asyncBufferedMutator
+        .mutate(Arrays.asList(put, delete, append))
+        .forEach(
+            future -> {
+              try {
+                future.get();
+              } catch (InterruptedException | ExecutionException e) {
+                throw new AssertionError("BigtableAsyncBufferedMutator#mutate test failed");
+              }
+            });
+
+    verify(mockRequestAdapter).adaptEntry(put);
+    verify(mockRequestAdapter).adaptEntry(delete);
+    verify(mockRequestAdapter).adapt(append);
+
+    verify(mockBulkMutation).add(rowEntryForPut);
+    verify(mockBulkMutation).add(rowEntryForDelete);
+    verify(mockDataClient).readModifyWriteRowAsync(readModifyWriteRow);
+  }
+}


### PR DESCRIPTION
Thanks @igorbernstein2 for pointing this out [here](https://github.com/googleapis/java-bigtable-hbase/pull/2475/files#r401808975).

This PR fixes missed bufferedMutator.close(). Also, adding unit test cases for the same.