### PR TITLE
chore(deps): remove dependency on google-http-client

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/pom.xml
+++ b/bigtable-client-core-parent/bigtable-hbase/pom.xml
@@ -141,12 +141,6 @@ limitations under the License.
       <artifactId>google-auth-library-oauth2-http</artifactId>
     </dependency>
 
-    <!-- TODO: remove this is direct dep, its only used for its Clock interface -->
-    <dependency>
-      <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-shaded-client</artifactId>

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/PutAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/PutAdapter.java
@@ -15,10 +15,8 @@
  */
 package com.google.cloud.bigtable.hbase.adapters;
 
-import com.google.api.client.util.Clock;
 import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.hbase.util.TimestampConverter;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
 import java.util.List;
 import java.util.Map.Entry;
@@ -36,8 +34,6 @@ import org.apache.hadoop.hbase.client.Put;
 public class PutAdapter extends MutationAdapter<Put> {
   private final int maxKeyValueSize;
   private final boolean setClientTimestamp;
-
-  @VisibleForTesting Clock clock = Clock.SYSTEM;
 
   /**
    * Constructor for PutAdapter.
@@ -74,7 +70,7 @@ public class PutAdapter extends MutationAdapter<Put> {
 
     // Bigtable uses a 1ms granularity. Use this timestamp if the Put does not have one specified to
     // make mutations idempotent.
-    long currentTimestampMicros = setClientTimestamp ? clock.currentTimeMillis() * 1000 : -1;
+    long currentTimestampMicros = setClientTimestamp ? System.currentTimeMillis() * 1000 : -1;
     final int rowLength = operation.getRow().length;
 
     for (Entry<byte[], List<Cell>> entry : operation.getFamilyCellMap().entrySet()) {

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/util/OperationAccountant.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/util/OperationAccountant.java
@@ -15,11 +15,12 @@
  */
 package com.google.cloud.bigtable.hbase.util;
 
-import com.google.api.client.util.NanoClock;
+import com.google.api.core.ApiClock;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.ApiFutures;
 import com.google.api.core.InternalApi;
+import com.google.api.core.NanoClock;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.util.concurrent.TimeUnit;
@@ -42,7 +43,7 @@ public class OperationAccountant {
   // Flush() will still wait to complete.
   private static final long INTERVAL_NO_SUCCESS_WARNING_NANOS = TimeUnit.SECONDS.toNanos(30);
 
-  private final NanoClock clock;
+  private final ApiClock clock;
   private final long finishWaitMillis;
 
   private final Object signal = new String("");
@@ -53,11 +54,11 @@ public class OperationAccountant {
 
   /** Constructor for {@link OperationAccountant}. */
   public OperationAccountant() {
-    this(NanoClock.SYSTEM, DEFAULT_FINISH_WAIT_MILLIS);
+    this(NanoClock.getDefaultClock(), DEFAULT_FINISH_WAIT_MILLIS);
   }
 
   @VisibleForTesting
-  OperationAccountant(NanoClock clock, long finishWaitMillis) {
+  OperationAccountant(ApiClock clock, long finishWaitMillis) {
     this.clock = clock;
     this.finishWaitMillis = finishWaitMillis;
     resetNoSuccessWarningDeadline();

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/util/TestOperationAccountant.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/util/TestOperationAccountant.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
-import com.google.api.client.util.NanoClock;
+import com.google.api.core.ApiClock;
 import com.google.api.core.SettableApiFuture;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -42,7 +42,7 @@ import org.mockito.stubbing.Answer;
 public class TestOperationAccountant {
   @Rule public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
-  @Mock NanoClock clock;
+  @Mock ApiClock clock;
 
   @Test
   public void testOnOperationCompletion() {


### PR DESCRIPTION
We unintentionally started depending on google-http-client for for minimal functionality. This will either inline or pull the functionality from elsewhere and drop the dep