### PR TITLE
fix: to fix deleteRowRangeByPrefix for integer values above 127

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBigtableTableAdminClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBigtableTableAdminClient.java
@@ -28,6 +28,7 @@ import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
 import com.google.cloud.bigtable.admin.v2.models.ModifyColumnFamiliesRequest;
 import com.google.cloud.bigtable.admin.v2.models.Table;
 import com.google.longrunning.Operation;
+import com.google.protobuf.ByteString;
 import java.util.List;
 
 /**
@@ -124,11 +125,28 @@ public interface IBigtableTableAdminClient {
   /**
    * Permanently deletes all rows in a range.
    *
+   * @param tableId a {@link String} object representing table Id.
+   * @param rowKeyPrefix a {@link ByteString} object representing row key prefix.
+   */
+  void dropRowRange(String tableId, ByteString rowKeyPrefix);
+
+  /**
+   * Permanently deletes all rows in a range.
+   *
    * @param tableId
    * @param rowKeyPrefix
    * @return a {@link ApiFuture} that returns {@link Void} object.
    */
   ApiFuture<Void> dropRowRangeAsync(String tableId, String rowKeyPrefix);
+
+  /**
+   * Permanently deletes all rows in a range.
+   *
+   * @param tableId a {@link String} object representing table Id.
+   * @param rowKeyPrefix a {@link ByteString} object representing row key prefix.
+   * @return a {@link ApiFuture} that returns {@link Void} object.
+   */
+  ApiFuture<Void> dropRowRangeAsync(String tableId, ByteString rowKeyPrefix);
 
   /**
    * Drops all data in the table.

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminClientWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminClientWrapper.java
@@ -208,12 +208,17 @@ public class BigtableTableAdminClientWrapper implements IBigtableTableAdminClien
   /** {@inheritDoc} */
   @Override
   public void dropRowRange(String tableId, String rowKeyPrefix) {
+    dropRowRange(tableId, ByteString.copyFromUtf8(rowKeyPrefix));
+  }
+
+  @Override
+  public void dropRowRange(String tableId, ByteString rowKeyPrefix) {
     Preconditions.checkNotNull(rowKeyPrefix);
     DropRowRangeRequest protoRequest =
         DropRowRangeRequest.newBuilder()
             .setName(instanceName.toTableNameStr(tableId))
             .setDeleteAllDataFromTable(false)
-            .setRowKeyPrefix(ByteString.copyFromUtf8(rowKeyPrefix))
+            .setRowKeyPrefix(rowKeyPrefix)
             .build();
     delegate.dropRowRange(protoRequest);
   }
