### PR TITLE
fix: updated assertions and scan for firstKeyOnlyFilter test (#2483)

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FirstKeyOnlyFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FirstKeyOnlyFilterAdapter.java
@@ -29,8 +29,7 @@ import org.apache.hadoop.hbase.filter.FirstKeyOnlyFilter;
 @InternalApi("For internal usage only")
 public class FirstKeyOnlyFilterAdapter extends TypedFilterAdapterBase<FirstKeyOnlyFilter> {
 
-  private static Filters.Filter LIMIT_ONE =
-      FILTERS.chain().filter(FILTERS.limit().cellsPerRow(1)).filter(FILTERS.value().strip());
+  private static Filters.Filter LIMIT_ONE = FILTERS.limit().cellsPerRow(1);
 
   /** {@inheritDoc} */
   @Override

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFirstKeyOnlyFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFirstKeyOnlyFilterAdapter.java
@@ -35,12 +35,6 @@ public class TestFirstKeyOnlyFilterAdapter {
   public void onlyTheFirstKeyFromEachRowIsEmitted() throws IOException {
     Filters.Filter adaptedFilter =
         adapter.adapt(new FilterAdapterContext(new Scan(), null), new FirstKeyOnlyFilter());
-    Assert.assertEquals(
-        FILTERS
-            .chain()
-            .filter(FILTERS.limit().cellsPerRow(1))
-            .filter(FILTERS.value().strip())
-            .toProto(),
-        adaptedFilter.toProto());
+    Assert.assertEquals(FILTERS.limit().cellsPerRow(1).toProto(), adaptedFilter.toProto());
   }
 }


### PR DESCRIPTION
* chore(test): updated assertions for firstKeyOnlyFilter

This PR updates integration tests assertions to verify firstKeyOnlyFilter.

* chore: reverting back FirstKeyOnlyFilterAdapter to return cell with value

This commit partially reverts changes from #1996 to have consistent behavior with HBase FirstKeyOnlyFilter.

* to trigger failed CI Job

(cherry picked from commit a2cbe7a97c2f65bd1f2a21eaba0c8868b315d55d)

towards #2785, cherry pick of https://github.com/googleapis/java-bigtable-hbase/pull/2483