### PR TITLE
fix: fix race condition where a retry triggers a full table scan

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ReadRowsRequestManager.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ReadRowsRequestManager.java
@@ -52,6 +52,10 @@ class ReadRowsRequestManager {
     this.originalRequest = originalRequest;
   }
 
+  public ByteString getLastFoundKey() {
+    return lastFoundKey;
+  }
+
   void updateLastFoundKey(ByteString key) {
     this.lastFoundKey = key;
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
@@ -20,6 +20,7 @@ import com.google.api.core.ApiClock;
 import com.google.api.core.InternalApi;
 import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.v2.ReadRowsResponse;
+import com.google.bigtable.v2.RowSet;
 import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.cloud.bigtable.grpc.DeadlineGenerator;
 import com.google.cloud.bigtable.grpc.async.AbstractRetryingOperation;
@@ -197,6 +198,21 @@ public class RetryingReadRowsOperation
   /** {@inheritDoc} */
   @Override
   public void onClose(Status status, Metadata trailers) {
+    // Edgecase: it possible to receive the full ReadRows stream, but still receive a non-ok status.
+    // In that case, there is a high chance that the retry request will be empty, as all of the
+    // received keys & ranges will be pruned. This will cause the retry request to do a full table
+    // scan. To mitigate this, we will just mask the status as an ok after we are certain that we
+    // have received all of the data.
+    // This mitigation must only be activated after at least one row is received so that we can
+    // distinguish from a perfectly valid initial full table scan.
+    if (!status.isOk() && requestManager.getLastFoundKey() != null) {
+      ReadRowsRequest retryRequest = requestManager.buildUpdatedRequest();
+      boolean isFullTableScan = retryRequest.getRows().equals(RowSet.getDefaultInstance());
+      if (isFullTableScan) {
+        status = Status.OK;
+      }
+    }
+
     if (status.getCause() instanceof StreamWaitTimeoutException) {
       StreamWaitTimeoutException timeoutException = (StreamWaitTimeoutException) status.getCause();
       switch (timeoutException.getState()) {

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGrpcClient.java
@@ -248,7 +248,7 @@ public class TestBigtableDataGrpcClient {
   @Test
   public void testScannerIdle() throws IOException {
     ReadRowsRequest.Builder requestBuilder = ReadRowsRequest.newBuilder().setTableName(TABLE_NAME);
-    requestBuilder.getRowsBuilder().addRowKeys(ByteString.EMPTY);
+
     ResultScanner<FlatRow> scanner = defaultClient.readFlatRows(requestBuilder.build());
     ArgumentCaptor<ClientCall.Listener> listenerCaptor =
         ArgumentCaptor.forClass(ClientCall.Listener.class);

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGrpcClient.java
@@ -280,7 +280,6 @@ public class TestBigtableDataGrpcClient {
   public void testReadFlatRowsAsyncWaitTimeoutRetry() throws Exception {
     ReadRowsRequest.Builder requestBuilder = ReadRowsRequest.newBuilder().setTableName(TABLE_NAME);
 
-
     // Start the call
     ListenableFuture<List<FlatRow>> resultFuture =
         defaultClient.readFlatRowsAsync(requestBuilder.build());

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGrpcClient.java
@@ -279,7 +279,7 @@ public class TestBigtableDataGrpcClient {
   @Test
   public void testReadFlatRowsAsyncWaitTimeoutRetry() throws Exception {
     ReadRowsRequest.Builder requestBuilder = ReadRowsRequest.newBuilder().setTableName(TABLE_NAME);
-    requestBuilder.getRowsBuilder().addRowKeys(ByteString.EMPTY);
+
 
     // Start the call
     ListenableFuture<List<FlatRow>> resultFuture =


### PR DESCRIPTION
There is a race condition where a read rows stream will return all of the data, but still end in a non-ok status. This will trigger a full table scan because the row resumption logic will strip away all of seem keys & ranges, leaving the retry request empty, will cause a full table scan.

This PR will detect this case and will replace the status code to be ok. This should be a very rare condition.
