### PR TITLE
fix: ReadRows not counting the rpc as the first attempt

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
@@ -434,6 +434,11 @@ public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
   public ListenableFuture<ResultT> getAsyncResult() {
     Preconditions.checkState(operationTimerContext == null);
     operationTimerContext = rpc.getRpcMetrics().timeOperation();
+
+    // CreateFirstAttempt establishes the time when first call was made and the deadline is set to `timeOfFirstCall +
+    // timeout`. Hence, its important to create first attempt before any RPCs go out of client.
+    currentBackoff = exponentialRetryAlgorithm.createFirstAttempt();
+
     run();
     return completionFuture;
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
@@ -276,15 +276,6 @@ public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
   protected abstract boolean onOK(Metadata trailers);
 
   protected Long getNextBackoff() {
-    if (currentBackoff == null) {
-      // Historically, the client waited for "total timeout" after the first failure.  For now,
-      // that behavior is preserved, even though that's not the ideal.
-      //
-      // TODO: Think through retries, and create policy that works with the mental model most
-      //       users would have of relating to retries.  That would likely involve updating some
-      //       default settings in addition to changing the algorithm.
-      currentBackoff = exponentialRetryAlgorithm.createFirstAttempt();
-    }
     currentBackoff = exponentialRetryAlgorithm.createNextAttempt(currentBackoff);
     if (!exponentialRetryAlgorithm.shouldRetry(currentBackoff)) {
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
@@ -301,7 +301,9 @@ public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
 
   @VisibleForTesting
   public boolean inRetryMode() {
-    return currentBackoff != null;
+    // ResetStatusBasedBackoff will create the first attempt which creates currentBackoff with 0
+    // attempts.
+    return currentBackoff != null && currentBackoff.getAttemptCount() > 0;
   }
 
   /**
@@ -309,7 +311,9 @@ public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
    * Status oriented exception handling.
    */
   protected void resetStatusBasedBackoff() {
-    this.currentBackoff = null;
+    // Reset the backoff parameters. CreateFirstAttempt will log the current time as the time of
+    // first call and enforce timeout from this timeOfFirstCall.
+    this.currentBackoff = exponentialRetryAlgorithm.createFirstAttempt();
     this.failedCount = 0;
   }
 
@@ -357,6 +361,14 @@ public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
    * happen correctly.
    */
   protected void run() {
+
+    if (currentBackoff == null) {
+      // CreateFirstAttempt establishes the time when first call was made and the deadline is set to
+      // `timeOfFirstCall + timeout`. Hence, its important to create first attempt before any RPCs
+      // go out of client.
+      currentBackoff = exponentialRetryAlgorithm.createFirstAttempt();
+    }
+
     try (Scope scope = TRACER.withSpan(operationSpan)) {
       rpcTimerContext = rpc.getRpcMetrics().timeRpc();
       operationSpan.addAnnotation(
@@ -425,11 +437,6 @@ public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
   public ListenableFuture<ResultT> getAsyncResult() {
     Preconditions.checkState(operationTimerContext == null);
     operationTimerContext = rpc.getRpcMetrics().timeOperation();
-
-    // CreateFirstAttempt establishes the time when first call was made and the deadline is set to
-    // `timeOfFirstCall +
-    // timeout`. Hence, its important to create first attempt before any RPCs go out of client.
-    currentBackoff = exponentialRetryAlgorithm.createFirstAttempt();
 
     run();
     return completionFuture;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
@@ -435,7 +435,8 @@ public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
     Preconditions.checkState(operationTimerContext == null);
     operationTimerContext = rpc.getRpcMetrics().timeOperation();
 
-    // CreateFirstAttempt establishes the time when first call was made and the deadline is set to `timeOfFirstCall +
+    // CreateFirstAttempt establishes the time when first call was made and the deadline is set to
+    // `timeOfFirstCall +
     // timeout`. Hence, its important to create first attempt before any RPCs go out of client.
     currentBackoff = exponentialRetryAlgorithm.createFirstAttempt();
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/OperationClock.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/OperationClock.java
@@ -47,6 +47,11 @@ public class OperationClock implements ApiClock {
     this.timeNs = timeUnit.toNanos(time);
   }
 
+  @VisibleForTesting
+  synchronized void incrementSleepTime(long time, TimeUnit timeUnit) {
+    this.totalSleepTimeNs += timeUnit.toNanos(time);
+  }
+
   @Override
   public synchronized long nanoTime() {
     return timeNs + totalSleepTimeNs;

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestRetryingUnaryOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestRetryingUnaryOperation.java
@@ -151,13 +151,41 @@ public class TestRetryingUnaryOperation {
   }
 
   private void testTimeout(long expectedTimeoutMs, CallOptions options)
+          throws InterruptedException, java.util.concurrent.TimeoutException {
+    testTimeout(expectedTimeoutMs, options, Status.UNAVAILABLE,
+            /* Do maximum possible attempts within deadline */0 );
+  }
+
+  private void testDeadlineExceeded(long expectedTimeoutMs, CallOptions options)
+          throws InterruptedException, java.util.concurrent.TimeoutException {
+    // When the deadline is exceeded waiting for response, there is no time for a retry, hence only 1 attempt.
+    testTimeout(expectedTimeoutMs, options, Status.DEADLINE_EXCEEDED, 1);
+  }
+
+  /**
+   * Helper method to test timeout scenarios
+   * @param expectedTimeoutMs expected timeout in millis
+   * @param options call options for RPC calls.
+   * @param expectedError the error returned from the mock API call.
+   * @param expectedNumberOfAttempts Expected number of attempted RPCs, it includes the original call and all the
+   *                                 retries. Passing 0 cancels the validation on the number of attempts.
+   * @throws InterruptedException
+   * @throws java.util.concurrent.TimeoutException
+   */
+  private void testTimeout(final long expectedTimeoutMs, CallOptions options, final Status expectedError,
+                           final int expectedNumberOfAttempts)
       throws InterruptedException, java.util.concurrent.TimeoutException {
-    final Status errorStatus = Status.UNAVAILABLE;
+    final AtomicInteger counter = new AtomicInteger(0);
     Answer<Void> answer =
         new Answer<Void>() {
           @Override
           public Void answer(InvocationOnMock invocation) {
-            invocation.<Listener>getArgument(1).onClose(errorStatus, null);
+            if(expectedError == Status.DEADLINE_EXCEEDED){
+              // Simulate the client waiting for the response.
+              clock.incrementSleepTime(expectedTimeoutMs, TimeUnit.MILLISECONDS);
+            }
+            counter.incrementAndGet();
+            invocation.<Listener>getArgument(1).onClose(expectedError, null);
             return null;
           }
         };
@@ -169,9 +197,12 @@ public class TestRetryingUnaryOperation {
       Assert.fail();
     } catch (ExecutionException e) {
       Assert.assertEquals(BigtableRetriesExhaustedException.class, e.getCause().getClass());
-      Assert.assertEquals(errorStatus.getCode(), Status.fromThrowable(e).getCode());
+      Assert.assertEquals(expectedError.getCode(), Status.fromThrowable(e).getCode());
     }
 
+    if(expectedNumberOfAttempts > 0){
+      Assert.assertEquals(expectedNumberOfAttempts, counter.get());
+    }
     clock.assertTimeWithinExpectations(TimeUnit.MILLISECONDS.toNanos(expectedTimeoutMs));
   }
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestRetryingUnaryOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestRetryingUnaryOperation.java
@@ -151,36 +151,44 @@ public class TestRetryingUnaryOperation {
   }
 
   private void testTimeout(long expectedTimeoutMs, CallOptions options)
-          throws InterruptedException, java.util.concurrent.TimeoutException {
-    testTimeout(expectedTimeoutMs, options, Status.UNAVAILABLE,
-            /* Do maximum possible attempts within deadline */0 );
+      throws InterruptedException, java.util.concurrent.TimeoutException {
+    testTimeout(
+        expectedTimeoutMs,
+        options,
+        Status.UNAVAILABLE,
+        /* Do maximum possible attempts within deadline */ 0);
   }
 
   private void testDeadlineExceeded(long expectedTimeoutMs, CallOptions options)
-          throws InterruptedException, java.util.concurrent.TimeoutException {
-    // When the deadline is exceeded waiting for response, there is no time for a retry, hence only 1 attempt.
+      throws InterruptedException, java.util.concurrent.TimeoutException {
+    // When the deadline is exceeded waiting for response, there is no time for a retry, hence only
+    // 1 attempt.
     testTimeout(expectedTimeoutMs, options, Status.DEADLINE_EXCEEDED, 1);
   }
 
   /**
    * Helper method to test timeout scenarios
+   *
    * @param expectedTimeoutMs expected timeout in millis
    * @param options call options for RPC calls.
    * @param expectedError the error returned from the mock API call.
-   * @param expectedNumberOfAttempts Expected number of attempted RPCs, it includes the original call and all the
-   *                                 retries. Passing 0 cancels the validation on the number of attempts.
+   * @param expectedNumberOfAttempts Expected number of attempted RPCs, it includes the original
+   *     call and all the retries. Passing 0 cancels the validation on the number of attempts.
    * @throws InterruptedException
    * @throws java.util.concurrent.TimeoutException
    */
-  private void testTimeout(final long expectedTimeoutMs, CallOptions options, final Status expectedError,
-                           final int expectedNumberOfAttempts)
+  private void testTimeout(
+      final long expectedTimeoutMs,
+      CallOptions options,
+      final Status expectedError,
+      final int expectedNumberOfAttempts)
       throws InterruptedException, java.util.concurrent.TimeoutException {
     final AtomicInteger counter = new AtomicInteger(0);
     Answer<Void> answer =
         new Answer<Void>() {
           @Override
           public Void answer(InvocationOnMock invocation) {
-            if(expectedError == Status.DEADLINE_EXCEEDED){
+            if (expectedError == Status.DEADLINE_EXCEEDED) {
               // Simulate the client waiting for the response.
               clock.incrementSleepTime(expectedTimeoutMs, TimeUnit.MILLISECONDS);
             }
@@ -200,7 +208,7 @@ public class TestRetryingUnaryOperation {
       Assert.assertEquals(expectedError.getCode(), Status.fromThrowable(e).getCode());
     }
 
-    if(expectedNumberOfAttempts > 0){
+    if (expectedNumberOfAttempts > 0) {
       Assert.assertEquals(expectedNumberOfAttempts, counter.get());
     }
     clock.assertTimeWithinExpectations(TimeUnit.MILLISECONDS.toNanos(expectedTimeoutMs));


### PR DESCRIPTION
This is to fix test failures introduced in #2570. currentBackoff was originally null as a performance optimization. This new change will create new TimedAttemptSettings for every message.

Behavioral change: the first rpc counts as the first attempt

Fixes #2567
