### PR TITLE
chore: stop shading conscrypt

### DIFF
--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
@@ -77,6 +77,12 @@ limitations under the License.
       <artifactId>metrics-core</artifactId>
       <version>${dropwizard.metrics.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.conscrypt</groupId>
+      <artifactId>conscrypt-openjdk-uber</artifactId>
+      <version>${grpc-conscrypt.version}</version>
+      <scope>runtime</scope>
+    </dependency>
 
     <!-- Test deps -->
     <dependency>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -115,6 +115,12 @@ limitations under the License.
       <artifactId>metrics-core</artifactId>
       <version>${dropwizard.metrics.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.conscrypt</groupId>
+      <artifactId>conscrypt-openjdk-uber</artifactId>
+      <version>${grpc-conscrypt.version}</version>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -177,6 +183,7 @@ limitations under the License.
                   <exclude>org.hamcrest:hamcrest-core</exclude>
                   <exclude>javax.inject:javax.inject</exclude>
                   <exclude>javax.annotation:javax.annotation-api</exclude>
+                  <exclude>org.conscrypt:conscrypt-openjdk-uber</exclude>
                 </excludes>
               </artifactSet>
               <relocations>
@@ -289,12 +296,6 @@ limitations under the License.
                   <pattern>org.apache.commons.lang3</pattern>
                   <shadedPattern>
                     com.google.bigtable.repackaged.org.apache.commons.lang3
-                  </shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.conscrypt</pattern>
-                  <shadedPattern>
-                    com.google.bigtable.repackaged.org.conscrypt
                   </shadedPattern>
                 </relocation>
                 <relocation>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
@@ -77,6 +77,12 @@ limitations under the License.
       <artifactId>metrics-core</artifactId>
       <version>${dropwizard.metrics.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.conscrypt</groupId>
+      <artifactId>conscrypt-openjdk-uber</artifactId>
+      <version>${grpc-conscrypt.version}</version>
+      <scope>runtime</scope>
+    </dependency>
 
     <!-- Test deps -->
     <dependency>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
@@ -297,12 +297,6 @@ limitations under the License.
                   </shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>org.conscrypt</pattern>
-                  <shadedPattern>
-                    com.google.bigtable.repackaged.org.conscrypt
-                  </shadedPattern>
-                </relocation>
-                <relocation>
                   <pattern>org.threeten</pattern>
                   <shadedPattern>
                     com.google.bigtable.repackaged.org.threeten

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
@@ -105,6 +105,12 @@ limitations under the License.
       <artifactId>metrics-core</artifactId>
       <version>${dropwizard.metrics.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.conscrypt</groupId>
+      <artifactId>conscrypt-openjdk-uber</artifactId>
+      <version>${grpc-conscrypt.version}</version>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -174,6 +180,7 @@ limitations under the License.
                   <exclude>org.apache.htrace:htrace-core4</exclude>
                   <exclude>org.apache.yetus:audience-annotations</exclude>
                   <exclude>javax.annotation:javax.annotation-api</exclude>
+                  <exclude>org.conscrypt:conscrypt-openjdk-uber</exclude>
                 </excludes>
               </artifactSet>
               <relocations>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@ limitations under the License.
     <!-- core dependency versions -->
     <bigtable.version>1.21.0</bigtable.version>
     <dropwizard.metrics.version>3.2.6</dropwizard.metrics.version>
+    <grpc-conscrypt.version>2.5.1</grpc-conscrypt.version>
     <!--  keeping at this version to align with hbase-->
     <slf4j.version>1.7.25</slf4j.version>
     <commons-logging.version>1.2</commons-logging.version>

--- a/renovate.json5
+++ b/renovate.json5
@@ -97,6 +97,11 @@
       "enabled": false
     },
     {
+      // pin to bigtable version
+      "excludePackagePatterns" : ["^grpc-conscrypt.version"],
+      "enabled": false
+    },
+    {
       // this is temporary as we currently get renovate updates when we do a release from bigtable-1.x
       "packagePatterns": ["^com.google.cloud.bigtable"],
       "enabled": false


### PR DESCRIPTION
Until https://github.com/google/conscrypt/issues/811 is fixed, we can't shade it reliably.

A follow up PR will add build time checks to ensure that grpc-conscrypt property is properly kept in sync
