### PR TITLE
deps: update bigtable veneer to 1.15.0

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -223,7 +223,8 @@ this is not used directly, but upgrading due to transitive vulnerabilities in ol
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.11.2</version>
+      <!-- align version with veneer's flattened dep -->
+      <version>2.11.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
@@ -491,6 +491,8 @@ this is not used directly, but upgrading due to transitive vulnerabilities in ol
           <usedDependencies>
             <usedDependency>${project.groupId}:bigtable-hbase-2.x</usedDependency>
             <usedDependency>org.slf4j:slf4j-log4j12</usedDependency>
+            <!-- commons-codec is not used directly, but upgrading due to transitive vulnerabilities in older versions. -->
+            <usedDependency>commons-codec:commons-codec</usedDependency>
           </usedDependencies>
         </configuration>
       </plugin>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
@@ -416,6 +416,14 @@ limitations under the License.
       <scope>test</scope>
     </dependency>
 
+    <!--  TODO: remove this dependency when upgraded through transitive dependency (http-client -> org.apache.httpcomponents:httpclient)
+this is not used directly, but upgrading due to transitive vulnerabilities in older versions-->
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.14</version>
+    </dependency>
+
     <!-- Testing deps -->
     <dependency>
       <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@ limitations under the License.
     <compileSource.1.8>1.8</compileSource.1.8>
 
     <!-- core dependency versions -->
-    <bigtable.version>1.13.0</bigtable.version>
+    <bigtable.version>1.15.0</bigtable.version>
     <dropwizard.metrics.version>3.2.6</dropwizard.metrics.version>
     <!--  keeping at this version to align with hbase-->
     <slf4j.version>1.7.25</slf4j.version>


### PR DESCRIPTION
Since switching to the flattened pom in 1.15.0, some previously transitive deps are now top level and therefore required some updates in the hbase dependencies.