@@ -221,12 +226,17 @@ public class BigtableTableAdminClientWrapper implements IBigtableTableAdminClien
   /** {@inheritDoc} */
   @Override
   public ApiFuture<Void> dropRowRangeAsync(String tableId, String rowKeyPrefix) {
+    return dropRowRangeAsync(tableId, ByteString.copyFromUtf8(rowKeyPrefix));
+  }
+
+  @Override
+  public ApiFuture<Void> dropRowRangeAsync(String tableId, ByteString rowKeyPrefix) {
     Preconditions.checkNotNull(rowKeyPrefix);
     DropRowRangeRequest protoRequest =
         DropRowRangeRequest.newBuilder()
             .setName(instanceName.toTableNameStr(tableId))
             .setDeleteAllDataFromTable(false)
-            .setRowKeyPrefix(ByteString.copyFromUtf8(rowKeyPrefix))
+            .setRowKeyPrefix(rowKeyPrefix)
             .build();
     return ApiFutureUtil.transformAndAdapt(
         delegate.dropRowRangeAsync(protoRequest),

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminGCJClient.java
@@ -35,6 +35,7 @@ import com.google.cloud.bigtable.admin.v2.models.ModifyColumnFamiliesRequest;
 import com.google.cloud.bigtable.admin.v2.models.Table;
 import com.google.cloud.bigtable.core.IBigtableTableAdminClient;
 import com.google.longrunning.Operation;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -124,9 +125,19 @@ public class BigtableTableAdminGCJClient implements IBigtableTableAdminClient, A
     delegate.dropRowRange(tableId, rowKeyPrefix);
   }
 
+  @Override
+  public void dropRowRange(String tableId, ByteString rowKeyPrefix) {
+    delegate.dropRowRange(tableId, rowKeyPrefix);
+  }
+
   /** {@inheritDoc} */
   @Override
   public ApiFuture<Void> dropRowRangeAsync(String tableId, String rowKeyPrefix) {
+    return delegate.dropRowRangeAsync(tableId, rowKeyPrefix);
+  }
+
+  @Override
+  public ApiFuture<Void> dropRowRangeAsync(String tableId, ByteString rowKeyPrefix) {
     return delegate.dropRowRangeAsync(tableId, rowKeyPrefix);
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/AdminClientWrapper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/AdminClientWrapper.java
@@ -20,6 +20,7 @@ import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
 import com.google.cloud.bigtable.admin.v2.models.ModifyColumnFamiliesRequest;
 import com.google.cloud.bigtable.admin.v2.models.Table;
+import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.util.List;
 
@@ -50,7 +51,7 @@ public interface AdminClientWrapper extends AutoCloseable {
   ApiFuture<Table> modifyFamiliesAsync(ModifyColumnFamiliesRequest request);
 
   /** Permanently deletes all rows in a range. */
-  ApiFuture<Void> dropRowRangeAsync(String tableId, String rowKeyPrefix);
+  ApiFuture<Void> dropRowRangeAsync(String tableId, ByteString rowKeyPrefix);
 
   /** Asynchronously drops all data in the table */
   ApiFuture<Void> dropAllRowsAsync(String tableId);

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/AdminClientClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/AdminClientClassicApi.java
@@ -133,13 +133,13 @@ public class AdminClientClassicApi implements AdminClientWrapper {
   }
 
   @Override
-  public ApiFuture<Void> dropRowRangeAsync(String tableId, String rowKeyPrefix) {
+  public ApiFuture<Void> dropRowRangeAsync(String tableId, ByteString rowKeyPrefix) {
     Preconditions.checkNotNull(rowKeyPrefix);
     DropRowRangeRequest protoRequest =
         DropRowRangeRequest.newBuilder()
             .setName(instanceName.toTableNameStr(tableId))
             .setDeleteAllDataFromTable(false)
-            .setRowKeyPrefix(ByteString.copyFromUtf8(rowKeyPrefix))
+            .setRowKeyPrefix(rowKeyPrefix)
             .build();
     return ApiFutureUtil.transformAndAdapt(
         delegate.dropRowRangeAsync(protoRequest),

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/AdminClientVeneerApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/AdminClientVeneerApi.java
@@ -22,6 +22,7 @@ import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
 import com.google.cloud.bigtable.admin.v2.models.ModifyColumnFamiliesRequest;
 import com.google.cloud.bigtable.admin.v2.models.Table;
 import com.google.cloud.bigtable.hbase.wrappers.AdminClientWrapper;
+import com.google.protobuf.ByteString;
 import java.util.List;
 
 /** For internal use only - public for technical reasons. */
@@ -60,7 +61,7 @@ public class AdminClientVeneerApi implements AdminClientWrapper {
   }
 
   @Override
-  public ApiFuture<Void> dropRowRangeAsync(String tableId, String rowKeyPrefix) {
+  public ApiFuture<Void> dropRowRangeAsync(String tableId, ByteString rowKeyPrefix) {
     return delegate.dropRowRangeAsync(tableId, rowKeyPrefix);
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
@@ -37,6 +37,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
+import com.google.protobuf.ByteString;
 import io.grpc.Status;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -798,7 +799,7 @@ public abstract class AbstractBigtableAdmin implements Admin {
     try {
       ApiExceptions.callAndTranslateApiException(
           tableAdminClientWrapper.dropRowRangeAsync(
-              tableName.getNameAsString(), Bytes.toString(prefix)));
+              tableName.getNameAsString(), ByteString.copyFrom(prefix)));
     } catch (Throwable throwable) {
       throw new IOException(
           String.format("Failed to truncate table '%s'", tableName.getNameAsString()), throwable);

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestAdminClientClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestAdminClientClassicApi.java
@@ -138,16 +138,17 @@ public class TestAdminClientClassicApi {
 
   @Test
   public void dropRowRangeAsyncForDeleteByPrefix() throws ExecutionException, InterruptedException {
+    ByteString rowKey = ByteString.copyFrom(new byte[] {0, -32, 122, 13});
     DropRowRangeRequest request =
         DropRowRangeRequest.newBuilder()
             .setName(TABLE_NAME)
             .setDeleteAllDataFromTable(false)
-            .setRowKeyPrefix(ByteString.copyFromUtf8(ROW_KEY_PREFIX))
+            .setRowKeyPrefix(rowKey)
             .build();
 
     when(delegate.dropRowRangeAsync(request))
         .thenReturn(immediateFuture(Empty.newBuilder().build()));
-    adminClientWrapper.dropRowRangeAsync(TABLE_ID, ROW_KEY_PREFIX).get();
+    adminClientWrapper.dropRowRangeAsync(TABLE_ID, rowKey).get();
 
     verify(delegate).dropRowRangeAsync(request);
   }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestAdminClientVeneerApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestAdminClientVeneerApi.java
@@ -30,6 +30,7 @@ import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
 import com.google.cloud.bigtable.admin.v2.models.ModifyColumnFamiliesRequest;
 import com.google.cloud.bigtable.admin.v2.models.Table;
 import com.google.common.collect.Queues;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
@@ -128,11 +129,11 @@ public class TestAdminClientVeneerApi {
 
   @Test
   public void dropRowRangeAsync() throws Exception {
-    String rowKey = "cf-dropRange-async";
+    ByteString rowKey = ByteString.copyFromUtf8("cf-dropRange-async");
     adminClientWrapper.dropRowRangeAsync(TABLE_ID_1, rowKey).get();
     DropRowRangeRequest rangeRequest = fakeAdminService.popLastRequest();
     assertEquals(TABLE_ID_1, NameUtil.extractTableIdFromTableName(rangeRequest.getName()));
-    assertEquals(rowKey, rangeRequest.getRowKeyPrefix().toStringUtf8());
+    assertEquals(rowKey, rangeRequest.getRowKeyPrefix());
   }
 
   @Test

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/pom.xml
@@ -108,6 +108,16 @@ limitations under the License.
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
+      <artifactId>grpc-google-cloud-bigtable-admin-v2</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-cloud-bigtable-admin-v2</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-cloud-bigtable-v2</artifactId>
       <scope>compile</scope>
     </dependency>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase1_x/TestBigtableAdmin.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase1_x/TestBigtableAdmin.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase1_x;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.bigtable.admin.v2.BigtableTableAdminGrpc;
+import com.google.bigtable.admin.v2.DropRowRangeRequest;
+import com.google.cloud.bigtable.hbase.BigtableConfiguration;
+import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Empty;
+import io.grpc.Metadata;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.concurrent.ArrayBlockingQueue;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.TableName;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TestBigtableAdmin {
+
+  private static final String PROJECT_ID = "fake-project";
+  private static final String INSTANCE_ID = "fake-instance";
+  private static final String TABLE_ID = "fake-table";
+  private static final String TABLE_NAME =
+      String.format("projects/%s/instances/%s/tables/%s", PROJECT_ID, INSTANCE_ID, TABLE_ID);
+
+  private Server fakeBigtableServer;
+  private BigtableConnection connection;
+  private BigtableAdmin admin;
+
+  private ArrayBlockingQueue requestQueue = new ArrayBlockingQueue(1);
+  private ArrayBlockingQueue responseQueue = new ArrayBlockingQueue(1);
+
+  @Before
+  public void setup() throws Exception {
+    final int port;
+
+    try (ServerSocket serverSocket = new ServerSocket(0)) {
+      port = serverSocket.getLocalPort();
+    }
+
+    fakeBigtableServer =
+        ServerBuilder.forPort(port)
+            .intercept(new RequestInterceptor())
+            .addService(new BigtableTableAdminGrpc.BigtableTableAdminImplBase() {})
+            .build();
+    fakeBigtableServer.start();
+
+    Configuration configuration = BigtableConfiguration.configure(PROJECT_ID, INSTANCE_ID);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + port);
+    connection = new BigtableConnection(configuration);
+    admin = (BigtableAdmin) connection.getAdmin();
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    connection.close();
+    fakeBigtableServer.shutdown();
+  }
+
+  @Test
+  public void testDeleteRowRangeByPrefixNonUtf8() throws IOException, InterruptedException {
+    TableName tableName = TableName.valueOf(TABLE_ID);
+    ByteString expectedKey = ByteString.copyFrom(new byte[] {0, 0, 0, (byte) 128});
+
+    DropRowRangeRequest expectedRequest =
+        DropRowRangeRequest.newBuilder().setName(TABLE_NAME).setRowKeyPrefix(expectedKey).build();
+    responseQueue.put(Empty.getDefaultInstance());
+
+    admin.deleteRowRangeByPrefix(tableName, expectedKey.toByteArray());
+
+    assertEquals(expectedRequest, requestQueue.take());
+  }
+
+  private class RequestInterceptor implements ServerInterceptor {
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+        final ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+      return new ServerCall.Listener<ReqT>() {
+        @Override
+        public void onReady() {
+          call.request(1);
+        }
+
+        @Override
+        public void onMessage(ReqT message) {
+          requestQueue.add(message);
+
+          call.sendHeaders(new Metadata());
+          try {
+            @SuppressWarnings("unchecked")
+            RespT response = (RespT) responseQueue.take();
+            call.sendMessage(response);
+            call.close(Status.OK, new Metadata());
+          } catch (InterruptedException e) {
+            call.close(
+                Status.CANCELLED
+                    .withCause(e)
+                    .withDescription("Timed out waiting for mock response"),
+                new Metadata());
+          }
+        }
+      };
+    }
+  }
+}


### PR DESCRIPTION
Fixes: #2509

This commit removes the intermediate conversion of `rowKeyPrefix` with UTF-8 String. Now we directly convert user-provided byte array to `ByteString` protobuf.
