### PR TITLE
fix: null gcrule for supporting max versions

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/admin/TableAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/admin/TableAdapter.java
@@ -20,6 +20,7 @@ import static com.google.cloud.bigtable.hbase.adapters.admin.ColumnDescriptorAda
 import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.admin.v2.models.ColumnFamily;
 import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
+import com.google.cloud.bigtable.admin.v2.models.GCRules.GCRule;
 import com.google.cloud.bigtable.admin.v2.models.Table;
 import com.google.protobuf.ByteString;
 import org.apache.hadoop.hbase.HColumnDescriptor;
@@ -46,7 +47,12 @@ public class TableAdapter {
     if (request != null) {
       for (HColumnDescriptor column : desc.getColumnFamilies()) {
         String columnName = column.getNameAsString();
-        request.addFamily(columnName, buildGarbageCollectionRule(column));
+        GCRule gcRule = buildGarbageCollectionRule(column);
+        if (gcRule == null) {
+          request.addFamily(columnName);
+        } else {
+          request.addFamily(columnName, gcRule);
+        }
       }
     }
   }


### PR DESCRIPTION
the intention of the setting max versions in HBase with Integer.MAX_VALUE is to allow the table to have unlimited versions. This change mitigates the NPE and allows a table to be created without a version limit. 
```java
HColumnDescriptor columnDesc = new HColumnDescriptor(cf);
columnDesc.setMaxVersions(Integer.MAX_VALUE);
```

Based on this GCRule mapping 
[ColumnDescriptorAdapter.java#L175-L176](https://github.com/googleapis/java-bigtable-hbase/blob/master/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/admin/ColumnDescriptorAdapter.java#L175-L176), the default number of versions isn't really meant to be `2,147,483,647`, but should be unlimited when `maxVersions == Integer.MAX_VALUE`.

Test with the fix applied:
```java
  public static void main(String[] args) throws IOException {
    Configuration conf = new Configuration(false);
    BigtableConfiguration.configure(conf, "jh-data-sandbox", "instance-1234");
    Connection bigtableConn = BigtableConfiguration.connect(conf);

    String table = args[0];
    String cf = "cf1";

    BigtableTableAdminClient tableAdminClient =
        BigtableTableAdminClient.create(
            BigtableTableAdminSettings.newBuilder()
                .setProjectId("jh-data-sandbox")
                .setInstanceId("instance-1234")
                .build());

    tableAdminClient.createTable(
        CreateTableRequest.of(table).addFamily(cf));

     Admin admin = bigtableConn.getAdmin(); HTableDescriptor htd = new HTableDescriptor(table + "_z");
     HColumnDescriptor columnDesc = new HColumnDescriptor(cf);
     columnDesc.setMaxVersions(Integer.MAX_VALUE);
     htd.addFamily(columnDesc);
     admin.createTable(htd);
  }
```
produces:
```bash
$ cbt --project jh-data-sandbox --instance instance-1234 ls t1_z
Family Name	GC Policy
-----------	---------
cf1		<never>

$ cbt --project jh-data-sandbox --instance instance-1234 ls t1
Family Name	GC Policy
-----------	---------
cf1		<never>
```

Fixes #2909 ☕️
