### PR TITLE
fix: updated assertions and scan for firstKeyOnlyFilter test

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestFilters.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestFilters.java
@@ -1388,7 +1388,9 @@ public abstract class AbstractTestFilters extends AbstractTest {
       for (Result result : resultScanner) {
         Assert.assertArrayEquals(Bytes.toBytes(rowPrefix + rowIndex), result.getRow());
         Assert.assertEquals("Should only return 1 keyvalue", 1, result.size());
-        Assert.assertTrue(CellUtil.matchingValue(result.rawCells()[0], columnValue));
+        Assert.assertTrue(
+            "Should contains column value",
+            CellUtil.matchingValue(result.rawCells()[0], columnValue));
 
         rowIndex++;
       }

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestFilters.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestFilters.java
@@ -1366,14 +1366,14 @@ public abstract class AbstractTestFilters extends AbstractTest {
     int rowCount = 5;
     int numCols = 5;
     String rowPrefix = dataHelper.randomString("testFirstKeyValue-");
-    String columnValue = "includeThisValue";
+    byte[] columnValue = Bytes.toBytes("includeThisValue");
     Table table = getDefaultTable();
 
     List<Put> puts = new ArrayList<>(rowCount);
     for (int rowIndex = 0; rowIndex < rowCount; rowIndex++) {
       Put put = new Put(Bytes.toBytes(rowPrefix + rowIndex));
       for (int i = 0; i < numCols; ++i) {
-        put.addColumn(COLUMN_FAMILY, dataHelper.randomData(""), Bytes.toBytes(columnValue));
+        put.addColumn(COLUMN_FAMILY, dataHelper.randomData(""), columnValue);
       }
       puts.add(put);
     }
@@ -1388,6 +1388,7 @@ public abstract class AbstractTestFilters extends AbstractTest {
       for (Result result : resultScanner) {
         Assert.assertArrayEquals(Bytes.toBytes(rowPrefix + rowIndex), result.getRow());
         Assert.assertEquals("Should only return 1 keyvalue", 1, result.size());
+        Assert.assertTrue(CellUtil.matchingValue(result.rawCells()[0], columnValue));
 
         rowIndex++;
       }

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestFilters.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestFilters.java
@@ -1363,22 +1363,35 @@ public abstract class AbstractTestFilters extends AbstractTest {
   @Test
   public void testFirstKeyFilter() throws IOException {
     // Initialize
+    int rowCount = 5;
     int numCols = 5;
+    String rowPrefix = dataHelper.randomString("testFirstKeyValue-");
     String columnValue = "includeThisValue";
     Table table = getDefaultTable();
-    byte[] rowKey = dataHelper.randomData("testRow-");
-    Put put = new Put(rowKey);
-    for (int i = 0; i < numCols; ++i) {
-      put.addColumn(COLUMN_FAMILY, dataHelper.randomData(""), Bytes.toBytes(columnValue));
+
+    List<Put> puts = new ArrayList<>(rowCount);
+    for (int rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+      Put put = new Put(Bytes.toBytes(rowPrefix + rowIndex));
+      for (int i = 0; i < numCols; ++i) {
+        put.addColumn(COLUMN_FAMILY, dataHelper.randomData(""), Bytes.toBytes(columnValue));
+      }
+      puts.add(put);
     }
-    table.put(put);
+    table.put(puts);
 
     // Filter for results
     Filter filter = new FirstKeyOnlyFilter();
 
-    Get get = new Get(rowKey).setFilter(filter);
-    Result result = table.get(get);
-    Assert.assertEquals("Should only return 1 keyvalue", 1, result.size());
+    Scan scan = new Scan().setRowPrefixFilter(Bytes.toBytes(rowPrefix)).setFilter(filter);
+    try (ResultScanner resultScanner = table.getScanner(scan)) {
+      int rowIndex = 0;
+      for (Result result : resultScanner) {
+        Assert.assertArrayEquals(Bytes.toBytes(rowPrefix + rowIndex), result.getRow());
+        Assert.assertEquals("Should only return 1 keyvalue", 1, result.size());
+
+        rowIndex++;
+      }
+    }
 
     table.close();
   }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FirstKeyOnlyFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FirstKeyOnlyFilterAdapter.java
@@ -29,8 +29,7 @@ import org.apache.hadoop.hbase.filter.FirstKeyOnlyFilter;
 @InternalApi("For internal usage only")
 public class FirstKeyOnlyFilterAdapter extends TypedFilterAdapterBase<FirstKeyOnlyFilter> {
 
-  private static Filters.Filter LIMIT_ONE =
-      FILTERS.chain().filter(FILTERS.limit().cellsPerRow(1)).filter(FILTERS.value().strip());
+  private static Filters.Filter LIMIT_ONE = FILTERS.limit().cellsPerRow(1);
 
   /** {@inheritDoc} */
   @Override

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFirstKeyOnlyFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFirstKeyOnlyFilterAdapter.java
@@ -35,12 +35,6 @@ public class TestFirstKeyOnlyFilterAdapter {
   public void onlyTheFirstKeyFromEachRowIsEmitted() throws IOException {
     Filters.Filter adaptedFilter =
         adapter.adapt(new FilterAdapterContext(new Scan(), null), new FirstKeyOnlyFilter());
-    Assert.assertEquals(
-        FILTERS
-            .chain()
-            .filter(FILTERS.limit().cellsPerRow(1))
-            .filter(FILTERS.value().strip())
-            .toProto(),
-        adaptedFilter.toProto());
+    Assert.assertEquals(FILTERS.limit().cellsPerRow(1).toProto(), adaptedFilter.toProto());
   }
 }


### PR DESCRIPTION
Fixes #2477 

This PR update integration test to perform a `scan` and `rowKey` assertions to verify firstKeyOnlyFilter functionality.