### PR TITLE
Add timers to Rowmerger to detect stuck queries

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -129,10 +129,8 @@ public class BigtableSession implements Closeable {
   // 256 MB, server has 256 MB limit.
   private static final int MAX_MESSAGE_SIZE = 1 << 28;
 
-  // Google Frontends limits keepalive calls at 30s by default.
-  static final long CHANNEL_KEEP_ALIVE_TIME_SECONDS = 30;
-  // Use this conservative values for timeout (10s)
-  static final long CHANNEL_KEEP_ALIVE_TIMEOUT_SECONDS = 10;
+  static final long DIRECT_PATH_KEEP_ALIVE_TIME_SECONDS = 3600;
+  static final long DIRECT_PATH_KEEP_ALIVE_TIMEOUT_SECONDS = 20;
 
   @VisibleForTesting
   static final String PROJECT_ID_EMPTY_OR_NULL = "ProjectId must not be empty or null.";
@@ -590,6 +588,9 @@ public class BigtableSession implements Closeable {
               + " This is currently an experimental feature and should not be used in production.");
 
       builder = ComputeEngineChannelBuilder.forAddress(host, options.getPort());
+      builder.keepAliveTime(DIRECT_PATH_KEEP_ALIVE_TIME_SECONDS, TimeUnit.SECONDS);
+      builder.keepAliveTimeout(DIRECT_PATH_KEEP_ALIVE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
       // When channel pooling is enabled, force the pick_first grpclb strategy.
       // This is necessary to avoid the multiplicative effect of creating channel pool with
       // `poolSize` number of `ManagedChannel`s, each with a `subSetting` number of number of
@@ -624,10 +625,6 @@ public class BigtableSession implements Closeable {
     return builder
         .idleTimeout(Long.MAX_VALUE, TimeUnit.SECONDS)
         .maxInboundMessageSize(MAX_MESSAGE_SIZE)
-        .keepAliveTime(CHANNEL_KEEP_ALIVE_TIME_SECONDS, TimeUnit.SECONDS)
-        .keepAliveTimeout(CHANNEL_KEEP_ALIVE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-        // Default behavior Do not use keepalive without any outstanding rpc calls as it can add a
-        // bunch of load.
         .userAgent(BigtableVersionInfo.CORE_USER_AGENT + "," + options.getUserAgent())
         .intercept(interceptors)
         .build();

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
@@ -192,15 +192,19 @@ public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
 
   protected void onError(Status status, Metadata trailers) {
     Code code = status.getCode();
+    String channelId = ChannelPool.extractIdentifier(trailers);
+
     // CANCELLED
     if (code == Status.Code.CANCELLED) {
+      LOG.error(
+          "Received a CANCELLED error. Failure #%d, got: %s on channel %s.\nTrailers: %s",
+          status.getCause(), failedCount, status, channelId, trailers);
       setException(status.asRuntimeException());
       // An explicit user cancellation is not considered a failure.
       finalizeStats(status);
       return;
     }
 
-    String channelId = ChannelPool.extractIdentifier(trailers);
     // Non retry scenario
     if (!retryOptions.enableRetries()
         || !retryOptions.isRetryable(code)

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/Watchdog.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/Watchdog.java
@@ -183,8 +183,9 @@ public class Watchdog implements Runnable {
 
             @Override
             public void onClose(Status status, Metadata trailers) {
+              // Log channel IDs. I am not sure if we should log here for everything.
+              // LOG.warn("Closing the channel: " + ChannelPool.extractIdentifier(trailers));
               openStreams.remove(WatchedCall.this);
-
               super.onClose(status, trailers);
             }
           },
@@ -235,7 +236,7 @@ public class Watchdog implements Runnable {
             if (waitTime >= waitTimeoutMs) {
               delegate()
                   .cancel(
-                      "Canceled due to timeout waiting for next response",
+                      "Canceled due to timeout waiting for next response for " + waitTime + " ms.",
                       new StreamWaitTimeoutException(this.state, waitTime));
               return true;
             }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/Watchdog.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/Watchdog.java
@@ -183,8 +183,6 @@ public class Watchdog implements Runnable {
 
             @Override
             public void onClose(Status status, Metadata trailers) {
-              // Log channel IDs. I am not sure if we should log here for everything.
-              // LOG.warn("Closing the channel: " + ChannelPool.extractIdentifier(trailers));
               openStreams.remove(WatchedCall.this);
               super.onClose(status, trailers);
             }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RowMerger.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RowMerger.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.Executors;
@@ -453,11 +452,12 @@ public class RowMerger implements StreamObserver<ReadRowsResponse> {
     try {
       nextRowMonitorReschedulingcounter++;
       if (nextRowMonitorReschedulingcounter % 500 == 0) {
-        // Heartbeat every 20 rows to make sure that its running.
+        // Heartbeat every 500 rows to make sure that its running.
         // This counter is local to a RowMerger, which is tied to a single ReadRows call, so having
         // a higher number will mean that it never
         // gets called.
-        LOG.warn("RowMerger[" + this.id + "] processed %d rows", nextRowMonitorReschedulingcounter - 1);
+        LOG.warn(
+            "RowMerger[" + this.id + "] processed %d rows", nextRowMonitorReschedulingcounter - 1);
       }
       if (nextRowFuture != null) {
         nextRowFuture.cancel(false);


### PR DESCRIPTION
This PR is based on my earlier [PR](https://github.com/googleapis/java-bigtable-hbase/pull/2696), it contains the following changes:

1. Pull in all the new changes from bigtable-1.x, this contains multiple bug fixes for WatchDog and RetryingReadRowsOpearation.
2. Reduce the frequency of RowMerger heartbeats
3. Add an id to RowMerger to identify the log messages in hosts processing more than 1 Dataflow workitem.