### PR TITLE
fix: ReadRows not counting the rpc as the first attempt

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
@@ -301,7 +301,9 @@ public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
 
   @VisibleForTesting
   public boolean inRetryMode() {
-    return currentBackoff != null;
+    // ResetStatusBasedBackoff will create the first attempt which creates currentBackoff with 0
+    // attempts.
+    return currentBackoff != null && currentBackoff.getAttemptCount() > 0;
   }
 
   /**
@@ -309,7 +311,9 @@ public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
    * Status oriented exception handling.
    */
   protected void resetStatusBasedBackoff() {
-    this.currentBackoff = null;
+    // Reset the backoff parameters. CreateFirstAttempt will log the current time as the time of
+    // first call and enforce timeout from this timeOfFirstCall.
+    this.currentBackoff = exponentialRetryAlgorithm.createFirstAttempt();
     this.failedCount = 0;
   }
 
@@ -357,6 +361,14 @@ public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
    * happen correctly.
    */
   protected void run() {
+
+    if (currentBackoff == null) {
+      // CreateFirstAttempt establishes the time when first call was made and the deadline is set to
+      // `timeOfFirstCall + timeout`. Hence, its important to create first attempt before any RPCs
+      // go out of client.
+      currentBackoff = exponentialRetryAlgorithm.createFirstAttempt();
+    }
+
     try (Scope scope = TRACER.withSpan(operationSpan)) {
       rpcTimerContext = rpc.getRpcMetrics().timeRpc();
       operationSpan.addAnnotation(
@@ -425,11 +437,6 @@ public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
   public ListenableFuture<ResultT> getAsyncResult() {
     Preconditions.checkState(operationTimerContext == null);
     operationTimerContext = rpc.getRpcMetrics().timeOperation();
-
-    // CreateFirstAttempt establishes the time when first call was made and the deadline is set to
-    // `timeOfFirstCall +
-    // timeout`. Hence, its important to create first attempt before any RPCs go out of client.
-    currentBackoff = exponentialRetryAlgorithm.createFirstAttempt();
 
     run();
     return completionFuture;


### PR DESCRIPTION
edit (kolea2): 

This is to fix test failures introduced in #2570. `currentBackoff` was originally null as a performance optimization. This new change will create new TimedAttemptSettings for every message.

Behavioral change: the first rpc counts as the first attempt