### PR TITLE
fix: BigtableSession is never closed by Reader causing "ManagedChannel allocation site" exceptions (#2782)

### DIFF
--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableIO.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableIO.java
@@ -699,6 +699,10 @@ public class CloudBigtableIO {
         scanner.close();
         scanner = null;
       }
+      if (session != null) {
+        session.close();
+        session = null;
+      }
       long totalOps = getRowsReadCount();
       long elapsedTimeMs = System.currentTimeMillis() - workStart;
       long operationsPerSecond = elapsedTimeMs == 0 ? 0 : (totalOps * 1000 / elapsedTimeMs);


### PR DESCRIPTION
* fix: BigtableSession is never closed by Reader causing "ManagedChannel allocation site" exceptions

* fix: BigtableSession is never closed by Reader causing "ManagedChannel allocation site" exceptions

(cherry picked from commit 5340db59ca2e78c513574b04f2173dea50fb637d)

Closes #2785 