### PR TITLE
chore: remove stale dependency override

### DIFF
--- a/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
@@ -168,11 +168,6 @@ limitations under the License.
       <artifactId>commons-codec</artifactId>
       <version>1.15</version>
     </dependency>
-    <dependency>
-      <groupId>com.squareup.okhttp</groupId>
-      <artifactId>okhttp</artifactId>
-      <version>2.7.5</version>
-    </dependency>
 
     <dependency>
       <groupId>commons-logging</groupId>
@@ -387,7 +382,6 @@ limitations under the License.
           <usedDependencies>
             <usedDependency>com.google.auto.value:auto-value</usedDependency>
             <usedDependency>commons-codec:commons-codec</usedDependency>
-            <usedDependency>com.squareup.okhttp:okhttp</usedDependency>
             <usedDependency>org.apache.beam:beam-sdks-java-io-hadoop-common
             </usedDependency>
             <usedDependency>org.apache.beam:beam-runners-direct-java


### PR DESCRIPTION
This was originally added to force upgrade a transitive dep that had security vulnerabilities. This dep is no longer used, so the override is not necessary