### PR TITLE
feat: align grpc channel ids in bigtable exceptions

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/ChannelPool.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/io/ChannelPool.java
@@ -53,9 +53,6 @@ public class ChannelPool extends ManagedChannel {
   private static final Key<String> CHANNEL_ID_KEY =
       Key.of("bigtable-channel-id", Metadata.ASCII_STRING_MARSHALLER);
 
-  private static final Key<String> CHANNEL_LOG_ID_KEY =
-      Key.of("grpc-channel-id", Metadata.ASCII_STRING_MARSHALLER);
-
   /** For internal use only - public for technical reasons. */
   @InternalApi("For internal usage only")
   public static final String extractIdentifier(Metadata trailers) {


### PR DESCRIPTION
Currently bigtable client annotates its error messages with sequential channel ids which are unrelated to actual grpc log ids. This PR bubbles up both to make it easier top correlate with grpc verbose logging