### PR TITLE
fix: update readRowsAsync to use RetryingReadRowsOperation

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
@@ -557,7 +557,10 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
     }
 
     @Override
-    public void onError(Throwable throwable) {
+    public void onError(Throwable ignored) {
+      // note: we dont need to save the error here because it will be bubbled (possibly wrapped)
+      // by the Operation's getAsyncResult. This check is mainly a sanity check to ensure that the
+      // caller doesn't ignore that error and try to fetch partial results.
       state.set(State.ERROR);
     }
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
@@ -53,8 +53,10 @@ import com.google.cloud.bigtable.grpc.scanner.RowMerger;
 import com.google.cloud.bigtable.grpc.scanner.ScanHandler;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -67,6 +69,7 @@ import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 
 /**
@@ -351,13 +354,14 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
   /** {@inheritDoc} */
   @Override
   public ListenableFuture<List<Row>> readRowsAsync(ReadRowsRequest request) {
-    if (shouldOverrideAppProfile(request.getAppProfileId())) {
-      request = request.toBuilder().setAppProfileId(clientDefaultAppProfileId).build();
-    }
-
     return Futures.transform(
-        createStreamingListener(request, readRowsAsync, request.getTableName()).getAsyncResult(),
-        ROW_LIST_TRANSFORMER,
+        readFlatRowsAsync(request),
+        new Function<List<FlatRow>, List<Row>>() {
+          @Override
+          public List<Row> apply(List<FlatRow> input) {
+            return Lists.transform(input, FLAT_ROW_TRANSFORMER);
+          }
+        },
         MoreExecutors.directExecutor());
   }
 
@@ -367,10 +371,17 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
     if (shouldOverrideAppProfile(request.getAppProfileId())) {
       request = request.toBuilder().setAppProfileId(clientDefaultAppProfileId).build();
     }
+    final StreamCollector<FlatRow> rowCollector = new StreamCollector<>();
+    RetryingReadRowsOperation operation = createReadRowsRetryListener(request, rowCollector);
 
     return Futures.transform(
-        createStreamingListener(request, readRowsAsync, request.getTableName()).getAsyncResult(),
-        FLAT_ROW_LIST_TRANSFORMER,
+        operation.getAsyncResult(),
+        new Function<String, List<FlatRow>>() {
+          @Override
+          public List<FlatRow> apply(String ignored) {
+            return rowCollector.getResults();
+          }
+        },
         MoreExecutors.directExecutor());
   }
 
@@ -380,10 +391,10 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
     if (shouldOverrideAppProfile(request.getAppProfileId())) {
       request = request.toBuilder().setAppProfileId(clientDefaultAppProfileId).build();
     }
-
-    return FLAT_ROW_LIST_TRANSFORMER.apply(
-        createStreamingListener(request, readRowsAsync, request.getTableName())
-            .getBlockingResult());
+    final StreamCollector<FlatRow> rowCollector = new StreamCollector<>();
+    RetryingReadRowsOperation operation = createReadRowsRetryListener(request, rowCollector);
+    operation.getBlockingResult();
+    return rowCollector.getResults();
   }
 
   private <ReqT, RespT> RetryingUnaryOperation<ReqT, RespT> createUnaryListener(
@@ -520,5 +531,46 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
 
   private boolean shouldOverrideAppProfile(String requestProfile) {
     return !this.clientDefaultAppProfileId.isEmpty() && requestProfile.isEmpty();
+  }
+
+  /**
+   * Helper to buffer rows from a RetryingReadRowsOperation.
+   *
+   * <p>Each row will be buffered in a list.
+   *
+   * <p>This class assumes that the {@link StreamObserver} methods will be called by a single gRPC
+   * thread at a time.
+   */
+  private static class StreamCollector<T> implements StreamObserver<T> {
+    private enum State {
+      BUFFERING,
+      OK,
+      ERROR
+    };
+
+    private final ImmutableList.Builder<T> results = ImmutableList.builder();
+    private final AtomicReference<State> state = new AtomicReference(State.BUFFERING);
+
+    @Override
+    public void onNext(T item) {
+      results.add(item);
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+      state.set(State.ERROR);
+    }
+
+    @Override
+    public void onCompleted() {
+      state.compareAndSet(State.BUFFERING, State.OK);
+    }
+
+    public List<T> getResults() {
+      Preconditions.checkState(
+          state.get() == State.OK,
+          "Unexpected state, stream must be complete before fetching the results");
+      return results.build();
+    }
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGrpcClient.java
@@ -347,7 +347,8 @@ public class TestBigtableDataGrpcClient {
       verify(mockClientCall, times(1)).start(listenerCaptor.capture(), any(Metadata.class));
       Listener listener = listenerCaptor.getValue();
 
-      // Reset mock before starting the next attempt
+      // Reset mock before starting the next attempt, this ensures that the call count verification
+      // is incremental. (ie. times(1) for a single attempt instead n+1 for previous attempts)
       Mockito.reset(mockClientCall);
 
       // mark last attempt as timeout to possibly start the next attempt


### PR DESCRIPTION
This will allow that method to inherit features like stream resumption and retry on stream timeouts.
