### PR TITLE
deps: Update beam version to  2.24.0

### DIFF
--- a/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
@@ -51,6 +51,10 @@ limitations under the License.
           <groupId>io.opencensus</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-census</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
@@ -61,13 +61,6 @@ limitations under the License.
     </dependency>
     <dependency>
       <groupId>org.apache.beam</groupId>
-      <artifactId>
-        beam-sdks-java-extensions-google-cloud-platform-core
-      </artifactId>
-      <version>${beam.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.beam</groupId>
       <artifactId>beam-sdks-java-io-hadoop-common</artifactId>
       <version>${beam.version}</version>
     </dependency>
@@ -88,7 +81,7 @@ limitations under the License.
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>${beam-guava.version}</version>
+      <version>${guava.version}</version>
     </dependency>
 
     <!-- TODO: check if commons-codec was transitively updated to 1.13 and okhttp was updated to 2.7.5 when upgrading-->

--- a/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
@@ -33,9 +33,13 @@ limitations under the License.
     <dependencies>
       <dependency>
         <groupId>io.grpc</groupId>
+        <artifactId>grpc-api</artifactId>
+        <version>1.29.0</version>
+      </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
         <artifactId>grpc-core</artifactId>
         <version>1.29.0</version>
-        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -62,10 +66,6 @@ limitations under the License.
         <exclusion>
           <groupId>io.opencensus</groupId>
           <artifactId>*</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.grpc</groupId>
-          <artifactId>grpc-census</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -116,18 +116,6 @@ limitations under the License.
         <exclusion>
           <groupId>com.google.cloud.bigtable</groupId>
           <artifactId>bigtable-client-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.cloud</groupId>
-          <artifactId>google-cloud-spanner</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.grpc</groupId>
-          <artifactId>grpc-grpclb</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.grpc</groupId>
-          <artifactId>grpc-netty</artifactId>
         </exclusion>
         <exclusion>
           <groupId>com.google.api.grpc</groupId>

--- a/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
@@ -65,6 +65,13 @@ limitations under the License.
     </dependency>
     <dependency>
       <groupId>org.apache.beam</groupId>
+      <artifactId>
+        beam-sdks-java-extensions-google-cloud-platform-core
+      </artifactId>
+      <version>${beam.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.beam</groupId>
       <artifactId>beam-sdks-java-io-hadoop-common</artifactId>
       <version>${beam.version}</version>
     </dependency>
@@ -97,6 +104,18 @@ limitations under the License.
         <exclusion>
           <groupId>com.google.cloud.bigtable</groupId>
           <artifactId>bigtable-client-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.cloud</groupId>
+          <artifactId>google-cloud-spanner</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-grpclb</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-netty</artifactId>
         </exclusion>
         <exclusion>
           <groupId>com.google.api.grpc</groupId>

--- a/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
@@ -34,12 +34,12 @@ limitations under the License.
       <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-api</artifactId>
-        <version>1.29.0</version>
+        <version>${beam-grpc.version}</version>
       </dependency>
       <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-core</artifactId>
-        <version>1.29.0</version>
+        <version>${beam-grpc.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
@@ -28,6 +28,18 @@ limitations under the License.
     <mainClass>com.google.cloud.bigtable.beam.sequencefiles.Main</mainClass>
   </properties>
 
+  <!-- Adding this to resolve version conflict within beam sdk-->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-core</artifactId>
+        <version>1.29.0</version>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@ limitations under the License.
     <hamcrest.version>1.3</hamcrest.version>
     <mockito.version>3.6.28</mockito.version>
     <!-- TODO: check if commons-codec was transitively updated to 1.13 and okhttp was updated to 2.7.5 when upgrading-->
-    <beam.version>2.19.0</beam.version>
+    <beam.version>2.25.0</beam.version>
     <!-- referred from bigtable-beam-import and bigtable-emulator -->
     <guava.version>30.0-android</guava.version>
     <beam-guava.version>20.0</beam-guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@ limitations under the License.
     <hamcrest.version>1.3</hamcrest.version>
     <mockito.version>3.6.28</mockito.version>
     <!-- TODO: check if commons-codec was transitively updated to 1.13 and okhttp was updated to 2.7.5 when upgrading-->
-    <beam.version>2.25.0</beam.version>
+    <beam.version>2.24.0</beam.version>
     <!-- referred from bigtable-beam-import and bigtable-emulator -->
     <guava.version>30.0-android</guava.version>
     <beam-guava.version>20.0</beam-guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@ limitations under the License.
     <guava.version>30.0-android</guava.version>
     <beam-guava.version>20.0</beam-guava.version>
     <beam-auto-value.version>1.7.4</beam-auto-value.version>
+    <beam-grpc.version>1.29.0</beam-grpc.version>
 
     <!-- Benchmarks related dependencies -->
     <jmh.version>1.27</jmh.version>


### PR DESCRIPTION
1. Updates Beam version to 2.24.0 (previous 2.25.0, however this would requires us to re-evaluate HBase lib versions, too)
2. use `guava.version` instead of `beam-guava.version` per https://github.com/googleapis/java-bigtable-hbase/pull/2755/files/c6de811c9b2d70e9e4f209ed4dec1ad0a9a7e081#r544717122