### PR TITLE
fix: Extract out trace management from ResultScanners

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
@@ -306,6 +306,7 @@ public abstract class AbstractBigtableTable implements Table {
           }
         }
 
+        @Override
         public boolean renewLease() {
           throw new UnsupportedOperationException("renewLease");
         }


### PR DESCRIPTION
Fixes #2458 
