### PR TITLE
fix: hbase 2x shell

### DIFF
--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableConnection.java
@@ -170,7 +170,7 @@ public class BigtableConnection extends AbstractBigtableConnection {
             Proxy.newProxyInstance(
                 cls.getClassLoader(),
                 new Class<?>[] {cls},
-                new UnsupportedInvocationHandler("Unsupported" + cls.getName()));
+                new UnsupportedInvocationHandler("Unsupported" + cls.getSimpleName()));
 
     return proxy;
   }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableConnection.java
@@ -184,7 +184,9 @@ public class BigtableConnection extends AbstractBigtableConnection {
 
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-      if (args.length == 1
+      int argCount = (args == null) ? 0 : args.length;
+
+      if (argCount == 1
           && method.getName().equals("equals")
           && method.getParameterTypes()[0] == Object.class) {
         Object arg = args[0];
@@ -193,10 +195,10 @@ public class BigtableConnection extends AbstractBigtableConnection {
         }
         return proxy == arg;
       }
-      if (args.length == 1 && method.getName().equals("hashCode")) {
+      if (argCount == 0 && method.getName().equals("hashCode")) {
         return super.hashCode();
       }
-      if (args.length == 0 && method.getName().equals("toString")) {
+      if (argCount == 0 && method.getName().equals("toString")) {
         return name;
       }
 

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableConnection.java
@@ -18,6 +18,9 @@ package com.google.cloud.bigtable.hbase2_x;
 import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.hbase.adapters.SampledRowKeysAdapter;
 import java.io.IOException;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
@@ -28,6 +31,7 @@ import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.AbstractBigtableConnection;
 import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.Hbck;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.RegionInfoBuilder;
 import org.apache.hadoop.hbase.client.Table;
@@ -139,5 +143,57 @@ public class BigtableConnection extends AbstractBigtableConnection {
       regionInfos.add(location.getRegionInfo());
     }
     return regionInfos;
+  }
+
+  @Override
+  public Hbck getHbck() throws IOException {
+    return createUnsupportedProxy(Hbck.class);
+  }
+
+  @Override
+  public Hbck getHbck(ServerName masterServer) throws IOException {
+    return createUnsupportedProxy(Hbck.class);
+  }
+
+  private <T> T createUnsupportedProxy(Class<T> cls) {
+
+    @SuppressWarnings("unchecked")
+    T proxy =
+        (T)
+            Proxy.newProxyInstance(
+                cls.getClassLoader(),
+                new Class<?>[] {cls},
+                new UnsupportedInvocationHandler("Unsupported" + cls.getName()));
+
+    return proxy;
+  }
+
+  private static class UnsupportedInvocationHandler implements InvocationHandler {
+    private final String name;
+
+    private UnsupportedInvocationHandler(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+      if (args.length == 1
+          && method.getName().equals("equals")
+          && method.getParameterTypes()[0] == Object.class) {
+        Object arg = args[0];
+        if (arg == null) {
+          return false;
+        }
+        return proxy == arg;
+      }
+      if (args.length == 1 && method.getName().equals("hashCode")) {
+        return super.hashCode();
+      }
+      if (args.length == 0 && method.getName().equals("toString")) {
+        return name;
+      }
+
+      throw new UnsupportedOperationException(name + "." + method.getName());
+    }
   }
 }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableConnection.java
@@ -155,8 +155,15 @@ public class BigtableConnection extends AbstractBigtableConnection {
     return createUnsupportedProxy(Hbck.class);
   }
 
+  /**
+   * Create a dynamic proxy for the passed in interface.
+   *
+   * <p>The proxy will implement all methods by throwing an {@link UnsupportedOperationException}.
+   * This is useful for deferring the exception being thrown. For example hbase shell will acquire a
+   * reference toHbck, but wont actually use it. So it would be useful to allow hbase shell to
+   * initialize and defer the UnsupportOperationExcetion on Hbck is actually invoked.
+   */
   private <T> T createUnsupportedProxy(Class<T> cls) {
-
     @SuppressWarnings("unchecked")
     T proxy =
         (T)

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableConnection.java
@@ -100,10 +100,12 @@ public class TestBigtableConnection {
       Assert.assertEquals(hbck1, hbck1);
       Assert.assertNotEquals(hbck1, hbck2);
 
+      // Make sure that the hashCode is stable
       Assert.assertEquals(hbck1.hashCode(), hbck1.hashCode());
+      // And differs for different instances
       Assert.assertNotEquals(hbck1.hashCode(), hbck2.hashCode());
 
-      Assert.assertTrue(hbck1.toString().contains("Unsupported"));
+      Assert.assertEquals("UnsupportedHbck", hbck1.toString());
     }
   }
 }


### PR DESCRIPTION
fixes #2866
bigtable hbase shell has been broken since hbase 2.2.0. It broke because hbase added a feature that the shell referenced. The feature is not actively used by the shell, but it is referenced. This PR defers the unsupported operation errors so that the shell can load

Creating an integration test is going to take a bit more work, so it was extracted to #2904