### PR TITLE
feat: Add keepalive  in grpc channelbuilder

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -129,8 +129,12 @@ public class BigtableSession implements Closeable {
   // 256 MB, server has 256 MB limit.
   private static final int MAX_MESSAGE_SIZE = 1 << 28;
 
-  static final long DIRECT_PATH_KEEP_ALIVE_TIME_SECONDS = 3600;
-  static final long DIRECT_PATH_KEEP_ALIVE_TIMEOUT_SECONDS = 20;
+  // Google Frontends limits keepalive calls at 30s by default.
+  static final long CHANNEL_KEEP_ALIVE_TIME_SECONDS = 30;
+  // Use this conservative values for timeout (10s) and do
+  static final long CHANNEL_KEEP_ALIVE_TIMEOUT_SECONDS = 10;
+  // Do not use keepalive without any outstanding rpc calls as it can add a bunch of load.
+  static final boolean CHANNEL_KEEP_ALIVE_WITHOUT_RPC_CALLS = false;
 
   @VisibleForTesting
   static final String PROJECT_ID_EMPTY_OR_NULL = "ProjectId must not be empty or null.";
@@ -588,9 +592,6 @@ public class BigtableSession implements Closeable {
               + " This is currently an experimental feature and should not be used in production.");
 
       builder = ComputeEngineChannelBuilder.forAddress(host, options.getPort());
-      builder.keepAliveTime(DIRECT_PATH_KEEP_ALIVE_TIME_SECONDS, TimeUnit.SECONDS);
-      builder.keepAliveTimeout(DIRECT_PATH_KEEP_ALIVE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-
       // When channel pooling is enabled, force the pick_first grpclb strategy.
       // This is necessary to avoid the multiplicative effect of creating channel pool with
       // `poolSize` number of `ManagedChannel`s, each with a `subSetting` number of number of
@@ -625,6 +626,9 @@ public class BigtableSession implements Closeable {
     return builder
         .idleTimeout(Long.MAX_VALUE, TimeUnit.SECONDS)
         .maxInboundMessageSize(MAX_MESSAGE_SIZE)
+        .keepAliveTime(CHANNEL_KEEP_ALIVE_TIME_SECONDS, TimeUnit.SECONDS)
+        .keepAliveTimeout(CHANNEL_KEEP_ALIVE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .keepAliveWithoutCalls(CHANNEL_KEEP_ALIVE_WITHOUT_RPC_CALLS)
         .userAgent(BigtableVersionInfo.CORE_USER_AGENT + "," + options.getUserAgent())
         .intercept(interceptors)
         .build();

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -133,8 +133,6 @@ public class BigtableSession implements Closeable {
   static final long CHANNEL_KEEP_ALIVE_TIME_SECONDS = 30;
   // Use this conservative values for timeout (10s) and do
   static final long CHANNEL_KEEP_ALIVE_TIMEOUT_SECONDS = 10;
-  // Do not use keepalive without any outstanding rpc calls as it can add a bunch of load.
-  static final boolean CHANNEL_KEEP_ALIVE_WITHOUT_RPC_CALLS = false;
 
   @VisibleForTesting
   static final String PROJECT_ID_EMPTY_OR_NULL = "ProjectId must not be empty or null.";
@@ -628,7 +626,8 @@ public class BigtableSession implements Closeable {
         .maxInboundMessageSize(MAX_MESSAGE_SIZE)
         .keepAliveTime(CHANNEL_KEEP_ALIVE_TIME_SECONDS, TimeUnit.SECONDS)
         .keepAliveTimeout(CHANNEL_KEEP_ALIVE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-        .keepAliveWithoutCalls(CHANNEL_KEEP_ALIVE_WITHOUT_RPC_CALLS)
+        // Default behavior Do not use keepalive without any outstanding rpc calls as it can add a
+        // bunch of load.
         .userAgent(BigtableVersionInfo.CORE_USER_AGENT + "," + options.getUserAgent())
         .intercept(interceptors)
         .build();

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -131,7 +131,7 @@ public class BigtableSession implements Closeable {
 
   // Google Frontends limits keepalive calls at 30s by default.
   static final long CHANNEL_KEEP_ALIVE_TIME_SECONDS = 30;
-  // Use this conservative values for timeout (10s) and do
+  // Use this conservative values for timeout (10s)
   static final long CHANNEL_KEEP_ALIVE_TIMEOUT_SECONDS = 10;
 
   @VisibleForTesting


### PR DESCRIPTION
Since DIRECT_PATH KeepAlive configuration are loose compared to our keepalive configuration, I am omitting the DIRECTPATH configuration.

Sets KeepAlive timer to 30s (Google Frontends are configured  limits keepalive calls at 30s by default. If used below 30s, grpc automatically increases keepalive time by 2x after too_many_ping commands).

Sets KeepAliveTimeout to 10s (conservative)

Sets keepAliveWithoutCalls to false as it can potentially increase load.

Parameters discussed with @ejona86

Fixes #2681