### PR TITLE
fix: enabling the integration test on the correct kokoro target

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -51,7 +51,7 @@ javadoc)
     ;;
 integration)
 # clean needed when running more than one IT profile
-    mvn clean verify -B ${INTEGRATION_TEST_ARGS} -DtrimStackTrace=false -Dclirr.skip=true -fae
+    mvn clean verify -B ${INTEGRATION_TEST_ARGS} -Penable-integration-tests -DtrimStackTrace=false -Dclirr.skip=true -fae
     RETURN_CODE=$?
     ;;
 clirr)

--- a/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
@@ -449,6 +449,11 @@ limitations under the License.
     <!-- profile to run all integration tests -->
     <profile>
       <id>beamIntegrationTest</id>
+      <properties>
+        <!-- Needed to enable integration tests before we figure out -->
+        <!-- possible misconfiguration of Failsafe plugin -->
+        <skipITs>false</skipITs>
+      </properties>
       <build>
         <plugins>
           <plugin>

--- a/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
@@ -449,11 +449,6 @@ limitations under the License.
     <!-- profile to run all integration tests -->
     <profile>
       <id>beamIntegrationTest</id>
-      <properties>
-        <!-- Needed to enable integration tests before we figure out -->
-        <!-- possible misconfiguration of Failsafe plugin -->
-        <skipITs>false</skipITs>
-      </properties>
       <build>
         <plugins>
           <plugin>
@@ -483,11 +478,6 @@ limitations under the License.
 
     <profile>
       <id>hbasesnapshotsIntegrationTest</id>
-      <properties>
-        <!-- Needed to enable integration tests before we figure out -->
-        <!-- possible misconfiguration of Failsafe plugin -->
-        <skipITs>false</skipITs>
-      </properties>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
When moving the <skipITs> to individual profile, I accidentally moved it to a incorrect target instead of `beamIntegrationTest`.

This PR is to fix this and run Beam integration tests in presubmit and nightly.