### PR TITLE
test: Remove unused assertions and deprecated methods from HBase2

### DIFF
--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestColumnFamilyAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestColumnFamilyAdmin.java
@@ -30,16 +30,16 @@ public class TestColumnFamilyAdmin extends AbstractTestColumnFamilyAdmin {
 
   @Override
   protected void addColumn(byte[] columnName, int versions) throws Exception {
-    admin.addColumn(tableName, new HColumnDescriptor(columnName).setMaxVersions(versions));
+    admin.addColumnFamily(tableName, new HColumnDescriptor(columnName).setMaxVersions(versions));
   }
 
   @Override
   protected void modifyColumn(byte[] columnName, int versions) throws Exception {
-    admin.modifyColumn(tableName, new HColumnDescriptor(columnName).setMaxVersions(versions));
+    admin.modifyColumnFamily(tableName, new HColumnDescriptor(columnName).setMaxVersions(versions));
   }
 
   @Override
   protected void deleteColumn(byte[] columnName) throws Exception {
-    admin.deleteColumn(tableName, columnName);
+    admin.deleteColumnFamily(tableName, columnName);
   }
 }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestCreateTableHBase2.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestCreateTableHBase2.java
@@ -60,7 +60,7 @@ public class TestCreateTableHBase2 extends AbstractTestCreateTable {
 
   private TableDescriptor createDescriptor(TableName tableName) {
     return TableDescriptorBuilder.newBuilder(tableName)
-        .addColumnFamily(ColumnFamilyDescriptorBuilder.newBuilder(COLUMN_FAMILY).build())
+        .setColumnFamily(ColumnFamilyDescriptorBuilder.newBuilder(COLUMN_FAMILY).build())
         .build();
   }
 

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestPut.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestPut.java
@@ -68,11 +68,6 @@ public class TestPut extends AbstractTestPut {
     }
 
     Assert.assertNotNull("Exception should have been thrown", thrownException);
-    // Assert.assertEquals("Expecting one exception", 1, thrownException.getNumExceptions());
-    // Assert.assertArrayEquals("Row key", rowKey, thrownException.getRow.getRow());
-    // Assert.assertTrue("Cause: NoSuchColumnFamilyException",
-    //    thrownException.getCause() instanceof NoSuchColumnFamilyException);
-
     Get get = new Get(rowKey);
     Result result = table.get(get);
     Assert.assertEquals("Atomic behavior means there should be nothing here", 0, result.size());


### PR DESCRIPTION
In HBase2 there's several deprecated method such as addColumn etc,
I think it will be better to use latest method addColumnFamily. Furthermore,
there's unused assertion still included in the test in commented form.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable-hbase/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #2566 ☕️
