### PR TITLE
chore: fix shading leaks

### DIFF
--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
@@ -59,6 +59,10 @@ limitations under the License.
           <groupId>io.opencensus</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-census</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -68,11 +72,6 @@ limitations under the License.
     </dependency>
 
     <!-- Manually promote dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>${jsr305.version}</version>
-    </dependency>
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -102,10 +102,6 @@ limitations under the License.
     </dependency>
 
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
       <version>${commons-logging.version}</version>
@@ -167,22 +163,16 @@ limitations under the License.
                   <!-- exclude user visible deps -->
                   <exclude>io.dropwizard.metrics:metrics-core</exclude>
                   <exclude>commons-logging:commons-logging</exclude>
-                  <exclude>com.google.code.findbugs:jsr305</exclude>
                   <!-- exclude hbase-shaded-client & all of its dependencies -->
                   <exclude>org.apache.hbase:hbase-shaded-client</exclude>
                   <exclude>org.slf4j:slf4j-api</exclude>
                   <exclude>org.slf4j:slf4j-log4j12</exclude>
-                  <exclude>org.slf4j:slf4j-api</exclude>
                   <exclude>log4j:log4j</exclude>
                   <exclude>org.apache.htrace:htrace-core</exclude>
                   <exclude>
                     com.github.stephenc.findbugs:findbugs-annotations
                   </exclude>
                   <exclude>log4j:log4j</exclude>
-                  <exclude>junit:junit</exclude>
-                  <exclude>org.hamcrest:hamcrest-core</exclude>
-                  <exclude>javax.inject:javax.inject</exclude>
-                  <exclude>javax.annotation:javax.annotation-api</exclude>
                   <exclude>org.conscrypt:conscrypt-openjdk-uber</exclude>
                 </excludes>
               </artifactSet>
@@ -233,6 +223,11 @@ limitations under the License.
                     com.google.bigtable.repackaged.io.grpc
                   </shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>io.perfmark</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.io.perfmark</shadedPattern>
+                </relocation>
+
 
                 <!-- Opencensus related shading -->
                 <relocation>
@@ -240,6 +235,10 @@ limitations under the License.
                   <shadedPattern>
                     com.google.bigtable.repackaged.io.opencensus
                   </shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>google.monitoring</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.google.monitoring</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.json</pattern>
@@ -309,6 +308,19 @@ limitations under the License.
                   <shadedPattern>
                     com.google.bigtable.repackaged.org.codehaus
                   </shadedPattern>
+                </relocation>
+
+                <relocation>
+                  <pattern>org.checkerframework</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.org.checkerframework</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>android.annotation</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.android.annotation</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>javax.annotation</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.javax.annotation</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
@@ -58,6 +58,10 @@ limitations under the License.
           <groupId>io.opencensus</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-census</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -67,11 +71,6 @@ limitations under the License.
     </dependency>
 
     <!-- Manually promote dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>${jsr305.version}</version>
-    </dependency>
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
@@ -72,11 +72,11 @@ limitations under the License.
     </dependency>
     <dependency>
       <groupId>io.opencensus</groupId>
-      <artifactId>opencensus-exporter-trace-stackdriver</artifactId>
+      <artifactId>opencensus-exporter-stats-stackdriver</artifactId>
     </dependency>
     <dependency>
       <groupId>io.opencensus</groupId>
-      <artifactId>opencensus-exporter-stats-stackdriver</artifactId>
+      <artifactId>opencensus-exporter-trace-stackdriver</artifactId>
     </dependency>
     <!-- grpc-census needed alongside opencensus-exporter-stats-stackdriver for GRPC stats exports to work -->
     <dependency>
@@ -91,10 +91,6 @@ limitations under the License.
       <version>${hbase2.version}</version>
     </dependency>
 
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-    </dependency>
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
@@ -162,24 +158,16 @@ limitations under the License.
                   <!-- exclude user visible deps -->
                   <exclude>io.dropwizard.metrics:metrics-core</exclude>
                   <exclude>commons-logging:commons-logging</exclude>
-                  <exclude>com.google.code.findbugs:jsr305</exclude>
                   <!-- exclude hbase-shaded-client & all of its dependencies -->
                   <exclude>org.apache.hbase:hbase-shaded-client</exclude>
                   <exclude>org.slf4j:slf4j-api</exclude>
-                  <exclude>org.slf4j:slf4j-log4j12</exclude>
-                  <exclude>org.slf4j:slf4j-api</exclude>
                   <exclude>log4j:log4j</exclude>
-                  <exclude>org.apache.htrace:htrace-core</exclude>
+                  <exclude>org.apache.htrace:htrace-core4</exclude>
+                  <exclude>org.apache.yetus:audience-annotations</exclude>
                   <exclude>
                     com.github.stephenc.findbugs:findbugs-annotations
                   </exclude>
                   <exclude>log4j:log4j</exclude>
-                  <exclude>junit:junit</exclude>
-                  <exclude>org.hamcrest:hamcrest-core</exclude>
-                  <exclude>javax.inject:javax.inject</exclude>
-                  <exclude>org.apache.htrace:htrace-core4</exclude>
-                  <exclude>org.apache.yetus:audience-annotations</exclude>
-                  <exclude>javax.annotation:javax.annotation-api</exclude>
                   <exclude>org.conscrypt:conscrypt-openjdk-uber</exclude>
                 </excludes>
               </artifactSet>
@@ -231,6 +219,11 @@ limitations under the License.
                     com.google.bigtable.repackaged.io.grpc
                   </shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>io.perfmark</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.io.perfmark</shadedPattern>
+                </relocation>
+
 
                 <!-- Opencensus related shading -->
                 <relocation>
@@ -238,6 +231,10 @@ limitations under the License.
                   <shadedPattern>
                     com.google.bigtable.repackaged.io.opencensus
                   </shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>google.monitoring</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.google.monitoring</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.json</pattern>
@@ -307,6 +304,19 @@ limitations under the License.
                   <shadedPattern>
                     com.google.bigtable.repackaged.org.codehaus
                   </shadedPattern>
+                </relocation>
+
+                <relocation>
+                  <pattern>org.checkerframework</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.org.checkerframework</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>android.annotation</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.android.annotation</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>javax.annotation</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.javax.annotation</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>


### PR DESCRIPTION
* shade jsr305, its considered an internal implementation detail and shouldn't leak to hbase surface
* remove stale excludes for test deps
* add missing relocations
* exclude grpc-census since its shaded
