### PR TITLE
chore(deps): cleanup forced transitive dep upgrades

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -212,14 +212,6 @@ limitations under the License.
       <version>${dropwizard.metrics.version}</version>
     </dependency>
 
-    <!--  TODO: remove this dependency when upgraded through transitive dependency (http-client -> org.apache.httpcomponents:httpclient)
-this is not used directly, but upgrading due to transitive vulnerabilities in older versions-->
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <version>1.15</version>
-    </dependency>
-
     <!-- Test -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -281,16 +273,6 @@ this is not used directly, but upgrading due to transitive vulnerabilities in ol
               <value>src/test/resources/logging.properties</value>
             </property>
           </systemProperties>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <!-- commons-codec is not used directly, but upgrading due to transitive vulnerabilities in older versions. -->
-          <usedDependencies>
-            <usedDependency>commons-codec:commons-codec</usedDependency>
-          </usedDependencies>
         </configuration>
       </plugin>
     </plugins>

--- a/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
@@ -187,6 +187,13 @@ limitations under the License.
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <version>1.15</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.20</version>
+      <scope>runtime</scope>
     </dependency>
 
 
@@ -371,20 +378,6 @@ limitations under the License.
       </plugin>
 
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <usedDependencies>
-            <usedDependency>commons-codec:commons-codec</usedDependency>
-            <usedDependency>org.apache.beam:beam-sdks-java-io-hadoop-common
-            </usedDependency>
-            <usedDependency>org.apache.beam:beam-runners-direct-java
-            </usedDependency>
-          </usedDependencies>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>com.google.cloud.bigtable.test</groupId>
         <artifactId>bigtable-build-helper</artifactId>
         <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
@@ -400,10 +393,8 @@ limitations under the License.
                 <targetDependency>org.apache.beam:beam-sdks-java-core:${beam.version}</targetDependency>
               </targetDependencies>
               <ignoredDependencies>
-                <!-- Version of commons-compress shipped with beam had a security issue, we are forcing a newer version -->
-                <ignoredDependency>org.apache.commons:commons-compress</ignoredDependency>
-                <!-- TODO: figure out how to resolve this -->
-                <ignoredDependency>com.google.errorprone:error_prone_annotations</ignoredDependency>
+                <!-- beam's dependency tree has an older version closer higher in the tree -->
+                <dependency>org.apache.commons:commons-compress</dependency>
               </ignoredDependencies>
             </configuration>
           </execution>

--- a/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
@@ -78,6 +78,8 @@ limitations under the License.
     <dependency>
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-sdks-java-io-hadoop-common</artifactId>
+      <!-- used at runtime via WritableCoderProviderRegistrar service -->
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.beam</groupId>

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/pom.xml
@@ -127,13 +127,6 @@ limitations under the License.
       <version>${beam-slf4j.version}</version>
     </dependency>
 
-    <!-- CVE Group: force update transitive deps to exclude CVEs -->
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-compress</artifactId>
-      <version>1.20</version>
-    </dependency>
-
     <!-- Test Group -->
     <dependency>
       <groupId>org.mockito</groupId>
@@ -273,16 +266,6 @@ limitations under the License.
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <!-- commons-compress is not used directly, but upgrading due to transitive vulnerabilities in older versions-->
-          <usedDependencies>
-            <usedDependency>org.apache.commons:commons-compress</usedDependency>
-          </usedDependencies>
-        </configuration>
-      </plugin>
 
       <plugin>
         <groupId>com.google.cloud.bigtable.test</groupId>
@@ -300,11 +283,24 @@ limitations under the License.
                 <targetDependency>org.apache.beam:beam-sdks-java-core:${beam.version}</targetDependency>
               </targetDependencies>
               <ignoredDependencies>
-                <!-- Version of commons-compress shipped with beam had a security issue, we are forcing a newer version -->
-                <dependency>org.apache.commons:commons-compress</dependency>
                 <!-- beam's dependency tree has an older version closer higher in the tree -->
                 <dependency>com.google.errorprone:error_prone_annotations</dependency>
               </ignoredDependencies>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <!-- Silence checks for old version commons-compress. The the actual
