### PR TITLE
fix: manifests in executable jars

### DIFF
--- a/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
@@ -324,6 +324,7 @@ limitations under the License.
           <shadedArtifactAttached>true</shadedArtifactAttached>
           <transformers>
             <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer" />
           </transformers>
 	  <filters>
 	      <filter>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
@@ -132,6 +132,10 @@ limitations under the License.
             </goals>
             <configuration>
               <shadedArtifactAttached>true</shadedArtifactAttached>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer" />
+              </transformers>
               <artifactSet>
                 <excludes>
                   <exclude>tomcat:*</exclude>
@@ -144,6 +148,9 @@ limitations under the License.
                   <artifact>*:*</artifact>
                   <excludes>
                     <exclude>META-INF/MANIFEST.MF</exclude>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
                     <exclude>META-INF/**/pom.properties</exclude>
                     <exclude>META-INF/**/pom.xml</exclude>
                     <exclude>META-INF/NOTICE.txt</exclude>


### PR DESCRIPTION
During the dependency cleanup, I accidentally removed the ManifestResource transformer that prevented the shaded jar from being run with java -jar. This restores this functionality
