### PR TITLE
chore(deps): remove unnecessary deps

### DIFF
--- a/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
@@ -403,8 +403,6 @@ limitations under the License.
                 <targetDependency>org.apache.beam:beam-sdks-java-core:${beam.version}</targetDependency>
               </targetDependencies>
               <ignoredDependencies>
-                <!-- Version of commons-compress shipped with beam had a security issue, we are forcing a newer version -->
-                <ignoredDependency>org.apache.commons:commons-compress</ignoredDependency>
                 <!-- TODO: figure out how to resolve this -->
                 <ignoredDependency>com.google.errorprone:error_prone_annotations</ignoredDependency>
                 <!-- TODO: align conscrypt with beam upgade -->

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/pom.xml
@@ -88,14 +88,6 @@ limitations under the License.
       <version>${slf4j.version}</version>
     </dependency>
 
-    <!--  TODO: remove this dependency when upgraded through transitive dependency (beam-sdks-java-core)
-     this is not used directly, but upgrading due to transitive vulnerabilities in older versions-->
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-compress</artifactId>
-      <version>1.20</version>
-    </dependency>
-
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
@@ -233,16 +225,6 @@ limitations under the License.
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <!-- commons-compress is not used directly, but upgrading due to transitive vulnerabilities in older versions-->
-          <usedDependencies>
-            <usedDependency>org.apache.commons:commons-compress</usedDependency>
-          </usedDependencies>
-        </configuration>
-      </plugin>
 
       <plugin>
         <groupId>com.google.cloud.bigtable.test</groupId>
@@ -260,8 +242,6 @@ limitations under the License.
                 <targetDependency>org.apache.beam:beam-sdks-java-core:${beam.version}</targetDependency>
               </targetDependencies>
               <ignoredDependencies>
-                <!-- Version of commons-compress shipped with beam had a security issue, we are forcing a newer version -->
-                <dependency>org.apache.commons:commons-compress</dependency>
                 <!-- beam's dependency tree has an older version closer higher in the tree -->
                 <dependency>com.google.errorprone:error_prone_annotations</dependency>
                 <!-- TODO: align conscrypt with beam upgade -->


### PR DESCRIPTION
This original added to mitigate a security vulnerability. After reviewing the relevant issues, it seem like the vulnerabilities are irrelevant to bigtable-hbase. commons-compress is only used by avro and the security issues are listed here:
https://commons.apache.org/proper/commons-compress/security-reports.html

All of them are related to crafting malicious compressed files that cause excessive cpu usage. Since bigtable-hbase-beam doesn't touch any avro files, this doesnt affect us at all