### PR TITLE
Add timeout for take() in ResponseQueueReader

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
@@ -468,7 +468,8 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
 
     // Delegate all resumable operations to the scanner. It will request a non-resumable scanner
     // during operation.
-    final ResponseQueueReader reader = new ResponseQueueReader();
+    final ResponseQueueReader reader =
+        new ResponseQueueReader(retryOptions.getReadPartialRowTimeoutMillis());
     RetryingReadRowsOperation operation = createReadRowsRetryListener(request, reader);
     operation.setResultObserver(
         new StreamObserver<ReadRowsResponse>() {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/Watchdog.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/Watchdog.java
@@ -66,7 +66,7 @@ public class Watchdog implements Runnable {
   private static final Logger LOG = new Logger(Watchdog.class);
 
   // By default kill the stream after 10 minutes of inactivity
-  public static final long DEFAULT_IDLE_TIMEOUT_MS = TimeUnit.MINUTES.toMillis(10);
+  private static final long DEFAULT_IDLE_TIMEOUT_MS = TimeUnit.MINUTES.toMillis(10);
   private static final long MIN_CHECK_PERIOD_MS = TimeUnit.SECONDS.toMillis(10);
 
   // Dummy value to convert the ConcurrentHashMap into a Set

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/Watchdog.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/Watchdog.java
@@ -66,7 +66,7 @@ public class Watchdog implements Runnable {
   private static final Logger LOG = new Logger(Watchdog.class);
 
   // By default kill the stream after 10 minutes of inactivity
-  private static final long DEFAULT_IDLE_TIMEOUT_MS = TimeUnit.MINUTES.toMillis(10);
+  public static final long DEFAULT_IDLE_TIMEOUT_MS = TimeUnit.MINUTES.toMillis(10);
   private static final long MIN_CHECK_PERIOD_MS = TimeUnit.SECONDS.toMillis(10);
 
   // Dummy value to convert the ConcurrentHashMap into a Set

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResponseQueueReader.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResponseQueueReader.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.grpc.scanner;
 
 import com.google.api.core.InternalApi;
 import com.google.bigtable.v2.ReadRowsRequest;
+import com.google.cloud.bigtable.grpc.io.Watchdog;
 import com.google.cloud.bigtable.metrics.BigtableClientMetrics;
 import com.google.cloud.bigtable.metrics.BigtableClientMetrics.MetricLevel;
 import com.google.cloud.bigtable.metrics.Timer;
@@ -59,11 +60,9 @@ public class ResponseQueueReader
   private ClientCallStreamObserver<ReadRowsRequest> requestStream;
   private AtomicInteger markerCounter = new AtomicInteger();
 
-  private static final long DEFAULT_WAIT_FOR_ROWS_TIMEOUT = TimeUnit.MINUTES.toMillis(10);
-
   /** Constructor for ResponseQueueReader. */
   public ResponseQueueReader() {
-    this(DEFAULT_WAIT_FOR_ROWS_TIMEOUT);
+    this(Watchdog.DEFAULT_IDLE_TIMEOUT_MS);
   }
 
   public ResponseQueueReader(long waitForRowsTimeoutMillis) {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResponseQueueReader.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ResponseQueueReader.java
@@ -17,7 +17,6 @@ package com.google.cloud.bigtable.grpc.scanner;
 
 import com.google.api.core.InternalApi;
 import com.google.bigtable.v2.ReadRowsRequest;
-import com.google.cloud.bigtable.grpc.io.Watchdog;
 import com.google.cloud.bigtable.metrics.BigtableClientMetrics;
 import com.google.cloud.bigtable.metrics.BigtableClientMetrics.MetricLevel;
 import com.google.cloud.bigtable.metrics.Timer;
@@ -61,10 +60,6 @@ public class ResponseQueueReader
   private AtomicInteger markerCounter = new AtomicInteger();
 
   /** Constructor for ResponseQueueReader. */
-  public ResponseQueueReader() {
-    this(Watchdog.DEFAULT_IDLE_TIMEOUT_MS);
-  }
-
   public ResponseQueueReader(long waitForRowsTimeoutMillis) {
     if (BigtableClientMetrics.isEnabled(MetricLevel.Info)) {
       startTime = System.nanoTime();

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/ResponseQueueReaderTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/ResponseQueueReaderTest.java
@@ -51,9 +51,11 @@ public class ResponseQueueReaderTest {
 
   private ResponseQueueReader underTest;
 
+  private static final long waitForRowsTimeoutMillis = TimeUnit.SECONDS.toMillis(5);
+
   @Before
   public void setup() {
-    underTest = new ResponseQueueReader();
+    underTest = new ResponseQueueReader(waitForRowsTimeoutMillis);
     underTest.beforeStart(mockClientCallStreamObserver);
   }
 


### PR DESCRIPTION
- This should prevent issues where any bugs in the watchdog can cause
  this to block forever.

This is a defense in depth mitigation for failures in the Watchdog. See #2528 for an example of when not having this causes issues.