+          issue is irrelevant, but fixing it will create real dependency issues
+          for end users -->
+          <execution>
+            <id>enforce-banned-deps</id>
+            <configuration>
+              <skip>true</skip>
             </configuration>
           </execution>
         </executions>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
@@ -130,6 +130,17 @@ limitations under the License.
               <skip>true</skip>
             </configuration>
           </execution>
+          <!-- This must be a drop in replacement for hbase-client, so can't
+            manage hbase's deps -->
+          <execution>
+            <id>enforce-banned-deps</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
@@ -490,16 +490,6 @@ limitations under the License.
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <usedDependencies>
-            <usedDependency>${project.groupId}:bigtable-hbase-1.x</usedDependency>
-            <usedDependency>io.grpc:grpc-grpclb</usedDependency>
-          </usedDependencies>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
@@ -35,6 +35,7 @@ limitations under the License.
   </description>
 
   <dependencies>
+    <!-- Primary Group -->
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>bigtable-hbase-1.x-hadoop</artifactId>
@@ -55,6 +56,20 @@ limitations under the License.
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-server</artifactId>
       <version>${hbase1.version}</version>
+    </dependency>
+
+    <!-- CVE Group: force update transitive deps to exclude CVEs -->
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.15</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.20</version>
+      <scope>runtime</scope>
     </dependency>
   </dependencies>
 
@@ -189,6 +204,12 @@ limitations under the License.
                 <dependency>org.slf4j:slf4j-api</dependency>
                 <!-- TODO: figure out what to do about metrics mismatch -->
                 <dependency>io.dropwizard.metrics:metrics-core</dependency>
+
+                <!-- BEGIN: force upgrade transitive deps due to security reports -->
+                <dependency>org.apache.commons:commons-compress</dependency>
+                <dependency>org.tukaani:xz</dependency>
+                <dependency>commons-codec:commons-codec</dependency>
+                <!-- END: force upgrade transitive deps due to security reports -->
               </ignoredDependencies>
             </configuration>
           </execution>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
@@ -136,6 +136,17 @@ limitations under the License.
               <skip>true</skip>
             </configuration>
           </execution>
+          <!-- This must be a drop in replacement for hbase-client, so can't
+            manage hbase's deps -->
+          <execution>
+            <id>enforce-banned-deps</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
@@ -416,14 +416,6 @@ limitations under the License.
       <scope>test</scope>
     </dependency>
 
-    <!--  TODO: remove this dependency when upgraded through transitive dependency (http-client -> org.apache.httpcomponents:httpclient)
-this is not used directly, but upgrading due to transitive vulnerabilities in older versions-->
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <version>1.15</version>
-    </dependency>
-
     <!-- Testing deps -->
     <dependency>
       <groupId>org.mockito</groupId>
@@ -476,18 +468,6 @@ this is not used directly, but upgrading due to transitive vulnerabilities in ol
             </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <usedDependencies>
-            <usedDependency>${project.groupId}:bigtable-hbase-2.x</usedDependency>
-            <usedDependency>org.slf4j:slf4j-log4j12</usedDependency>
-            <!-- commons-codec is not used directly, but upgrading due to transitive vulnerabilities in older versions. -->
-            <usedDependency>commons-codec:commons-codec</usedDependency>
-          </usedDependencies>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -352,6 +352,22 @@ limitations under the License.
               </rules>
             </configuration>
           </execution>
+          <execution>
+            <id>enforce-banned-deps</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>commons-codec:commons-codec:[,1.15)</exclude>
+                    <exclude>org.apache.commons:commons-compress:[,1.20)</exclude>
+                  </excludes>
+                </bannedDependencies>
+              </rules>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
     </plugins>


### PR DESCRIPTION
Awhile back we added direct deps on indirect dependencies to exclude deps that have security issues. The security issues are not relevant to bigtable, but we decided it was good practice. This PR revisits that decision:
1. it add build checks that will by default fail the build if we accidentally depend on the problematic versions
2. it specifically ignores the new checks in scenarios where are not in control of our deps

This depends on beam upgrade (#2892  and needs to be rebased once that PR merges