### PR TITLE
fix: update readRowsAsync to use RetryingReadRowsOperation (#2738)

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGrpcClient.java
@@ -53,8 +53,10 @@ import com.google.cloud.bigtable.grpc.scanner.RowMerger;
 import com.google.cloud.bigtable.grpc.scanner.ScanHandler;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -67,6 +69,7 @@ import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 
 /**
@@ -351,13 +354,14 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
   /** {@inheritDoc} */
   @Override
   public ListenableFuture<List<Row>> readRowsAsync(ReadRowsRequest request) {
-    if (shouldOverrideAppProfile(request.getAppProfileId())) {
-      request = request.toBuilder().setAppProfileId(clientDefaultAppProfileId).build();
-    }
-
     return Futures.transform(
-        createStreamingListener(request, readRowsAsync, request.getTableName()).getAsyncResult(),
-        ROW_LIST_TRANSFORMER,
+        readFlatRowsAsync(request),
+        new Function<List<FlatRow>, List<Row>>() {
+          @Override
+          public List<Row> apply(List<FlatRow> input) {
+            return Lists.transform(input, FLAT_ROW_TRANSFORMER);
+          }
+        },
         MoreExecutors.directExecutor());
   }
 
@@ -367,10 +371,17 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
     if (shouldOverrideAppProfile(request.getAppProfileId())) {
       request = request.toBuilder().setAppProfileId(clientDefaultAppProfileId).build();
     }
+    final StreamCollector<FlatRow> rowCollector = new StreamCollector<>();
+    RetryingReadRowsOperation operation = createReadRowsRetryListener(request, rowCollector);
 
     return Futures.transform(
-        createStreamingListener(request, readRowsAsync, request.getTableName()).getAsyncResult(),
-        FLAT_ROW_LIST_TRANSFORMER,
+        operation.getAsyncResult(),
+        new Function<String, List<FlatRow>>() {
+          @Override
+          public List<FlatRow> apply(String ignored) {
+            return rowCollector.getResults();
+          }
+        },
         MoreExecutors.directExecutor());
   }
 
@@ -380,10 +391,10 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
     if (shouldOverrideAppProfile(request.getAppProfileId())) {
       request = request.toBuilder().setAppProfileId(clientDefaultAppProfileId).build();
     }
