### PR TITLE
feat: minimize bloat in mapreduce module

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -209,7 +209,7 @@ limitations under the License.
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
-      <version>${dropwizard.metrics.version}</version>
+      <version>${hbase1-metrics.version}</version>
     </dependency>
 
     <!-- Test -->

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
@@ -80,7 +80,7 @@ limitations under the License.
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
-      <version>${dropwizard.metrics.version}</version>
+      <version>${hbase1-metrics.version}</version>
       <exclusions>
         <!-- see slf4j notes below -->
         <exclusion>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/README.md
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/README.md
@@ -39,7 +39,7 @@ from/to     Cloud Bigtable using a Map Reduce cluster (ie. dataproc).
 2. Download the gcloud sdk.
 3. Configure [Bigtable IAM roles](https://cloud.google.com/bigtable/docs/access-control#roles) 
     for the [Dataproc Service Account](https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/service-accounts#what_are_service_accounts) 
-    when running on Dataproc. Alternatively, download service account credentials json from Google Cloud Console.
+    when running on Dataproc.
 4. Submit the job. 
    ```bash
     # Export

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/README.md
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/README.md
@@ -1,0 +1,40 @@
+# Map/Reduce jobs to import from/export to Bigtable
+
+This module provides a work alike to some of the jobs implemented in hbase-server.
+Specifically this currently the ability to export and import SequenceFile from/to
+Cloud Bigtable using a Map Reduce cluster (ie. dataproc).
+
+## Expected Usage 
+
+### Hadoop
+1. Download and extract hbase 1.4.13 from https://hbase.apache.org/downloads.html
+2. Configure you hbase-site.xml file to your hbase cluster
+3. Download the latest shaded version of this module `bigtable-hbase-1.x-mapreduce-shaded-XXX.jar`
+4. Download your service account credentials json file from google cloud console
+5. Start the job:
+    To export:
+        ```
+        HBASE_CLASSPATH=path/to/bigtable-hbase-1.x-mapreduce-shaded-XXX.jar \
+        GOOGLE_APPLICATION_CREDENTIALS=path/to/service-account.json \
+        hbase com.google.cloud.bigtable.mapreduce.Driver \
+            export-table \
+            -Dgoogle.bigtable.project.id=<project-id> \
+            -Dgoogle.bigtable.instance.id=<instance-id> \
+            <table-id> \
+            <outputdir>
+        ```
+    
+    To import:
+        ```
+        HBASE_CLASSPATH=path/to/bigtable-hbase-1.x-mapreduce-shaded-XXX.jar \
+        GOOGLE_APPLICATION_CREDENTIALS=path/to/service-account.json \
+        hbase com.google.cloud.bigtable.mapreduce.Driver \
+                    import-table \
+                    -Dgoogle.bigtable.project.id=<project-id> \
+                    -Dgoogle.bigtable.instance.id=<instane-id> \
+                    <table-id> \
+                    <inputdir>
+        ```
+
+### Dataproc
+TODO

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/README.md
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/README.md
@@ -7,7 +7,7 @@ from/to     Cloud Bigtable using a Map Reduce cluster (ie. dataproc).
 ## Expected Usage 
 
 [//]: # ({x-version-update-start:bigtable-hbase-1x-parent:released})
-### Hadoop
+### On-prem Hadoop
 
 1. Download or build bigtable-hbase-1.x-mapreduce-1.14.0-shaded-byo-hadoop.jar
 2. Download service account credentials json from Google Cloud Console.
@@ -37,6 +37,9 @@ from/to     Cloud Bigtable using a Map Reduce cluster (ie. dataproc).
 
 1. Download or build bigtable-hbase-1.x-mapreduce-1.14.0-shaded-byo-hadoop.jar.
 2. Download the gcloud sdk.
+3. Configure [Bigtable IAM roles](https://cloud.google.com/bigtable/docs/access-control#roles) 
+    for the [Dataproc Service Account](https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/service-accounts#what_are_service_accounts) 
+    when running on Dataproc. Alternatively, download service account credentials json from Google Cloud Console.
 4. Submit the job. 
    ```bash
     # Export

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/README.md
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/README.md
@@ -67,4 +67,12 @@ from/to     Cloud Bigtable using a Map Reduce cluster (ie. dataproc).
         <inputdir>
    ```
 
+### Backwards compatibility
+
+To maintain backwards compatibility of this artifact, we still provide
+`bigtable-hbase-1.x-mapreduce-1.14.0-shaded.jar` artifact that includes
+hadoop jars. However we encourage our users to migrate to 
+`bigtable-hbase-1.x-mapreduce-1.14.0-shaded-byo-hadoop.jar` to avoid dependency
+conflicts with the existing classpath on Hadoop workers.
+
 [//]: # ({x-version-update-end})

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/README.md
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/README.md
@@ -1,8 +1,8 @@
 # Map/Reduce jobs to import from/export to Bigtable
 
 This module provides a work alike to some of the jobs implemented in hbase-server.
-Specifically this currently the ability to export and import SequenceFile from/to
-Cloud Bigtable using a Map Reduce cluster (ie. dataproc).
+Specifically this currently has the ability to export and import SequenceFile
+from/to     Cloud Bigtable using a Map Reduce cluster (ie. dataproc).
 
 ## Expected Usage 
 
@@ -11,9 +11,7 @@ Cloud Bigtable using a Map Reduce cluster (ie. dataproc).
 
 1. Download or build bigtable-hbase-1.x-mapreduce-1.14.0-shaded-byo-hadoop.jar
 2. Download service account credentials json from Google Cloud Console.
-2. Download hadoop-client binary distribution.
-3. Configure hadoop's core-site.xml for your cluster.
-4. Submit the job. 
+3. Submit the job using your edge node's hadoop installation. 
    ```bash
    # Export
    GOOGLE_APPLICATION_CREDENTIALS=path/to/service-account.json \
@@ -41,23 +39,29 @@ Cloud Bigtable using a Map Reduce cluster (ie. dataproc).
 2. Download the gcloud sdk.
 4. Submit the job. 
    ```bash
-   # Export
-   gcloud dataproc jobs submit hadoop \
-       --jar bigtable-hbase-1.x-mapreduce-1.14.0-shaded-byo-hadoop.jar \
-           export-table \
-           -Dgoogle.bigtable.project.id=<project-id> \
-           -Dgoogle.bigtable.instance.id=<instance-id> \
-           <table-id> \
-           <outputdir>
+    # Export
+    gcloud dataproc jobs submit hadoop \
+        --cluster <dataproc-cluster> \
+        --region <dataproc-region> \
+        --jar bigtable-hbase-1.x-mapreduce-1.14.0-shaded-byo-hadoop.jar \
+        -- \
+        export-table \
+        -Dgoogle.bigtable.project.id=<project-id> \
+        -Dgoogle.bigtable.instance.id=<instance-id> \
+        <table-id> \
+        <outputdir>
    
-   # Import
-      gcloud dataproc jobs submit hadoop \
-         --jar bigtable-hbase-1.x-mapreduce-1.14.0-shaded-byo-hadoop.jar \
-          import-table \
-          -Dgoogle.bigtable.project.id=<project-id> \
-          -Dgoogle.bigtable.instance.id=<instance-id> \
-          <table-id> \
-          <inputdir>
+    # Import
+    gcloud dataproc jobs submit hadoop \
+        --cluster <dataproc-cluster> \
+        --region <dataproc-region> \
+        --jar bigtable-hbase-1.x-mapreduce-1.14.0-shaded-byo-hadoop.jar \
+        -- \
+        import-table \
+        -Dgoogle.bigtable.project.id=<project-id> \
+        -Dgoogle.bigtable.instance.id=<instance-id> \
+        <table-id> \
+        <inputdir>
    ```
 
 [//]: # ({x-version-update-end})

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/README.md
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/README.md
@@ -6,35 +6,58 @@ Cloud Bigtable using a Map Reduce cluster (ie. dataproc).
 
 ## Expected Usage 
 
+[//]: # ({x-version-update-start:bigtable-hbase-1x-parent:released})
 ### Hadoop
-1. Download and extract hbase 1.4.13 from https://hbase.apache.org/downloads.html
-2. Configure you hbase-site.xml file to your hbase cluster
-3. Download the latest shaded version of this module `bigtable-hbase-1.x-mapreduce-shaded-XXX.jar`
-4. Download your service account credentials json file from google cloud console
-5. Start the job:
-    To export:
-        ```
-        HBASE_CLASSPATH=path/to/bigtable-hbase-1.x-mapreduce-shaded-XXX.jar \
-        GOOGLE_APPLICATION_CREDENTIALS=path/to/service-account.json \
-        hbase com.google.cloud.bigtable.mapreduce.Driver \
-            export-table \
-            -Dgoogle.bigtable.project.id=<project-id> \
-            -Dgoogle.bigtable.instance.id=<instance-id> \
-            <table-id> \
-            <outputdir>
-        ```
-    
-    To import:
-        ```
-        HBASE_CLASSPATH=path/to/bigtable-hbase-1.x-mapreduce-shaded-XXX.jar \
-        GOOGLE_APPLICATION_CREDENTIALS=path/to/service-account.json \
-        hbase com.google.cloud.bigtable.mapreduce.Driver \
-                    import-table \
-                    -Dgoogle.bigtable.project.id=<project-id> \
-                    -Dgoogle.bigtable.instance.id=<instane-id> \
-                    <table-id> \
-                    <inputdir>
-        ```
+
+1. Download or build bigtable-hbase-1.x-mapreduce-1.14.0-shaded-byo-hadoop.jar
+2. Download service account credentials json from Google Cloud Console.
+2. Download hadoop-client binary distribution.
+3. Configure hadoop's core-site.xml for your cluster.
+4. Submit the job. 
+   ```bash
+   # Export
+   GOOGLE_APPLICATION_CREDENTIALS=path/to/service-account.json \
+   hadoop jar bigtable-hbase-1.x-mapreduce-1.14.0-shaded-byo-hadoop.jar \
+       export-table \
+       -Dgoogle.bigtable.project.id=<project-id> \
+       -Dgoogle.bigtable.instance.id=<instance-id> \
+       <table-id> \
+       <outputdir>
+   
+   # Import
+      GOOGLE_APPLICATION_CREDENTIALS=path/to/service-account.json \
+      hadoop jar bigtable-hbase-1.x-mapreduce-1.14.0-shaded-byo-hadoop.jar \
+          import-table \
+          -Dgoogle.bigtable.project.id=<project-id> \
+          -Dgoogle.bigtable.instance.id=<instance-id> \
+          <table-id> \
+          <inputdir>
+   ```
+
 
 ### Dataproc
-TODO
+
+1. Download or build bigtable-hbase-1.x-mapreduce-1.14.0-shaded-byo-hadoop.jar.
+2. Download the gcloud sdk.
+4. Submit the job. 
+   ```bash
+   # Export
+   gcloud dataproc jobs submit hadoop \
+       --jar bigtable-hbase-1.x-mapreduce-1.14.0-shaded-byo-hadoop.jar \
+           export-table \
+           -Dgoogle.bigtable.project.id=<project-id> \
+           -Dgoogle.bigtable.instance.id=<instance-id> \
+           <table-id> \
+           <outputdir>
+   
+   # Import
+      gcloud dataproc jobs submit hadoop \
+         --jar bigtable-hbase-1.x-mapreduce-1.14.0-shaded-byo-hadoop.jar \
+          import-table \
+          -Dgoogle.bigtable.project.id=<project-id> \
+          -Dgoogle.bigtable.instance.id=<instance-id> \
+          <table-id> \
+          <inputdir>
+   ```
+
+[//]: # ({x-version-update-end})

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/assembly/shaded-byo-hadoop.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/assembly/shaded-byo-hadoop.xml
@@ -34,7 +34,9 @@
       <unpack>true</unpack>
       <scope>provided</scope>
       <!-- These are populated from TableMapReduceUtil.addHBaseDependencyJars() -->
-      <!-- TODO: enforce the consistency -->
+      <!-- This is necessary because hbase 1x doesn't have a mapreduce artifact,
+      so we need to rely on extracting the relevant bits ourselves. hbase 2x,
+      ships with a mapreduce jar that properly marks hadoop deps are provided -->
       <includes>
         <include>org.apache.hbase:hbase-common</include>
         <include>org.apache.hbase:hbase-protocol</include>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/assembly/shaded-byo-hadoop.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/assembly/shaded-byo-hadoop.xml
@@ -1,0 +1,68 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+
+  <id>shaded-byo-hadoop</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+
+  <containerDescriptorHandlers>
+    <containerDescriptorHandler>
+      <handlerName>metaInf-services</handlerName>
+    </containerDescriptorHandler>
+  </containerDescriptorHandlers>
+
+  <dependencySets>
+    <!-- include project + runtime deps -->
+    <dependencySet>
+      <outputDirectory>/</outputDirectory>
+      <useProjectArtifact>true</useProjectArtifact>
+      <unpack>true</unpack>
+      <scope>runtime</scope>
+      <unpackOptions>
+        <excludes>
+          <exclude>META-INF/license/**</exclude>
+          <exclude>META-INF/license</exclude>
+        </excludes>
+      </unpackOptions>
+    </dependencySet>
+    <!-- include HBase mapreduce dependency jars -->
+    <dependencySet>
+      <outputDirectory>/</outputDirectory>
+      <useProjectArtifact>false</useProjectArtifact>
+      <unpack>true</unpack>
+      <scope>provided</scope>
+      <!-- These are populated from TableMapReduceUtil.addHBaseDependencyJars() -->
+      <!-- TODO: enforce the consistency -->
+      <includes>
+        <include>org.apache.hbase:hbase-common</include>
+        <include>org.apache.hbase:hbase-protocol</include>
+        <include>org.apache.hbase:hbase-client</include>
+        <include>org.apache.hbase:hbase-hadoop-compat</include>
+        <include>org.apache.hbase:hbase-hadoop2-compat</include>
+        <include>org.apache.hbase:hbase-server</include>
+        <include>org.apache.hbase:hbase-metrics</include>
+        <include>org.apache.hbase:hbase-metrics-api</include>
+        <include>org.apache.hbase:hbase-metrics-api</include>
+        <include>org.apache.hbase.thirdparty:hbase-shaded-gson</include>
+        <include>org.apache.hbase:hbase-prefix-tree</include>
+        <include>org.apache.zookeeper:zookeeper</include>
+        <include>io.netty:netty-all</include>
+        <include>com.google.protobuf:protobuf-java</include>
+        <include>com.google.guava:guava</include>
+        <include>org.apache.htrace:htrace-core</include>
+        <include>com.yammer.metrics:metrics-core</include>
+      </includes>
+      <unpackOptions>
+        <!-- TODO: figure out how to deal with conflicts -->
+        <excludes>
+          <!-- Some deps put their licenses into a directory which causes hadoop
+          jar to fail -->
+          <exclude>META-INF/license/**</exclude>
+          <exclude>META-INF/license</exclude>
+        </excludes>
+      </unpackOptions>
+    </dependencySet>
+  </dependencySets>
+</assembly>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/assembly/shaded.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/assembly/shaded.xml
@@ -1,0 +1,50 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+
+  <id>shaded</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+
+  <containerDescriptorHandlers>
+    <containerDescriptorHandler>
+      <handlerName>metaInf-services</handlerName>
+    </containerDescriptorHandler>
+  </containerDescriptorHandlers>
+
+  <dependencySets>
+    <!-- include project + runtime deps -->
+    <dependencySet>
+      <outputDirectory>/</outputDirectory>
+      <useProjectArtifact>true</useProjectArtifact>
+      <unpack>true</unpack>
+      <scope>runtime</scope>
+      <unpackOptions>
+        <!-- TODO: figure out how to deal with conflicts -->
+        <excludes>
+          <!-- Some deps put their licenses into a directory which causes hadoop
+          jar to fail -->
+          <exclude>META-INF/license/**</exclude>
+          <exclude>META-INF/license</exclude>
+        </excludes>
+      </unpackOptions>
+    </dependencySet>
+    <!-- include provided deps -->
+    <dependencySet>
+      <outputDirectory>/</outputDirectory>
+      <useProjectArtifact>true</useProjectArtifact>
+      <unpack>true</unpack>
+      <scope>provided</scope>
+      <unpackOptions>
+        <!-- TODO: figure out how to deal with conflicts -->
+        <excludes>
+          <!-- Some deps put their licenses into a directory which causes hadoop
+          jar to fail -->
+          <exclude>META-INF/license/**</exclude>
+          <exclude>META-INF/license</exclude>
+        </excludes>
+      </unpackOptions>
+    </dependencySet>
+  </dependencySets>
+</assembly>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
@@ -82,6 +82,14 @@ limitations under the License.
         </exclusion>
       </exclusions>
     </dependency>
+
+    <!-- Test Group -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
@@ -34,13 +34,44 @@ limitations under the License.
     in order to work with Bigtable.
   </description>
 
+  <properties>
+    <hbase1-mapreduce-slfj.version>1.7.10</hbase1-mapreduce-slfj.version>
+  </properties>
+
+  <!-- NOTE: this artifact is designed to be used alongside hbase-server via
+  the bin/hbase script. It's primary intention is to produce single jar that can
+  be added to hbase's classpath to kick off mapreduce jobs targeted at bigtable.
+  A secondary goal is for some java orchestration program to kick off the jobs.
+
+  Thus the dependencies here must be exactly:
+  - bigtable-hbase-1.x-hadoop
+  - any hbase provided jars
+
+  In the primary usecase we will shade bigtable-hbase-1.x-hadoop allowing the
+  enduser to drop a single jar in the hbase classpath. In the secondary case,
+  the enduser can explcitly add their own version hbase-server.
+  -->
+
   <dependencies>
     <!-- Primary Group -->
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-server</artifactId>
+      <version>${hbase1.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>bigtable-hbase-1.x-hadoop</artifactId>
       <version>${project.version}</version>
       <exclusions>
+        <!-- we need hbase-server instead of hbase-client -->
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-client</artifactId>
+        </exclusion>
+
         <!-- Workaround MNG-5899 & MSHADE-206. Maven >= 3.3.0 doesn't use the dependency reduced
         pom.xml files when invoking the build from a parent project. So we have to manually exclude
         the dependencies. Note that this works in conjunction with the manually promoted dependencies
@@ -50,26 +81,6 @@ limitations under the License.
           <artifactId>bigtable-hbase-1.x-shaded</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-server</artifactId>
-      <version>${hbase1.version}</version>
-    </dependency>
-
-    <!-- CVE Group: force update transitive deps to exclude CVEs -->
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <version>1.15</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-compress</artifactId>
-      <version>1.20</version>
-      <scope>runtime</scope>
     </dependency>
   </dependencies>
 
@@ -100,6 +111,14 @@ limitations under the License.
             <goals>
               <goal>enforce</goal>
             </goals>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </execution>
+          <!-- We are not introducing any new deps here. We expect to be
+          running in hadoop's provided classpath -->
+          <execution>
+            <id>enforce-banned-deps</id>
             <configuration>
               <skip>true</skip>
             </configuration>
@@ -151,13 +170,6 @@ limitations under the License.
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer" />
               </transformers>
-              <artifactSet>
-                <excludes>
-                  <exclude>tomcat:*</exclude>
-                  <exclude>javax.servlet.jsp:*</exclude>
-                  <exclude>javax.servlet:*</exclude>
-                </excludes>
-              </artifactSet>
               <filters>
                 <filter>
                   <artifact>*:*</artifact>
@@ -166,14 +178,6 @@ limitations under the License.
                     <exclude>META-INF/*.SF</exclude>
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>
-                    <exclude>META-INF/**/pom.properties</exclude>
-                    <exclude>META-INF/**/pom.xml</exclude>
-                    <exclude>META-INF/NOTICE.txt</exclude>
-                    <exclude>META-INF/LICENSE.txt</exclude>
-                    <exclude>META-INF/NOTICE</exclude>
-                    <exclude>META-INF/DEPENDENCIES</exclude>
-                    <exclude>META-INF/LICENSE</exclude>
-                    <exclude>META-INF/jersey-module-version</exclude>
                   </excludes>
                 </filter>
               </filters>
@@ -198,18 +202,8 @@ limitations under the License.
                 <targetDependency>org.apache.hbase:hbase-server:${hbase1.version}</targetDependency>
               </targetDependencies>
               <ignoredDependencies>
-                <!-- Unfortunately we can't use hadoop's version of slf4j
-                because dropwizard metrics slf4j logger requires a higher version
-                we can't shade it either -->
-                <dependency>org.slf4j:slf4j-api</dependency>
-                <!-- TODO: figure out what to do about metrics mismatch -->
-                <dependency>io.dropwizard.metrics:metrics-core</dependency>
-
-                <!-- BEGIN: force upgrade transitive deps due to security reports -->
-                <dependency>org.apache.commons:commons-compress</dependency>
-                <dependency>org.tukaani:xz</dependency>
-                <dependency>commons-codec:commons-codec</dependency>
-                <!-- END: force upgrade transitive deps due to security reports -->
+                <!-- TODO: figure out why this diverges from hbase-client -->
+                <ignoredDependency>org.slf4j:slf4j-api</ignoredDependency>
               </ignoredDependencies>
             </configuration>
           </execution>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
@@ -208,6 +208,9 @@ limitations under the License.
               <ignoredDependencies>
                 <!-- TODO: figure out why this diverges from hbase-client -->
                 <ignoredDependency>org.slf4j:slf4j-api</ignoredDependency>
+                <!-- For some reason, hbase-server pulls in test deps -->
+                <ignoredDependency>junit:junit</ignoredDependency>
+                <ignoredDependency>org.hamcrest:hamcrest-core</ignoredDependency>
               </ignoredDependencies>
             </configuration>
           </execution>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
@@ -39,7 +39,7 @@ limitations under the License.
   </properties>
 
   <!-- NOTE: this artifact is designed to be used alongside hbase-server via
-  the bin/hbase script. It's primary intention is to produce single jar that can
+  the bin/hbase script. Its primary intention is to produce a single jar that can
   be added to hbase's classpath to kick off mapreduce jobs targeted at bigtable.
   A secondary goal is for some java orchestration program to kick off the jobs.
 

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
@@ -155,32 +155,28 @@ limitations under the License.
           </archive>
         </configuration>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.3.0</version>
         <executions>
           <execution>
-            <phase>package</phase>
+            <id>shaded</id>
             <goals>
-              <goal>shade</goal>
+              <goal>single</goal>
             </goals>
+            <phase>package</phase>
             <configuration>
-              <shadedArtifactAttached>true</shadedArtifactAttached>
-              <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer" />
-              </transformers>
-              <filters>
-                <filter>
-                  <artifact>*:*</artifact>
-                  <excludes>
-                    <exclude>META-INF/MANIFEST.MF</exclude>
-                    <exclude>META-INF/*.SF</exclude>
-                    <exclude>META-INF/*.DSA</exclude>
-                    <exclude>META-INF/*.RSA</exclude>
-                  </excludes>
-                </filter>
-              </filters>
+              <archive>
+                <manifest>
+                  <mainClass>com.google.cloud.bigtable.mapreduce.Driver</mainClass>
+                </manifest>
+              </archive>
+              <descriptors>
+                <descriptor>assembly/shaded-byo-hadoop.xml</descriptor>
+                <descriptor>assembly/shaded.xml</descriptor>
+              </descriptors>
             </configuration>
           </execution>
         </executions>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/src/test/java/AssemblyConfigTest.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/src/test/java/AssemblyConfigTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2021 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.mapreduce.TableMapReduceUtil;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+@RunWith(JUnit4.class)
+public class AssemblyConfigTest {
+
+  /**
+   * This test ensures that assembly/shaded-byo-hadoop.xml {@code includes} match the expected HBase
+   * marpreduce classpath. It parses the file to find the coordinates and compares them to the
+   * classpath that {@link TableMapReduceUtil} generates.
+   *
+   * <p>This test expects that shaded-byu-hadoop will only have a single {@code dependencySet} to represent
+   * the deps required to run hbase mapreduce jars. It identifies the correct {@code dependencySet}
+   * by finding an {@code include} for {@code hbase-common} in the {@code provided} {@code scope}.
+   */
+  @Test
+  public void verifyBYOHadoopIncludes() throws Exception {
+    // If this fails, the provided dependencySet in assembly/shaded-byo-hadoop.xml should be updated
+    // to reflect the deps specified by TableMapReduceUtil.
+    Assert.assertEquals(
+        "The assembly descriptor `shaded-byo-hadoop.xml` must be in sync with TableMapReduceUtil dependency jars",
+        extractHBaseBaseArtifactDeps(),
+        extractAssemblyBaseArtifactIncludes(new File("assembly/shaded-byo-hadoop.xml")));
+  }
+
+  private static Set<String> extractAssemblyBaseArtifactIncludes(File file)
+      throws ParserConfigurationException, XPathExpressionException, IOException, SAXException {
+    Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(file);
+    XPathFactory xPathFactory = XPathFactory.newInstance();
+    XPathExpression depSetPath = xPathFactory.newXPath().compile(
+        "/assembly/dependencySets/dependencySet[scope='provided' and includes/include='org.apache.hbase:hbase-common']");
+
+    NodeList depSetNodes = (NodeList) depSetPath.evaluate(doc, XPathConstants.NODESET);
+    Assert.assertEquals("Expected single dependencySet with provided hbase-common", 1,
+        depSetNodes.getLength());
+
+    Node depSetNode = depSetNodes.item(0);
+    depSetPath = xPathFactory.newXPath().compile("includes/include");
+    NodeList includeNodes = (NodeList) depSetPath.evaluate(depSetNode, XPathConstants.NODESET);
+
+    Set<String> actualIncludeIds = new HashSet<>();
+    for (int i = 0; i < includeNodes.getLength(); i++) {
+      String versionlessCoordinate = includeNodes.item(i).getTextContent();
+      String artifactId = versionlessCoordinate.split(":")[1];
+      actualIncludeIds.add(artifactId);
+    }
+
+    return actualIncludeIds;
+  }
+
+  /**
+   * Extract the required base artifact ids from HBase's classpath.
+   *
+   * <p>This uses a heuristic that converts jar names into artifact ids. This approach is fragile,
+   * but shouldnt need to be updated much.
+   */
+  private static Set<String> extractHBaseBaseArtifactDeps() throws IOException {
+    Configuration configuration = new Configuration(false);
+    TableMapReduceUtil.addHBaseDependencyJars(configuration);
+    String classpath = TableMapReduceUtil.buildDependencyClasspath(configuration);
+
+    Set<String> expectedIncludeIds = new HashSet<>();
+    for (String pathStr : classpath.split(":")) {
+
+      String filename = new File(pathStr).getName();
+      // extract the artifact base name from the filename, stripping version and extension
+      String artifactId = filename.replaceAll(
+          "(.*)-\\d+\\.\\d+(\\.\\d+)?(?:-(?:incubating|alpha|beta)|\\.Final)?\\.jar$", "$1");
+      expectedIncludeIds.add(artifactId);
+    }
+    return expectedIncludeIds;
+  }
+}

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/src/test/java/AssemblyConfigTest.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/src/test/java/AssemblyConfigTest.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Pattern;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathConstants;
@@ -36,6 +37,8 @@ import org.xml.sax.SAXException;
 
 @RunWith(JUnit4.class)
 public class AssemblyConfigTest {
+  private static final Pattern ARTIFACT_FILENAME_RE =
+      Pattern.compile("(.*)-\\d+\\.\\d+(\\.\\d+)?(?:-(?:incubating|alpha|beta)|\\.Final)?\\.jar$");
 
   /**
    * This test ensures that assembly/shaded-byo-hadoop.xml {@code includes} match the expected HBase
@@ -101,9 +104,7 @@ public class AssemblyConfigTest {
 
       String filename = new File(pathStr).getName();
       // extract the artifact base name from the filename, stripping version and extension
-      String artifactId =
-          filename.replaceAll(
-              "(.*)-\\d+\\.\\d+(\\.\\d+)?(?:-(?:incubating|alpha|beta)|\\.Final)?\\.jar$", "$1");
+      String artifactId = ARTIFACT_FILENAME_RE.matcher(filename).replaceAll("$1");
       expectedIncludeIds.add(artifactId);
     }
     return expectedIncludeIds;

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/src/test/java/AssemblyConfigTest.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/src/test/java/AssemblyConfigTest.java
@@ -42,9 +42,10 @@ public class AssemblyConfigTest {
    * marpreduce classpath. It parses the file to find the coordinates and compares them to the
    * classpath that {@link TableMapReduceUtil} generates.
    *
-   * <p>This test expects that shaded-byu-hadoop will only have a single {@code dependencySet} to represent
-   * the deps required to run hbase mapreduce jars. It identifies the correct {@code dependencySet}
-   * by finding an {@code include} for {@code hbase-common} in the {@code provided} {@code scope}.
+   * <p>This test expects that shaded-byu-hadoop will only have a single {@code dependencySet} to
+   * represent the deps required to run hbase mapreduce jars. It identifies the correct {@code
+   * dependencySet} by finding an {@code include} for {@code hbase-common} in the {@code provided}
+   * {@code scope}.
    */
   @Test
   public void verifyBYOHadoopIncludes() throws Exception {
@@ -60,12 +61,15 @@ public class AssemblyConfigTest {
       throws ParserConfigurationException, XPathExpressionException, IOException, SAXException {
     Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(file);
     XPathFactory xPathFactory = XPathFactory.newInstance();
-    XPathExpression depSetPath = xPathFactory.newXPath().compile(
-        "/assembly/dependencySets/dependencySet[scope='provided' and includes/include='org.apache.hbase:hbase-common']");
+    XPathExpression depSetPath =
+        xPathFactory
+            .newXPath()
+            .compile(
+                "/assembly/dependencySets/dependencySet[scope='provided' and includes/include='org.apache.hbase:hbase-common']");
 
     NodeList depSetNodes = (NodeList) depSetPath.evaluate(doc, XPathConstants.NODESET);
-    Assert.assertEquals("Expected single dependencySet with provided hbase-common", 1,
-        depSetNodes.getLength());
+    Assert.assertEquals(
+        "Expected single dependencySet with provided hbase-common", 1, depSetNodes.getLength());
 
     Node depSetNode = depSetNodes.item(0);
     depSetPath = xPathFactory.newXPath().compile("includes/include");
@@ -97,8 +101,9 @@ public class AssemblyConfigTest {
 
       String filename = new File(pathStr).getName();
       // extract the artifact base name from the filename, stripping version and extension
-      String artifactId = filename.replaceAll(
-          "(.*)-\\d+\\.\\d+(\\.\\d+)?(?:-(?:incubating|alpha|beta)|\\.Final)?\\.jar$", "$1");
+      String artifactId =
+          filename.replaceAll(
+              "(.*)-\\d+\\.\\d+(\\.\\d+)?(?:-(?:incubating|alpha|beta)|\\.Final)?\\.jar$", "$1");
       expectedIncludeIds.add(artifactId);
     }
     return expectedIncludeIds;

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -109,7 +109,7 @@ limitations under the License.
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
-      <version>${dropwizard.metrics.version}</version>
+      <version>${hbase1-metrics.version}</version>
     </dependency>
 
     <!-- See notes in bigtable-client-core/bigtable-hbase/pom.xml#verify-conscrypt-version -->

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/pom.xml
@@ -85,7 +85,7 @@ limitations under the License.
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
-      <version>${dropwizard.metrics.version}</version>
+      <version>${hbase1-metrics.version}</version>
     </dependency>
 
     <!-- These are direct dependencies of TestBigtableConnection.java which is in test scope,
@@ -141,7 +141,7 @@ limitations under the License.
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-graphite</artifactId>
-      <version>${dropwizard.metrics.version}</version>
+      <version>${hbase1-metrics.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
@@ -79,7 +79,7 @@ limitations under the License.
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
-      <version>${dropwizard.metrics.version}</version>
+      <version>${hbase2-metrics.version}</version>
       <exclusions>
         <!-- see slf4j notes below -->
         <exclusion>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
@@ -99,7 +99,7 @@ limitations under the License.
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
-      <version>${dropwizard.metrics.version}</version>
+      <version>${hbase2-metrics.version}</version>
     </dependency>
 
     <!-- See notes in bigtable-client-core/bigtable-hbase/pom.xml#verify-conscrypt-version -->

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/pom.xml
@@ -134,14 +134,14 @@ limitations under the License.
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
-      <version>${dropwizard.metrics.version}</version>
+      <version>${hbase2-metrics.version}</version>
     </dependency>
 
     <!-- Test dependencies-->
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-graphite</artifactId>
-      <version>3.2.6</version>
+      <version>${hbase2-metrics.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,6 @@ limitations under the License.
 
     <!-- core dependency versions -->
     <bigtable.version>1.21.0</bigtable.version>
-    <dropwizard.metrics.version>3.2.6</dropwizard.metrics.version>
     <grpc-conscrypt.version>2.5.1</grpc-conscrypt.version>
     <!--  keeping at this version to align with hbase-->
     <slf4j.version>1.7.25</slf4j.version>
@@ -66,7 +65,9 @@ limitations under the License.
 
     <!-- hbase dependency versions -->
     <hbase1.version>1.4.12</hbase1.version>
+    <hbase1-metrics.version>3.1.2</hbase1-metrics.version>
     <hbase2.version>2.2.3</hbase2.version>
+    <hbase2-metrics.version>3.2.6</hbase2-metrics.version>
 
     <!-- testing dependency versions -->
     <commons-lang.version>2.6</commons-lang.version>

--- a/renovate.json5
+++ b/renovate.json5
@@ -78,7 +78,10 @@
     },
     {
       // pin to hbase deps
-      "packagePatterns": ["^hbase1-hadoop-slf4j.version", "^hbase2-hadoop-slf4j.version"],
+      "packagePatterns": [
+        "^hbase.-hadoop-slf4j.version",
+        "^hbase.-mapreduce-slfj.version",
+      ],
       "enabled": false
     },
     {


### PR DESCRIPTION
Before this PR, mapreduce would produce 2 jars:
1. regular java jar that could be embedded in a job orchestrator. The consuming application would need to do it's own packaging to ensure that all deps are on the classpath
2. a shaded jar that included everything, which was meant to be used as a self contained jar with all hbase & hadoop deps

This PR introduces a middle ground to address the most common usecase: launching jobs via `hadoop jar`. This usecase expects that all hadoop jars will be provided by a hadoop installation, but all of the hbase deps still need to be provided. 

The approach this PR takes is:
1. Mark all hbase & hadoop deps are `provided`.
2. Switch to maven-assembly-plugin and define 2 descriptors:
    1. shaded - preserves the original kitchen sink jar
    2. shaded-byo-hadoop - includes jars explicitly needed for hbase mapreduce jars
3. Add a test to ensure that shaded-byo-hadoop stays consistent with hbase mapredcp

If we ever port bigtable-hbase-mapreduce to hbase 2.x we can simplify this by dependeing directly on hbase-shaded-mapreduce.