### PR TITLE
deps: update beam to 2.20.0

### DIFF
--- a/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
@@ -88,7 +88,7 @@ limitations under the License.
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>${beam-guava.version}</version>
+      <version>${guava.version}</version>
     </dependency>
 
     <!-- TODO: check if commons-codec was transitively updated to 1.13 and okhttp was updated to 2.7.5 when upgrading-->

--- a/pom.xml
+++ b/pom.xml
@@ -76,10 +76,9 @@ limitations under the License.
     <hamcrest.version>1.3</hamcrest.version>
     <mockito.version>3.3.3</mockito.version>
     <!-- TODO: check if commons-codec was transitively updated to 1.13 and okhttp was updated to 2.7.5 when upgrading-->
-    <beam.version>2.19.0</beam.version>
+    <beam.version>2.20.0</beam.version>
     <!-- referred from bigtable-beam-import and bigtable-emulator -->
     <guava.version>28.2-android</guava.version>
-    <beam-guava.version>20.0</beam-guava.version>
     <beam-auto-value.version>1.7</beam-auto-value.version>
 
     <!-- Benchmarks related dependencies -->


### PR DESCRIPTION
Looks like guava was updated and the need to align with 20.0 is no longer necessary.

Opening in favor of #2494 