-
-    return FLAT_ROW_LIST_TRANSFORMER.apply(
-        createStreamingListener(request, readRowsAsync, request.getTableName())
-            .getBlockingResult());
+    final StreamCollector<FlatRow> rowCollector = new StreamCollector<>();
+    RetryingReadRowsOperation operation = createReadRowsRetryListener(request, rowCollector);
+    operation.getBlockingResult();
+    return rowCollector.getResults();
   }
 
   private <ReqT, RespT> RetryingUnaryOperation<ReqT, RespT> createUnaryListener(
@@ -520,5 +531,49 @@ public class BigtableDataGrpcClient implements BigtableDataClient {
 
   private boolean shouldOverrideAppProfile(String requestProfile) {
     return !this.clientDefaultAppProfileId.isEmpty() && requestProfile.isEmpty();
+  }
+
+  /**
+   * Helper to buffer rows from a RetryingReadRowsOperation.
+   *
+   * <p>Each row will be buffered in a list.
+   *
+   * <p>This class assumes that the {@link StreamObserver} methods will be called by a single gRPC
+   * thread at a time.
+   */
+  private static class StreamCollector<T> implements StreamObserver<T> {
+    private enum State {
+      BUFFERING,
+      OK,
+      ERROR
+    };
+
+    private final ImmutableList.Builder<T> results = ImmutableList.builder();
+    private final AtomicReference<State> state = new AtomicReference(State.BUFFERING);
+
+    @Override
+    public void onNext(T item) {
+      results.add(item);
+    }
+
+    @Override
+    public void onError(Throwable ignored) {
+      // note: we dont need to save the error here because it will be bubbled (possibly wrapped)
+      // by the Operation's getAsyncResult. This check is mainly a sanity check to ensure that the
+      // caller doesn't ignore that error and try to fetch partial results.
+      state.set(State.ERROR);
+    }
+
+    @Override
+    public void onCompleted() {
+      state.compareAndSet(State.BUFFERING, State.OK);
+    }
+
+    public List<T> getResults() {
+      Preconditions.checkState(
+          state.get() == State.OK,
+          "Unexpected state, stream must be complete before fetching the results");
+      return results.build();
+    }
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGrpcClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGrpcClient.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.grpc;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -40,9 +41,14 @@ import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.cloud.bigtable.grpc.io.GoogleCloudResourcePrefixInterceptor;
 import com.google.cloud.bigtable.grpc.io.Watchdog;
+import com.google.cloud.bigtable.grpc.io.Watchdog.State;
+import com.google.cloud.bigtable.grpc.scanner.BigtableRetriesExhaustedException;
 import com.google.cloud.bigtable.grpc.scanner.FlatRow;
 import com.google.cloud.bigtable.grpc.scanner.ResultScanner;
 import com.google.cloud.bigtable.grpc.scanner.RetryingReadRowsOperationTest;
+import com.google.cloud.bigtable.grpc.scanner.RowMerger;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -52,8 +58,12 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -62,6 +72,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -263,6 +274,106 @@ public class TestBigtableDataGrpcClient {
     Assert.assertEquals(key3, scanner.next().getRowKey());
     // There was a retry based on the idle
     verify(mochScheduler, times(1)).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+  }
+
+  @Test
+  public void testReadFlatRowsAsyncWaitTimeoutRetry() throws Exception {
+    ReadRowsRequest.Builder requestBuilder = ReadRowsRequest.newBuilder().setTableName(TABLE_NAME);
+    requestBuilder.getRowsBuilder().addRowKeys(ByteString.EMPTY);
+
+    // Start the call
+    ListenableFuture<List<FlatRow>> resultFuture =
+        defaultClient.readFlatRowsAsync(requestBuilder.build());
+
+    // Capture the caller's listener
+    ArgumentCaptor<ClientCall.Listener> listenerCaptor =
+        ArgumentCaptor.forClass(ClientCall.Listener.class);
+    verify(mockClientCall, times(1)).start(listenerCaptor.capture(), any(Metadata.class));
+
+    // Get the listener for the first attempt
+    Listener listener = listenerCaptor.getValue();
+    listener.onMessage(
+        RetryingReadRowsOperationTest.buildResponse(ByteString.copyFromUtf8("Key1")));
+    listener.onClose(
+        Status.CANCELLED.withCause(
+            new Watchdog.StreamWaitTimeoutException(State.WAITING, TimeUnit.MINUTES.toMillis(10))),
+        new Metadata());
+
+    // Verify that the retry was scheduled
+    ArgumentCaptor<Runnable> scheduledRetryCaptor = ArgumentCaptor.forClass(Runnable.class);
+    verify(mochScheduler, times(1))
+        .schedule(scheduledRetryCaptor.capture(), anyLong(), any(TimeUnit.class));
+    Runnable scheduledRetry = scheduledRetryCaptor.getValue();
+    scheduledRetry.run();
+
+    // Get the listener for the retry attempyt
+    listener = listenerCaptor.getValue();
+    listener.onMessage(
+        RetryingReadRowsOperationTest.buildResponse(ByteString.copyFromUtf8("Key2")));
+    listener.onClose(Status.OK, new Metadata());
+
+    Assert.assertEquals(
+        resultFuture.get(),
+        RowMerger.toRows(
+            Lists.newArrayList(
+                RetryingReadRowsOperationTest.buildResponse(
+                    ByteString.copyFromUtf8("Key1"), ByteString.copyFromUtf8("Key2")))));
+  }
+
+  @Test
+  public void testReadFlatRowsAsyncWaitTimeoutRetryFailEventually() throws Exception {
+    // Run retries immediately
+    Mockito.when(mochScheduler.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class)))
+        .thenAnswer(
+            new Answer<ScheduledFuture>() {
+              @Override
+              public ScheduledFuture answer(InvocationOnMock invocation) {
+                Runnable runnable = invocation.getArgument(0);
+                runnable.run();
+                return null;
+              }
+            });
+
+    ReadRowsRequest.Builder requestBuilder = ReadRowsRequest.newBuilder().setTableName(TABLE_NAME);
+
+    // Start the call
+    ListenableFuture<List<FlatRow>> resultFuture =
+        defaultClient.readFlatRowsAsync(requestBuilder.build());
+
+    for (int i = 0; i < 11; i++) {
+      // Get the caller's listener for the current attempt.
+      ArgumentCaptor<ClientCall.Listener> listenerCaptor =
+          ArgumentCaptor.forClass(ClientCall.Listener.class);
+      verify(mockClientCall, times(1)).start(listenerCaptor.capture(), any(Metadata.class));
+      Listener listener = listenerCaptor.getValue();
+
+      // Reset mock before starting the next attempt, this ensures that the call count verification
+      // is incremental. (ie. times(1) for a single attempt instead n+1 for previous attempts)
+      Mockito.reset(mockClientCall);
+
+      // mark last attempt as timeout to possibly start the next attempt
+      listener.onClose(
+          Status.CANCELLED.withCause(
+              new Watchdog.StreamWaitTimeoutException(
+                  State.WAITING, TimeUnit.MINUTES.toMillis(10))),
+          new Metadata());
+
+      // Check if the operation finished
+      if (resultFuture.isDone()) {
+        break;
+      }
+    }
+
+    Throwable actualException = null;
+    try {
+      resultFuture.get(1, TimeUnit.MILLISECONDS);
+    } catch (ExecutionException e) {
+      actualException = e.getCause();
+    }
+
+    assertThat(
+        actualException,
+        CoreMatchers.<Throwable>instanceOf(BigtableRetriesExhaustedException.class));
   }
 
   private void setResponse(final Object response) {


### PR DESCRIPTION
This will allow that method to inherit features like stream resumption and retry on stream timeouts.
