### PR TITLE
build: enable release-please for bigtable-1.x branch

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,2 +1,6 @@
 releaseType: java-yoshi
 bumpMinorPreMajor: true
+branches:
+  - branch: bigtable-1.x
+    releaseType: java-yoshi
+    bumpMinorPreMajor: true

--- a/synth.metadata
+++ b/synth.metadata
@@ -23,7 +23,6 @@
     ".github/blunderbuss.yml",
     ".github/generated-files-bot.yml",
     ".github/readme/synth.py",
-    ".github/release-please.yml",
     ".github/trusted-contribution.yml",
     ".kokoro/coerce_logs.sh",
     ".kokoro/common.cfg",

--- a/synth.py
+++ b/synth.py
@@ -23,6 +23,7 @@ java.common_templates(excludes=[
   'CONTRIBUTING.md',
   '.github/ISSUE_TEMPLATE/bug_report.md',
   '.github/snippet-bot.yml',
+  '.github/release-please.yml',
   '.github/workflows/*',
   '.kokoro/presubmit/integration.cfg',
   '.kokoro/nightly/integration.cfg',


### PR DESCRIPTION
This should allow release-please to propose releases against the bigtable-1.x branch

To test, I ran against my own fork of this repo:
* pushed an empty feature to the bigtable-1.x branch
* release-please created: https://github.com/chingor13/java-bigtable-hbase/pull/3