### PR TITLE
chore(deps): remove dependency analysis for packaging artifacts and non-compile deps

### DIFF
--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
@@ -89,7 +89,9 @@ limitations under the License.
 
   <build>
     <plugins>
-      <!-- override google-cloud-shared-config due to hbase issue -->
+      <!-- disable google-cloud-shared-config enforcement checks because
+      hbase-client's dependency subtree doesn't follow the same rules and we are
+      powerless to fix it here -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
@@ -78,18 +78,7 @@ limitations under the License.
       <version>${dropwizard.metrics.version}</version>
     </dependency>
 
-    <!-- this is used only for test, but we need this as compile scope for repackaging-->
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-common</artifactId>
-      <version>${hbase1-hadoop.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-common</artifactId>
-      <version>${hbase1.version}</version>
-    </dependency>
-
+    <!-- Test deps -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -100,13 +89,18 @@ limitations under the License.
 
   <build>
     <plugins>
+      <!-- override google-cloud-shared-config due to hbase issue -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <configuration>
-          <!--  skipping due to hadoop upper deps bounds issues-->
-          <skip>true</skip>
-        </configuration>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -155,20 +149,19 @@ limitations under the License.
           </execution>
         </executions>
       </plugin>
+
+      <!-- skip for shaded jar-->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
-          <!-- Manually promote dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
-          <usedDependencies>
-            <usedDependency>com.google.code.findbugs:jsr305</usedDependency>
-            <usedDependency>commons-logging:commons-logging</usedDependency>
-            <usedDependency>io.dropwizard.metrics:metrics-core</usedDependency>
-          </usedDependencies>
+          <ignoredDependencies>
+            <dependency>*</dependency>
+          </ignoredDependencies>
         </configuration>
       </plugin>
+      <!-- skip for shaded jar-->
       <plugin>
-        <!-- skip for shaded jar-->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>clirr-maven-plugin</artifactId>
         <configuration>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
@@ -90,8 +90,8 @@ limitations under the License.
   <build>
     <plugins>
       <!-- disable google-cloud-shared-config enforcement checks because
-      hbase-client's dependency subtree doesn't follow the same rules and we are
-      powerless to fix it here -->
+      hbase-client's dependency subtree doesn't follow the same rules and is
+      unable to be fixed here -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
@@ -80,7 +80,7 @@ limitations under the License.
       </plugin>
 
       <plugin>
-        <!-- skip UpperBound enfrocement for hadoop jars -->
+        <!-- skip UpperBound enforcement for hadoop jars -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
@@ -56,44 +56,6 @@ limitations under the License.
     </dependency>
 
     <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-      <version>${commons-logging.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-common</artifactId>
-      <version>${hbase1-hadoop.version}</version>
-      <scope>${hadoop.scope}</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-mapreduce-client-core</artifactId>
-      <version>${hbase1-hadoop.version}</version>
-      <scope>${hadoop.scope}</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-annotations</artifactId>
-      <version>${hbase1.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-client</artifactId>
-      <version>${hbase1.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-common</artifactId>
-      <version>${hbase1.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-annotations</artifactId>
-      <version>${hbase1-hadoop.version}</version>
-      <scope>${hadoop.scope}</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-server</artifactId>
       <version>${hbase1.version}</version>
@@ -102,8 +64,23 @@ limitations under the License.
 
   <build>
     <plugins>
+      <!-- This is basically a replacement for the mapreduce jobs in hbase-server,
+      but with the implementation replaced by bigtable-hbase-1.x-hadoop. This means
+      that all of our dependencies are dictated by hbase-server. hbase-server
+      has a fairly complex dependency tree with a lot of exclusions. Trying to
+      replicate it here to declare exact deps our job uses creates an undue burden.-->
       <plugin>
-        <!-- overriding the default config to add exclusions-->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredDependencies>
+            <dependency>*</dependency>
+          </ignoredDependencies>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <!-- skip UpperBound enfrocement for hadoop jars -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>
@@ -113,29 +90,7 @@ limitations under the License.
               <goal>enforce</goal>
             </goals>
             <configuration>
-              <rules>
-                <requireMavenVersion>
-                  <version>[3.0,)</version>
-                </requireMavenVersion>
-                <requireJavaVersion>
-                  <version>[1.7,)</version>
-                </requireJavaVersion>
-                <requireUpperBoundDeps>
-                  <!-- todo(kolea2): fix these temporary exclusions-->
-                  <excludes>
-                    <exclude>com.google.guava:guava</exclude>
-                    <exclude>commons-codec:commons-codec</exclude>
-                    <exclude>org.apache.zookeeper:zookeeper</exclude>
-                    <exclude>org.apache.hadoop:hadoop-yarn-api</exclude>
-                  </excludes>
-                </requireUpperBoundDeps>
-                <banDuplicateClasses>
-                  <ignoreClasses>
-                    <!-- todo(kolea2): investigate transitive deps causing conflicts-->
-                    <ignoreClass>**</ignoreClass>
-                  </ignoreClasses>
-                </banDuplicateClasses>
-              </rules>
+              <skip>true</skip>
             </configuration>
           </execution>
         </executions>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -315,37 +315,19 @@ limitations under the License.
           </execution>
         </executions>
       </plugin>
+
+      <!-- skip for shaded jar-->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
-          <!-- Manually promote dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
-          <usedDependencies>
-            <usedDependency>
-              com.google.cloud.bigtable:bigtable-hbase-1.x
-            </usedDependency>
-            <usedDependency>
-              org.apache.hbase:hbase-shaded-client
-            </usedDependency>
-            <usedDependency>com.google.code.findbugs:jsr305</usedDependency>
-            <usedDependency>commons-logging:commons-logging</usedDependency>
-            <usedDependency>io.dropwizard.metrics:metrics-core</usedDependency>
-            <usedDependency>io.opencensus:opencensus-impl</usedDependency>
-            <usedDependency>
-              io.opencensus:opencensus-contrib-zpages
-            </usedDependency>
-            <usedDependency>
-              io.opencensus:opencensus-exporter-trace-stackdriver
-            </usedDependency>
-            <usedDependency>
-              io.opencensus:opencensus-exporter-stats-stackdriver
-            </usedDependency>
-            <usedDependency>io.grpc:grpc-census</usedDependency>
-          </usedDependencies>
+          <ignoredDependencies>
+            <dependency>*</dependency>
+          </ignoredDependencies>
         </configuration>
       </plugin>
+      <!-- skip for shaded jar-->
       <plugin>
-        <!-- skip for shaded jar-->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>clirr-maven-plugin</artifactId>
         <configuration>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
@@ -91,8 +91,8 @@ limitations under the License.
     <plugins>
       <plugin>
         <!-- disable google-cloud-shared-config enforcement checks because
-        hbase-client's dependency subtree doesn't follow the same rules and we are
-        powerless to fix it here -->
+        hbase-client's dependency subtree doesn't follow the same rules and is
+        unable to be fixed here -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
@@ -78,18 +78,7 @@ limitations under the License.
       <version>${dropwizard.metrics.version}</version>
     </dependency>
 
-    <!-- this is used only for test, but we need this as compile scope for repackaging-->
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-common</artifactId>
-      <version>${hbase2-hadoop.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-common</artifactId>
-      <version>${hbase2.version}</version>
-    </dependency>
-
+    <!-- Test deps -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -101,30 +90,17 @@ limitations under the License.
   <build>
     <plugins>
       <plugin>
-        <!-- overriding the default config to add exclusions-->
+        <!-- override google-cloud-shared-config due to hbase issue -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <configuration>
-          <rules>
-            <requireMavenVersion>
-              <version>[3.0,)</version>
-            </requireMavenVersion>
-            <requireJavaVersion>
-              <version>[1.7,)</version>
-            </requireJavaVersion>
-            <requireUpperBoundDeps>
-              <excludes>
-                <exclude>com.google.guava:guava</exclude>
-              </excludes>
-            </requireUpperBoundDeps>
-            <banDuplicateClasses>
-              <ignoreClasses>
-                <!-- todo(kolea2): investigate transitive deps causing conflicts-->
-                <ignoreClass>**</ignoreClass>
-              </ignoreClasses>
-            </banDuplicateClasses>
-          </rules>
-        </configuration>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -184,20 +160,19 @@ limitations under the License.
           </execution>
         </executions>
       </plugin>
+
+      <!-- skip for shaded jar-->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
-          <!-- Manually promote dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
-          <usedDependencies>
-            <usedDependency>com.google.code.findbugs:jsr305</usedDependency>
-            <usedDependency>commons-logging:commons-logging</usedDependency>
-            <usedDependency>io.dropwizard.metrics:metrics-core</usedDependency>
-          </usedDependencies>
+          <ignoredDependencies>
+              <dependency>*</dependency>
+          </ignoredDependencies>
         </configuration>
       </plugin>
+      <!-- skip for shaded jar-->
       <plugin>
-        <!-- skip for shaded jar-->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>clirr-maven-plugin</artifactId>
         <configuration>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
@@ -90,7 +90,9 @@ limitations under the License.
   <build>
     <plugins>
       <plugin>
-        <!-- override google-cloud-shared-config due to hbase issue -->
+        <!-- disable google-cloud-shared-config enforcement checks because
+        hbase-client's dependency subtree doesn't follow the same rules and we are
+        powerless to fix it here -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
@@ -313,37 +313,19 @@ limitations under the License.
           </execution>
         </executions>
       </plugin>
+
+      <!-- skip for shaded jar-->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
-          <!-- Manually promote dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
-          <usedDependencies>
-            <usedDependency>
-              com.google.cloud.bigtable:bigtable-hbase-2.x
-            </usedDependency>
-            <usedDependency>
-              org.apache.hbase:hbase-shaded-client
-            </usedDependency>
-            <usedDependency>com.google.code.findbugs:jsr305</usedDependency>
-            <usedDependency>commons-logging:commons-logging</usedDependency>
-            <usedDependency>io.dropwizard.metrics:metrics-core</usedDependency>
-            <usedDependency>io.opencensus:opencensus-impl</usedDependency>
-            <usedDependency>
-              io.opencensus:opencensus-contrib-zpages
-            </usedDependency>
-            <usedDependency>
-              io.opencensus:opencensus-exporter-trace-stackdriver
-            </usedDependency>
-            <usedDependency>
-              io.opencensus:opencensus-exporter-stats-stackdriver
-            </usedDependency>
-            <usedDependency>io.grpc:grpc-census</usedDependency>
-          </usedDependencies>
+          <ignoredDependencies>
+            <dependency>*</dependency>
+          </ignoredDependencies>
         </configuration>
       </plugin>
+      <!-- skip for shaded jar-->
       <plugin>
-        <!-- skip for shaded jar-->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>clirr-maven-plugin</artifactId>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,15 @@ limitations under the License.
     </testResources>
     <pluginManagement>
       <plugins>
+        <!-- Augment google-cloud-shared-config config to exclude non-compile deps -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <configuration>
+            <ignoreNonCompile>true</ignoreNonCompile>
+          </configuration>
+        </plugin>
+
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>


### PR DESCRIPTION
This should pull in less unnecessary deps as hbase-client explicitly excludes a bunch of transitive deps from hadoop-common.  Also this should simplify maintenance.

Also remove dependency analysis from bigtable-hbase-1.x-mapreduce. The artifact is primarily a copy of the mapreduce jobs that exist in hbase-server with the bigtable-hbase-1.x-hadoop inserted. This means that module lives within the confines of hbase-server dependencies and direct dep analysis doesn't buy much value. 