### PR TITLE
fix: bigtable-hbase-2.x-hadoop incompatible with hbase-shaded-client 2.x

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
@@ -41,8 +41,6 @@ import com.google.protobuf.ByteString;
 import io.grpc.Status;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -50,7 +48,6 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.ClusterStatus;
 import org.apache.hadoop.hbase.HBaseIOException;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HRegionInfo;
@@ -683,18 +680,6 @@ public abstract class AbstractBigtableAdmin implements Admin {
   @Deprecated
   public void deleteColumn(final String tableName, final String columnName) throws IOException {
     deleteColumn(TableName.valueOf(tableName), Bytes.toBytes(columnName));
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public ClusterStatus getClusterStatus() throws IOException {
-    return new ClusterStatus() {
-      @Override
-      public Collection<ServerName> getServers() {
-        // TODO(sduskis): Point the server name to options.getServerName()
-        return Collections.emptyList();
-      }
-    };
   }
 
   /** {@inheritDoc} */

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/main/java/com/google/cloud/bigtable/hbase1_x/BigtableAdmin.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/main/java/com/google/cloud/bigtable/hbase1_x/BigtableAdmin.java
@@ -17,9 +17,12 @@ package com.google.cloud.bigtable.hbase1_x;
 
 import com.google.api.core.InternalApi;
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Future;
 import java.util.regex.Pattern;
+import org.apache.hadoop.hbase.ClusterStatus;
 import org.apache.hadoop.hbase.ProcedureInfo;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.TableExistsException;
@@ -257,5 +260,15 @@ public class BigtableAdmin extends AbstractBigtableAdmin {
   public boolean[] setSplitOrMergeEnabled(boolean arg0, boolean arg1, MasterSwitchType... arg2)
       throws IOException {
     throw new UnsupportedOperationException("setSplitOrMergeEnabled"); // TODO
+  }
+
+  @Override
+  public ClusterStatus getClusterStatus() throws IOException {
+    return new ClusterStatus() {
+      @Override
+      public Collection<ServerName> getServers() {
+        return Collections.emptyList();
+      }
+    };
   }
 }

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase1_x/TestBigtableAdmin.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase1_x/TestBigtableAdmin.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.hbase1_x;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import com.google.bigtable.admin.v2.BigtableTableAdminGrpc;
 import com.google.bigtable.admin.v2.DropRowRangeRequest;
@@ -34,6 +35,7 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.concurrent.ArrayBlockingQueue;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.ClusterStatus;
 import org.apache.hadoop.hbase.TableName;
 import org.junit.After;
 import org.junit.Before;
@@ -128,5 +130,12 @@ public class TestBigtableAdmin {
         }
       };
     }
+  }
+
+  @Test
+  public void testGetClusterStatus() throws IOException {
+    // test to verify compatibility between 1x and 2x
+    ClusterStatus status = admin.getClusterStatus();
+    assertNotNull(status);
   }
 }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAdmin.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -32,6 +33,7 @@ import java.util.regex.Pattern;
 import org.apache.hadoop.hbase.CacheEvictionStats;
 import org.apache.hadoop.hbase.ClusterMetrics;
 import org.apache.hadoop.hbase.ClusterMetrics.Option;
+import org.apache.hadoop.hbase.ClusterStatus;
 import org.apache.hadoop.hbase.HRegionInfo;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.NamespaceDescriptor;
@@ -832,5 +834,20 @@ public class BigtableAdmin extends AbstractBigtableAdmin {
   public Future<Void> updateReplicationPeerConfigAsync(
       String s, ReplicationPeerConfig replicationPeerConfig) {
     throw new UnsupportedOperationException("updateReplicationPeerConfigAsync"); // TODO
+  }
+
+  @Override
+  public ClusterStatus getClusterStatus() throws IOException {
+    return new ClusterStatus(
+        "hbaseVersion",
+        "clusterid",
+        new HashMap(),
+        new ArrayList(),
+        null,
+        new ArrayList(),
+        new ArrayList(),
+        new String[0],
+        false,
+        -1);
   }
 }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase2_x/BigtableAdminTest.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase2_x/BigtableAdminTest.java
@@ -34,12 +34,10 @@ public class BigtableAdminTest {
   @Test
   public void testGetClusterStatus() throws IOException {
     // test to verify compatibility between 1x and 2x
-    AbstractBigtableConnection connectionMock;
-    BigtableAdmin bigtableAdmin;
-    connectionMock = mock(AbstractBigtableConnection.class);
+    AbstractBigtableConnection connectionMock = mock(AbstractBigtableConnection.class);
     BigtableApi bigtableApi = mock(BigtableApi.class);
     Mockito.doReturn(bigtableApi).when(connectionMock).getBigtableApi();
-    bigtableAdmin = new BigtableAdmin(connectionMock);
+    BigtableAdmin bigtableAdmin = new BigtableAdmin(connectionMock);
 
     ClusterStatus status = bigtableAdmin.getClusterStatus();
     assertNotNull(status);

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase2_x/BigtableAdminTest.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase2_x/BigtableAdminTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase2_x;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertNull;
+import static junit.framework.TestCase.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import com.google.cloud.bigtable.hbase.wrappers.BigtableApi;
+import java.io.IOException;
+import org.apache.hadoop.hbase.ClusterStatus;
+import org.apache.hadoop.hbase.client.AbstractBigtableConnection;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class BigtableAdminTest {
+
+  @Test
+  public void testGetClusterStatus() throws IOException {
+    // test to verify compatibility between 1x and 2x
+    AbstractBigtableConnection connectionMock;
+    BigtableAdmin bigtableAdmin;
+    connectionMock = mock(AbstractBigtableConnection.class);
+    BigtableApi bigtableApi = mock(BigtableApi.class);
+    Mockito.doReturn(bigtableApi).when(connectionMock).getBigtableApi();
+    bigtableAdmin = new BigtableAdmin(connectionMock);
+
+    ClusterStatus status = bigtableAdmin.getClusterStatus();
+    assertNotNull(status);
+    assertEquals("hbaseVersion", status.getHBaseVersion());
+    assertEquals("clusterid", status.getClusterId());
+    assertTrue(status.getServersName().isEmpty());
+    assertTrue(status.getDeadServerNames().isEmpty());
+    assertNull(status.getMaster());
+    assertTrue(status.getBackupMasterNames().isEmpty());
+    assertTrue(status.getRegionStatesInTransition().isEmpty());
+    assertEquals(0, status.getMasterCoprocessors().length);
+    assertFalse(status.getBalancerOn());
+    assertEquals(-1, status.getMasterInfoPort());
+  }
+}

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase2_x/BigtableAdminTest.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase2_x/BigtableAdminTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google Inc. All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes #2601
