### PR TITLE
chore: port cached channel pool to veneer backend

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BigtableVeneerApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BigtableVeneerApi.java
@@ -26,14 +26,20 @@ import java.io.IOException;
 /** For internal use only - public for technical reasons. */
 @InternalApi("For internal usage only")
 public class BigtableVeneerApi extends BigtableApi {
-
+  private static final SharedDataClientWrapperFactory sharedClientFactory =
+      new SharedDataClientWrapperFactory();
   private final DataClientWrapper dataClientWrapper;
   private final AdminClientWrapper adminClientWrapper;
 
   public BigtableVeneerApi(BigtableHBaseVeneerSettings settings) throws IOException {
     super(settings);
-    dataClientWrapper =
-        new DataClientVeneerApi(BigtableDataClient.create(settings.getDataSettings()));
+
+    if (settings.isChannelPoolCachingEnabled()) {
+      dataClientWrapper = sharedClientFactory.createDataClient(settings);
+    } else {
+      dataClientWrapper =
+          new DataClientVeneerApi(BigtableDataClient.create(settings.getDataSettings()));
+    }
     adminClientWrapper =
         new AdminClientVeneerApi(BigtableTableAdminClient.create(settings.getTableAdminSettings()));
   }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/SharedDataClentWrapper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/SharedDataClentWrapper.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers.veneer;
+
+import com.google.api.core.ApiFuture;
+import com.google.cloud.bigtable.data.v2.models.ConditionalRowMutation;
+import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
+import com.google.cloud.bigtable.data.v2.models.KeyOffset;
+import com.google.cloud.bigtable.data.v2.models.Query;
+import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
+import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import com.google.cloud.bigtable.hbase.wrappers.BulkMutationWrapper;
+import com.google.cloud.bigtable.hbase.wrappers.BulkReadWrapper;
+import com.google.cloud.bigtable.hbase.wrappers.DataClientWrapper;
+import com.google.cloud.bigtable.hbase.wrappers.veneer.SharedDataClientWrapperFactory.Key;
+import com.google.protobuf.ByteString;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+
+/** Simple wrapper around a {@link DataClientWrapper} that will release resources on close. */
+class SharedDataClentWrapper implements DataClientWrapper {
+  private final SharedDataClientWrapperFactory owner;
+  private final SharedDataClientWrapperFactory.Key key;
+  private final DataClientWrapper delegate;
+
+  public SharedDataClentWrapper(
+      SharedDataClientWrapperFactory owner, Key key, DataClientWrapper delegate) {
+    this.owner = owner;
+    this.key = key;
+    this.delegate = delegate;
+  }
+
+  @Override
+  public BulkMutationWrapper createBulkMutation(String tableId) {
+    return delegate.createBulkMutation(tableId);
+  }
+
+  @Override
+  public BulkReadWrapper createBulkRead(String tableId) {
+    return delegate.createBulkRead(tableId);
+  }
+
+  @Override
+  public ApiFuture<Void> mutateRowAsync(RowMutation rowMutation) {
+    return delegate.mutateRowAsync(rowMutation);
+  }
+
+  @Override
+  public ApiFuture<Result> readModifyWriteRowAsync(ReadModifyWriteRow readModifyWriteRow) {
+    return delegate.readModifyWriteRowAsync(readModifyWriteRow);
+  }
+
+  @Override
+  public ApiFuture<Boolean> checkAndMutateRowAsync(ConditionalRowMutation conditionalRowMutation) {
+    return delegate.checkAndMutateRowAsync(conditionalRowMutation);
+  }
+
+  @Override
+  public ApiFuture<List<KeyOffset>> sampleRowKeysAsync(String tableId) {
+    return delegate.sampleRowKeysAsync(tableId);
+  }
+
+  @Override
+  public ApiFuture<Result> readRowAsync(
+      String tableId, ByteString rowKey, @Nullable Filter filter) {
+    return delegate.readRowAsync(tableId, rowKey, filter);
+  }
+
+  @Override
+  public ResultScanner readRows(Query request) {
+    return delegate.readRows(request);
+  }
+
+  @Override
+  public ApiFuture<List<Result>> readRowsAsync(Query request) {
+    return delegate.readRowsAsync(request);
+  }
+
+  @Override
+  public void readRowsAsync(Query request, StreamObserver<Result> observer) {
+    delegate.readRowsAsync(request, observer);
+  }
+
+  @Override
+  public void close() throws IOException {
+    delegate.close();
+    owner.release(key);
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/SharedDataClientWrapper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/SharedDataClientWrapper.java
@@ -35,12 +35,12 @@ import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 
 /** Simple wrapper around a {@link DataClientWrapper} that will release resources on close. */
-class SharedDataClentWrapper implements DataClientWrapper {
+class SharedDataClientWrapper implements DataClientWrapper {
   private final SharedDataClientWrapperFactory owner;
   private final SharedDataClientWrapperFactory.Key key;
   private final DataClientWrapper delegate;
 
-  public SharedDataClentWrapper(
+  public SharedDataClientWrapper(
       SharedDataClientWrapperFactory owner, Key key, DataClientWrapper delegate) {
     this.owner = owner;
     this.key = key;

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/SharedDataClientWrapperFactory.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/SharedDataClientWrapperFactory.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers.veneer;
+
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.gax.core.FixedExecutorProvider;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.FixedHeaderProvider;
+import com.google.api.gax.rpc.FixedTransportChannelProvider;
+import com.google.api.gax.rpc.FixedWatchdogProvider;
+import com.google.cloud.bigtable.data.v2.BigtableDataClient;
+import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
+import com.google.cloud.bigtable.data.v2.BigtableDataSettings.Builder;
+import com.google.cloud.bigtable.data.v2.stub.EnhancedBigtableStubSettings;
+import com.google.cloud.bigtable.hbase.wrappers.DataClientWrapper;
+import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Manages shared resources between multiple clients.
+ *
+ * <p>This class is meant to support channel pool caching feature.
+ */
+class SharedDataClientWrapperFactory {
+  private final Map<Key, ClientContext> cachedContexts = new HashMap<>();
+  private final Map<Key, Integer> refCounts = new HashMap<>();
+
+  synchronized DataClientWrapper createDataClient(BigtableHBaseVeneerSettings settings)
+      throws IOException {
+    Preconditions.checkArgument(
+        !settings.getDataSettings().isRefreshingChannel(),
+        "Channel refreshing is not compatible with cached channel pools");
+
+    Key key = Key.createFromSettings(settings.getDataSettings());
+
+    // Get or create ClientContext that will contained the shared resources
+    ClientContext sharedCtx = cachedContexts.get(key);
+    if (sharedCtx == null) {
+      sharedCtx = ClientContext.create(settings.getDataSettings().getStubSettings());
+      cachedContexts.put(key, sharedCtx);
+      refCounts.put(key, 0);
+    }
+    // Increment the count
+    refCounts.put(key, refCounts.get(key) + 1);
+
+    try {
+      // Patch settings to use shared resources
+      Builder builder = settings.getDataSettings().toBuilder();
+      builder
+          .stubSettings()
+          .setTransportChannelProvider(
+              FixedTransportChannelProvider.create(sharedCtx.getTransportChannel()))
+          .setCredentialsProvider(FixedCredentialsProvider.create(sharedCtx.getCredentials()))
+          .setExecutorProvider(FixedExecutorProvider.create(sharedCtx.getExecutor()))
+          .setStreamWatchdogProvider(FixedWatchdogProvider.create(sharedCtx.getStreamWatchdog()))
+          .setHeaderProvider(FixedHeaderProvider.create(sharedCtx.getHeaders()))
+          .setClock(sharedCtx.getClock());
+
+      // Create a reference counted client wrapper
+      return new SharedDataClentWrapper(
+          this, key, new DataClientVeneerApi(BigtableDataClient.create(builder.build())));
+    } catch (IOException | RuntimeException e) {
+      release(key);
+      throw e;
+    }
+  }
+
+  synchronized void release(Key key) {
+    int refCount = refCounts.get(key);
+    if (--refCount > 0) {
+      refCounts.put(key, refCount);
+      return;
+    }
+
+    refCounts.remove(key);
+    ClientContext clientContext = cachedContexts.remove(key);
+    for (BackgroundResource resource : clientContext.getBackgroundResources()) {
+      resource.shutdown();
+    }
+  }
+
+  /**
+   * Identity for a shared {@link ClientContext}.
+   *
+   * <p>This value class contains primary identifying information for a ClientContext. It can be
+   * extracted from {@link BigtableDataSettings} and be used to check if a ClientContext would be
+   * compatible with a ClientContext required by {@link BigtableDataSettings}.
+   */
+  static final class Key {
+    private final String endpoint;
+    private final Map<String, String> headers;
+    private final CredentialsProvider credentialsProvider;
+
+    static Key createFromSettings(BigtableDataSettings settings) {
+      EnhancedBigtableStubSettings stubSettings = settings.getStubSettings();
+
+      return new Key(
+          stubSettings.getEndpoint(),
+          stubSettings.getHeaderProvider().getHeaders(),
+          stubSettings.getCredentialsProvider());
+    }
+
+    private Key(
+        String endpoint, Map<String, String> headers, CredentialsProvider credentialsProvider) {
+      this.endpoint = endpoint;
+      this.headers = headers;
+      this.credentialsProvider = credentialsProvider;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Key key = (Key) o;
+      return Objects.equal(endpoint, key.endpoint)
+          && Objects.equal(headers, key.headers)
+          && Objects.equal(credentialsProvider, key.credentialsProvider);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(endpoint, headers, credentialsProvider);
+    }
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/SharedDataClientWrapperFactory.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/SharedDataClientWrapperFactory.java
@@ -75,7 +75,7 @@ class SharedDataClientWrapperFactory {
           .setClock(sharedCtx.getClock());
 
       // Create a reference counted client wrapper
-      return new SharedDataClentWrapper(
+      return new SharedDataClientWrapper(
           this, key, new DataClientVeneerApi(BigtableDataClient.create(builder.build())));
     } catch (IOException | RuntimeException e) {
       release(key);

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/SharedDataClientWrapperFactoryTest.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/SharedDataClientWrapperFactoryTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.cloud.bigtable.hbase.wrappers.veneer;
 
 import com.google.bigtable.v2.BigtableGrpc;

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/SharedDataClientWrapperFactoryTest.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/SharedDataClientWrapperFactoryTest.java
@@ -1,0 +1,142 @@
+package com.google.cloud.bigtable.hbase.wrappers.veneer;
+
+import com.google.bigtable.v2.BigtableGrpc;
+import com.google.bigtable.v2.MutateRowRequest;
+import com.google.bigtable.v2.MutateRowResponse;
+import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
+import com.google.cloud.bigtable.hbase.wrappers.DataClientWrapper;
+import io.grpc.Grpc;
+import io.grpc.Metadata;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+// TODO: consider turning this into an emulator test that targets the HBase api instead
+// of SharedDataClientWrapperFactory. The pre-req would be to have a collection of tests
+// for hbase 1x & hbase2x that hermetic. Currently the only HBase level tests we have,
+// target the actual emulator, minicluster or prod.
+/**
+ * Test CACHED_DATA_CHANNEL_POOL feature by targeting an in process bigtable impl and counting the
+ * unique client ip/port combinations.
+ */
+@RunWith(JUnit4.class)
+public class SharedDataClientWrapperFactoryTest {
+  private Server server;
+  private int port;
+  private List<SocketAddress> remoteCallers;
+
+  @Before
+  public void setUp() throws IOException {
+    try (ServerSocket ss = new ServerSocket(0)) {
+      port = ss.getLocalPort();
+    }
+
+    remoteCallers = Collections.synchronizedList(new ArrayList<SocketAddress>());
+
+    server =
+        ServerBuilder.forPort(port)
+            .intercept(new RemoteCallerInterceptor(remoteCallers))
+            .addService(new FakeBigtable())
+            .build();
+    server.start();
+  }
+
+  @After
+  public void tearDown() {
+    server.shutdown();
+  }
+
+  @Test
+  public void testChannelsAreShared() throws Exception {
+    int channelCount = 2;
+    Configuration configuration = new Configuration(false);
+    configuration.set(BigtableOptionsFactory.PROJECT_ID_KEY, "my-project");
+    configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, "my-instance");
+    // primary paramters being tested
+    configuration.setInt(BigtableOptionsFactory.BIGTABLE_DATA_CHANNEL_COUNT_KEY, channelCount);
+    configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_USE_CACHED_DATA_CHANNEL_POOL, true);
+
+    // Manually expand BIGTABLE_EMULATOR_HOST_KEY so that the channel settings are known
+    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, "localhost");
+    configuration.setInt(BigtableOptionsFactory.BIGTABLE_PORT_KEY, port);
+    configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, true);
+    configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_USE_PLAINTEXT_NEGOTIATION, true);
+
+    // Build the settings
+    BigtableHBaseVeneerSettings settings = BigtableHBaseVeneerSettings.create(configuration);
+
+    // Create a bunch of clients and make multiple calls
+    SharedDataClientWrapperFactory factory = new SharedDataClientWrapperFactory();
+    List<DataClientWrapper> clients = new ArrayList<>();
+
+    for (int i = 0; i < channelCount * 5; i++) {
+      for (int j = 0; j < channelCount * 5; j++) {
+        DataClientWrapper dataClient = factory.createDataClient(settings);
+        clients.add(dataClient);
+        dataClient.mutateRowAsync(RowMutation.create("fake-table", "fake-key").deleteRow()).get();
+      }
+    }
+
+    // cleanup
+    for (DataClientWrapper client : clients) {
+      client.close();
+    }
+
+    // Despite having multiple client instances, there should only be `channelCount` remoteCallers
+    Set<SocketAddress> uniqueRemoteCallers = new HashSet<>(remoteCallers);
+    Assert.assertEquals(channelCount, uniqueRemoteCallers.size());
+  }
+
+  /**
+   * Interceptor that will collect remote addresses of the callers.
+   *
+   * <p>The collection given to this interceptor must be threadsafe
+   */
+  private static class RemoteCallerInterceptor implements ServerInterceptor {
+    private final Collection<SocketAddress> remoteAddrs;
+
+    RemoteCallerInterceptor(Collection<SocketAddress> remoteAddrs) {
+      this.remoteAddrs = remoteAddrs;
+    }
+
+    @Override
+    public <ReqT, RespT> Listener<ReqT> interceptCall(
+        ServerCall<ReqT, RespT> serverCall,
+        Metadata metadata,
+        ServerCallHandler<ReqT, RespT> serverCallHandler) {
+      remoteAddrs.add(serverCall.getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR));
+      return serverCallHandler.startCall(serverCall, metadata);
+    }
+  }
+
+  /** Minimal implementation of Bigtable service that will retur OK for any mutation */
+  private static class FakeBigtable extends BigtableGrpc.BigtableImplBase {
+    @Override
+    public void mutateRow(
+        MutateRowRequest request, StreamObserver<MutateRowResponse> responseObserver) {
+      responseObserver.onNext(MutateRowResponse.getDefaultInstance());
+      responseObserver.onCompleted();
+    }
+  }
+}


### PR DESCRIPTION
This is an existing feature in bigtable-client-core that needed to be re-implemented for the transition to java-bigtable
