### PR TITLE
feat: Enabling OpenCensus publishing for HBase shaded clients

### DIFF
--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -82,7 +82,16 @@ limitations under the License.
     </dependency>
     <dependency>
       <groupId>io.opencensus</groupId>
+      <artifactId>opencensus-exporter-stats-stackdriver</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opencensus</groupId>
       <artifactId>opencensus-exporter-trace-stackdriver</artifactId>
+    </dependency>
+    <!-- grpc-census needed alongside opencensus-exporter-stats-stackdriver for GRPC stats exports to work -->
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-census</artifactId>
     </dependency>
 
     <!-- Manually promote public dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
@@ -322,6 +331,10 @@ limitations under the License.
             <usedDependency>
               io.opencensus:opencensus-exporter-trace-stackdriver
             </usedDependency>
+            <usedDependency>
+              io.opencensus:opencensus-exporter-stats-stackdriver
+            </usedDependency>
+            <usedDependency>io.grpc:grpc-census</usedDependency>
           </usedDependencies>
         </configuration>
       </plugin>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
@@ -78,6 +78,15 @@ limitations under the License.
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-exporter-trace-stackdriver</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.opencensus</groupId>
+      <artifactId>opencensus-exporter-stats-stackdriver</artifactId>
+    </dependency>
+    <!-- grpc-census needed alongside opencensus-exporter-stats-stackdriver for GRPC stats exports to work -->
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-census</artifactId>
+    </dependency>
 
     <!-- Manually promote dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
     <dependency>
@@ -330,6 +339,10 @@ limitations under the License.
             <usedDependency>
               io.opencensus:opencensus-exporter-trace-stackdriver
             </usedDependency>
+            <usedDependency>
+              io.opencensus:opencensus-exporter-stats-stackdriver
+            </usedDependency>
+            <usedDependency>io.grpc:grpc-census</usedDependency>
           </usedDependencies>
         </configuration>
       </plugin>


### PR DESCRIPTION
Including the OpenCensus libraries into the shaded jars so that clients can easily enable it. Needed to help diagnose some user issues that are still on the HBase client