### PR TITLE
chore(deps): pin specific deps to be ignored by renovate-bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -66,6 +66,22 @@
         "^com.fasterxml.jackson.core"
       ],
       "groupName": "jackson dependencies"
+    },
+    {
+      "packagePatterns": ["^beam-auto-value.version"],
+      "enabled": false
+    },
+    {
+      "packagePatterns": ["^beam-grpc.version"],
+      "enabled": false
+    },
+    {
+      "packagePatterns": ["^beam-guava.version"],
+      "enabled": false
+    },
+    {
+      "packagePatterns": ["^com.google.cloud.bigtable"],
+      "enabled": false
     }
   ],
   "semanticCommits": true,

--- a/renovate.json
+++ b/renovate.json
@@ -80,6 +80,14 @@
       "enabled": false
     },
     {
+      "packagePatterns": ["^hbase1-hadoop.version"],
+      "enabled": false
+    },
+    {
+      "packagePatterns": ["^hbase2-hadoop.version"],
+      "enabled": false
+    },
+    {
       "packagePatterns": ["^com.google.cloud.bigtable"],
       "enabled": false
     }

--- a/renovate.json5
+++ b/renovate.json5
@@ -68,26 +68,32 @@
       "groupName": "jackson dependencies"
     },
     {
+      // pin to beam deps
       "packagePatterns": ["^beam-auto-value.version"],
       "enabled": false
     },
     {
+      // pin to beam deps
       "packagePatterns": ["^beam-grpc.version"],
       "enabled": false
     },
     {
+      // pin to beam deps
       "packagePatterns": ["^beam-guava.version"],
       "enabled": false
     },
     {
+      // pin to hbase deps
       "packagePatterns": ["^hbase1-hadoop.version"],
       "enabled": false
     },
     {
+      // pin to hbase deps
       "packagePatterns": ["^hbase2-hadoop.version"],
       "enabled": false
     },
     {
+      // this is temporary as we currently get renovate updates when we do a release from bigtable-1.x
       "packagePatterns": ["^com.google.cloud.bigtable"],
       "enabled": false
     }

--- a/synth.py
+++ b/synth.py
@@ -32,5 +32,6 @@ java.common_templates(excludes=[
   '.kokoro/dependencies.sh',
   '.kokoro/build.sh',
   '.kokoro/build.bat',
-  'samples/*'
+  'samples/*',
+  'renovate.json'
 ])


### PR DESCRIPTION
To avoid getting PRs like https://github.com/googleapis/java-bigtable-hbase/pull/2790 where we are instead pinning to a specific version.

The 'com.google.cloud.bigtable' is temporary as we currently get renovate updates when we do a release from bigtable-1.x.