### PR TITLE
deps: update shared config to 0.9.2

### DIFF
--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
@@ -129,6 +129,11 @@ limitations under the License.
                     <exclude>org.apache.hadoop:hadoop-yarn-api</exclude>
                   </excludes>
                 </requireUpperBoundDeps>
+                <banDuplicateClasses>
+                  <ignoreClasses>
+                    <ignoreClass>**</ignoreClass>
+                  </ignoreClasses>
+                </banDuplicateClasses>
               </rules>
             </configuration>
           </execution>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
@@ -131,6 +131,7 @@ limitations under the License.
                 </requireUpperBoundDeps>
                 <banDuplicateClasses>
                   <ignoreClasses>
+                    <!-- todo(kolea2): investigate transitive deps causing conflicts-->
                     <ignoreClass>**</ignoreClass>
                   </ignoreClasses>
                 </banDuplicateClasses>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
@@ -123,6 +123,7 @@ limitations under the License.
             </requireUpperBoundDeps>
             <banDuplicateClasses>
               <ignoreClasses>
+                <!-- todo(kolea2): investigate transitive deps causing conflicts-->
                 <ignoreClass>**</ignoreClass>
               </ignoreClasses>
             </banDuplicateClasses>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
@@ -121,6 +121,11 @@ limitations under the License.
                 <exclude>com.google.guava:guava</exclude>
               </excludes>
             </requireUpperBoundDeps>
+            <banDuplicateClasses>
+              <ignoreClasses>
+                <ignoreClass>**</ignoreClass>
+              </ignoreClasses>
+            </banDuplicateClasses>
           </rules>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@ limitations under the License.
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>0.4.0</version>
+    <version>0.9.2</version>
   </parent>
 
   <licenses>


### PR DESCRIPTION
For reference, seeing errors like:
```
[WARNING] Rule 3: org.apache.maven.plugins.enforcer.BanDuplicateClasses failed with message:
Duplicate classes found:

  Found in:
    tomcat:jasper-runtime:jar:5.5.23:compile
    org.mortbay.jetty:jsp-2.1:jar:6.1.14:compile
  Duplicate classes:
    org/apache/jasper/runtime/PageContextImpl$8.class
    org/apache/jasper/util/Queue.class
    org/apache/jasper/runtime/JspFragmentHelper.class
    org/apache/jasper/runtime/PageContextImpl$3.class
    org/apache/jasper/runtime/PerThreadTagHandlerPool.class
    org/apache/jasper/runtime/JspWriterImpl$1.class
    org/apache/jasper/Constants.class
    org/apache/jasper/runtime/PageContextImpl$11.class
    org/apache/jasper/runtime/PageContextImpl$1.class
    org/apache/jasper/runtime/PerThreadTagHandlerPool$PerThreadData.class
...
```