### PR TITLE
fix: race condition where a retry triggers a full table scan

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ReadRowsRequestManager.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/ReadRowsRequestManager.java
@@ -52,6 +52,10 @@ class ReadRowsRequestManager {
     this.originalRequest = originalRequest;
   }
 
+  public ByteString getLastFoundKey() {
+    return lastFoundKey;
+  }
+
   void updateLastFoundKey(ByteString key) {
     this.lastFoundKey = key;
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
@@ -20,6 +20,7 @@ import com.google.api.core.ApiClock;
 import com.google.api.core.InternalApi;
 import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.v2.ReadRowsResponse;
+import com.google.bigtable.v2.RowSet;
 import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.cloud.bigtable.grpc.async.AbstractRetryingOperation;
 import com.google.cloud.bigtable.grpc.async.BigtableAsyncRpc;
@@ -197,6 +198,21 @@ public class RetryingReadRowsOperation
   /** {@inheritDoc} */
   @Override
   public void onClose(Status status, Metadata trailers) {
+    // Edgecase: it possible to receive the full ReadRows stream, but still receive a non-ok status.
+    // In that case, there is a high chance that the retry request will be empty, as all of the
+    // received keys & ranges will be pruned. This will cause the retry request to do a full table
+    // scan. To mitigate this, we will just mask the status as an ok after we are certain that we
+    // have received all of the data.
+    // This mitigation must only be activated after at least one row is received so that we can
+    // distinguish from a perfectly valid initial full table scan.
+    if (!status.isOk() && requestManager.getLastFoundKey() != null) {
+      ReadRowsRequest retryRequest = requestManager.buildUpdatedRequest();
+      boolean isFullTableScan = retryRequest.getRows().equals(RowSet.getDefaultInstance());
+      if (isFullTableScan) {
+        status = Status.OK;
+      }
+    }
+
     if (status.getCause() instanceof StreamWaitTimeoutException) {
       StreamWaitTimeoutException timeoutException = (StreamWaitTimeoutException) status.getCause();
       switch (timeoutException.getState()) {

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGrpcClient.java
@@ -279,7 +279,6 @@ public class TestBigtableDataGrpcClient {
   @Test
   public void testReadFlatRowsAsyncWaitTimeoutRetry() throws Exception {
     ReadRowsRequest.Builder requestBuilder = ReadRowsRequest.newBuilder().setTableName(TABLE_NAME);
-    requestBuilder.getRowsBuilder().addRowKeys(ByteString.EMPTY);
 
     // Start the call
     ListenableFuture<List<FlatRow>> resultFuture =

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGrpcClient.java
@@ -227,7 +227,7 @@ public class TestBigtableDataGrpcClient {
   @Test
   public void testScanner() throws IOException {
     ReadRowsRequest.Builder requestBuilder = ReadRowsRequest.newBuilder().setTableName(TABLE_NAME);
-    requestBuilder.getRowsBuilder().addRowKeys(ByteString.EMPTY);
+
     ResultScanner<FlatRow> scanner = defaultClient.readFlatRows(requestBuilder.build());
     ArgumentCaptor<ClientCall.Listener> listenerCaptor =
         ArgumentCaptor.forClass(ClientCall.Listener.class);
@@ -248,7 +248,7 @@ public class TestBigtableDataGrpcClient {
   @Test
   public void testScannerIdle() throws IOException {
     ReadRowsRequest.Builder requestBuilder = ReadRowsRequest.newBuilder().setTableName(TABLE_NAME);
-    requestBuilder.getRowsBuilder().addRowKeys(ByteString.EMPTY);
+
     ResultScanner<FlatRow> scanner = defaultClient.readFlatRows(requestBuilder.build());
     ArgumentCaptor<ClientCall.Listener> listenerCaptor =
         ArgumentCaptor.forClass(ClientCall.Listener.class);

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperationTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperationTest.java
@@ -140,16 +140,16 @@ public class RetryingReadRowsOperationTest {
   }
 
   protected RetryingReadRowsOperation createOperation() {
-    return createOperation(CallOptions.DEFAULT, mockFlatRowObserver);
+    return createOperation(CallOptions.DEFAULT, READ_ENTIRE_TABLE_REQUEST, mockFlatRowObserver);
   }
 
   protected RetryingReadRowsOperation createOperation(
-      CallOptions options, StreamObserver<FlatRow> observer) {
+      CallOptions options, ReadRowsRequest request, StreamObserver<FlatRow> observer) {
     RetryingReadRowsOperation operation =
         new RetryingReadRowsOperation(
             observer,
             RETRY_OPTIONS,
-            READ_ENTIRE_TABLE_REQUEST,
+            request,
             mockRetryableRpc,
             options,
             mockRetryExecutorService,
@@ -249,7 +249,8 @@ public class RetryingReadRowsOperationTest {
             any(Metadata.class),
             any(ClientCall.class));
 
-    RetryingReadRowsOperation underTest = createOperation(options, mockFlatRowObserver);
+    RetryingReadRowsOperation underTest =
+        createOperation(options, READ_ENTIRE_TABLE_REQUEST, mockFlatRowObserver);
     try {
       underTest.getAsyncResult().get(100, TimeUnit.MILLISECONDS);
     } catch (ExecutionException e) {
@@ -423,6 +424,28 @@ public class RetryingReadRowsOperationTest {
     Assert.assertTrue(underTest.getRowMerger().isComplete());
   }
 
+  @Test
+  public void testErrorAfterComplete() throws UnsupportedEncodingException {
+    ByteString key1 = ByteString.copyFromUtf8("SomeKey1");
+    ByteString key2 = ByteString.copyFromUtf8("SomeKey2");
+
+    ReadRowsRequest req =
+        ReadRowsRequest.newBuilder()
+            .setRows(RowSet.newBuilder().addRowKeys(key1).addRowKeys(key2))
+            .build();
+    RetryingReadRowsOperation underTest =
+        createOperation(CallOptions.DEFAULT, req, mockFlatRowObserver);
+
+    start(underTest);
+    underTest.onMessage(buildResponse(key1));
+    underTest.onMessage(buildResponse(key2));
+    underTest.onClose(Status.DEADLINE_EXCEEDED, new Metadata());
+
+    verify(mockFlatRowObserver, times(1)).onCompleted();
+    Assert.assertFalse(underTest.inRetryMode());
+    Assert.assertTrue(underTest.getRowMerger().isComplete());
+  }
+
   @SuppressWarnings("unchecked")
   @Test
   public void testImmediateOnClose() {
@@ -476,16 +499,14 @@ public class RetryingReadRowsOperationTest {
   }
 
   private void start(RetryingReadRowsOperation underTest) {
+    ReadRowsRequest initialRequest = underTest.getRetryRequest();
+
     underTest.getAsyncResult();
     verify(mockRpcMetrics, times(1)).timeOperation();
     verify(mockRpcMetrics, times(1)).timeRpc();
     verify(mockRetryableRpc, times(1)).newCall(eq(CallOptions.DEFAULT));
     verify(mockRetryableRpc, times(1))
-        .start(
-            eq(READ_ENTIRE_TABLE_REQUEST),
-            same(underTest),
-            any(Metadata.class),
-            same(mockClientCall));
+        .start(eq(initialRequest), same(underTest), any(Metadata.class), same(mockClientCall));
   }
 
   private void finishOK(RetryingReadRowsOperation underTest, int expectedRetryCount) {


### PR DESCRIPTION
There is a race condition where a read rows stream will return all of the data, but still end in a non-ok status. This will trigger a full table scan because the row resumption logic will strip away all of seem keys & ranges, leaving the retry request empty, will cause a full table scan.

Cherry pick of #2742 