### PR TITLE
chore: prepare for major version bump

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <groupId>com.google.cloud.bigtable</groupId>
     <artifactId>bigtable-client-core-parent</artifactId>
-    <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-core-parent:current} -->
+    <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-core-parent:current} -->
   </parent>
 
   <artifactId>bigtable-client-core</artifactId>
@@ -194,7 +194,7 @@ limitations under the License.
     <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
       <artifactId>bigtable-metrics-api</artifactId>
-      <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-core-parent:current} -->
+      <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-core-parent:current} -->
     </dependency>
 
     <dependency>

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/pom.xml
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/pom.xml
@@ -19,7 +19,7 @@ limitations under the License.
   <parent>
     <groupId>com.google.cloud.bigtable</groupId>
     <artifactId>bigtable-client-core-parent</artifactId>
-    <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-core-parent:current} -->
+    <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-core-parent:current} -->
   </parent>
 
   <artifactId>bigtable-hbase-integration-tests-common</artifactId>

--- a/bigtable-client-core-parent/bigtable-hbase/pom.xml
+++ b/bigtable-client-core-parent/bigtable-hbase/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <groupId>com.google.cloud.bigtable</groupId>
     <artifactId>bigtable-client-core-parent</artifactId>
-    <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-core-parent:current} -->
+    <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-core-parent:current} -->
   </parent>
 
   <artifactId>bigtable-hbase</artifactId>
@@ -219,7 +219,7 @@ limitations under the License.
       <plugin>
         <groupId>com.google.cloud.bigtable.test</groupId>
         <artifactId>bigtable-build-helper</artifactId>
-        <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
+        <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
 
         <executions>
           <!-- TODO: Remove this once we can properly shade conscrypt:

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableHBaseVersion.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableHBaseVersion.java
@@ -30,18 +30,19 @@ public class TestBigtableHBaseVersion {
   @Test
   public void testVersionNumber() {
     // Version must have 3 parts i.e. x.y.z and can have an optional of -SNAPSHOT suffixed.
-    Pattern versionPattern = Pattern.compile("^(\\d+)\\.(\\d+)\\.(\\d+)(-\\w+)?");
+    Pattern versionPattern = Pattern.compile("^(\\d+)\\.(\\d+)\\.(\\d+)([-\\w]+)?");
     Matcher versionMatcher = versionPattern.matcher(BigtableHBaseVersion.getVersion());
 
     assertTrue("incorrect version format", versionMatcher.matches());
 
     int result =
         ComparisonChain.start()
-            .compare(1, Integer.parseInt(versionMatcher.group(1)))
-            .compare(14, Integer.parseInt(versionMatcher.group(2)))
-            .compare(1, Integer.parseInt(versionMatcher.group(3)))
+            .compare(2, Integer.parseInt(versionMatcher.group(1)))
+            .compare(0, Integer.parseInt(versionMatcher.group(2)))
+            .compare(0, Integer.parseInt(versionMatcher.group(3)))
             .result();
 
-    assertTrue("Expected BigtableHBaseVersion.getVersion() to be at least 1.14.1", result <= 0);
+    assertTrue(
+        "Expected BigtableHBaseVersion.getVersion() to be at least 2.0.0-alpha-1", result <= 0);
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableHBaseVersion.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableHBaseVersion.java
@@ -30,8 +30,9 @@ public class TestBigtableHBaseVersion {
   @Test
   public void testVersionNumber() {
     // Version must have 3 parts i.e. x.y.z and can have an optional of -SNAPSHOT suffixed.
-    Pattern versionPattern = Pattern.compile("^(\\d+)\\.(\\d+)\\.(\\d+)([-\\w]+)?");
-    Matcher versionMatcher = versionPattern.matcher(BigtableHBaseVersion.getVersion());
+    String version = BigtableHBaseVersion.getVersion();
+    Pattern versionPattern = Pattern.compile("^(\\d+)\\.(\\d+)\\.(\\d+)([-\\w]+)?$");
+    Matcher versionMatcher = versionPattern.matcher(version);
 
     assertTrue("incorrect version format", versionMatcher.matches());
 
@@ -44,5 +45,10 @@ public class TestBigtableHBaseVersion {
 
     assertTrue(
         "Expected BigtableHBaseVersion.getVersion() to be at least 2.0.0-alpha-1", result <= 0);
+
+    // Ensure that the suffix is either empty, starts with alpha/beta and/or ends with SNAPSHOT
+    String suffix = versionMatcher.group(4);
+    Pattern suffixPattern = Pattern.compile("^(?:-(?:alpha|beta)-\\d+)?(?:-SNAPSHOT)?$");
+    assertTrue("unexpected suffix format", suffixPattern.matcher(suffix).matches());
   }
 }

--- a/bigtable-client-core-parent/bigtable-metrics-api/pom.xml
+++ b/bigtable-client-core-parent/bigtable-metrics-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.cloud.bigtable</groupId>
     <artifactId>bigtable-client-core-parent</artifactId>
-    <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-core-parent:current} -->
+    <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-core-parent:current} -->
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bigtable-client-core-parent/pom.xml
+++ b/bigtable-client-core-parent/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <groupId>com.google.cloud.bigtable</groupId>
     <artifactId>bigtable-client-parent</artifactId>
-    <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-parent:current} -->
+    <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-parent:current} -->
   </parent>
 
   <artifactId>bigtable-client-core-parent</artifactId>

--- a/bigtable-dataflow-parent/bigtable-beam-import/README.md
+++ b/bigtable-dataflow-parent/bigtable-beam-import/README.md
@@ -5,7 +5,7 @@ Cloud Dataflow.
 
 ## Instructions
 [//]: # ({x-version-update-start:bigtable-dataflow-parent:released})
-Download [the import/export jar](http://search.maven.org/remotecontent?filepath=com/google/cloud/bigtable/bigtable-beam-import/1.14.1/bigtable-beam-import-1.14.1-shaded.jar), which is an aggregation of all required jars.
+Download [the import/export jar](http://search.maven.org/remotecontent?filepath=com/google/cloud/bigtable/bigtable-beam-import/2.0.0-alpha-1/bigtable-beam-import-2.0.0-alpha-1-shaded.jar), which is an aggregation of all required jars.
 
 Please pay attention to the Cluster CPU usage and adjust the number of Dataflow workers accordingly.
 
@@ -14,7 +14,7 @@ Please pay attention to the Cluster CPU usage and adjust the number of Dataflow 
 On the command line:
 
 ```
-java -jar bigtable-beam-import-1.14.1-shaded.jar export \
+java -jar bigtable-beam-import-2.0.0-alpha-1-shaded.jar export \
     --runner=dataflow \
     --project=[your_project_id] \
     --bigtableInstanceId=[your_instance_id] \
@@ -31,7 +31,7 @@ Create the table in your cluster.
 On the command line:
 
 ```
-java -jar bigtable-beam-import-1.14.1-shaded.jar import \
+java -jar bigtable-beam-import-2.0.0-alpha-1-shaded.jar import \
     --runner=dataflow \
     --project=[your_project_id] \
     --bigtableInstanceId=[your_instance_id] \

--- a/bigtable-dataflow-parent/bigtable-beam-import/README.md
+++ b/bigtable-dataflow-parent/bigtable-beam-import/README.md
@@ -5,7 +5,7 @@ Cloud Dataflow.
 
 ## Instructions
 [//]: # ({x-version-update-start:bigtable-dataflow-parent:released})
-Download [the import/export jar](http://search.maven.org/remotecontent?filepath=com/google/cloud/bigtable/bigtable-beam-import/2.0.0-alpha-1/bigtable-beam-import-2.0.0-alpha-1-shaded.jar), which is an aggregation of all required jars.
+Download [the import/export jar](http://search.maven.org/remotecontent?filepath=com/google/cloud/bigtable/bigtable-beam-import/1.14.1/bigtable-beam-import-1.14.1-shaded.jar), which is an aggregation of all required jars.
 
 Please pay attention to the Cluster CPU usage and adjust the number of Dataflow workers accordingly.
 
@@ -14,7 +14,7 @@ Please pay attention to the Cluster CPU usage and adjust the number of Dataflow 
 On the command line:
 
 ```
-java -jar bigtable-beam-import-2.0.0-alpha-1-shaded.jar export \
+java -jar bigtable-beam-import-1.14.1-shaded.jar export \
     --runner=dataflow \
     --project=[your_project_id] \
     --bigtableInstanceId=[your_instance_id] \
@@ -31,7 +31,7 @@ Create the table in your cluster.
 On the command line:
 
 ```
-java -jar bigtable-beam-import-2.0.0-alpha-1-shaded.jar import \
+java -jar bigtable-beam-import-1.14.1-shaded.jar import \
     --runner=dataflow \
     --project=[your_project_id] \
     --bigtableInstanceId=[your_instance_id] \

--- a/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
@@ -18,7 +18,7 @@ limitations under the License.
   <parent>
     <groupId>com.google.cloud.bigtable</groupId>
     <artifactId>bigtable-dataflow-parent</artifactId>
-    <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-dataflow-parent:current} -->
+    <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-dataflow-parent:current} -->
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -382,7 +382,7 @@ limitations under the License.
       <plugin>
         <groupId>com.google.cloud.bigtable.test</groupId>
         <artifactId>bigtable-build-helper</artifactId>
-        <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
+        <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
         <executions>
           <execution>
             <id>verify-mirror-deps</id>

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/pom.xml
@@ -16,7 +16,7 @@ limitations under the License.
   <parent>
     <groupId>com.google.cloud.bigtable</groupId>
     <artifactId>bigtable-dataflow-parent</artifactId>
-    <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-dataflow-parent:current} -->
+    <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-dataflow-parent:current} -->
   </parent>
 
   <artifactId>bigtable-hbase-beam</artifactId>
@@ -270,7 +270,7 @@ limitations under the License.
       <plugin>
         <groupId>com.google.cloud.bigtable.test</groupId>
         <artifactId>bigtable-build-helper</artifactId>
-        <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
+        <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
         <executions>
           <execution>
             <id>verify-mirror-deps</id>

--- a/bigtable-dataflow-parent/pom.xml
+++ b/bigtable-dataflow-parent/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <groupId>com.google.cloud.bigtable</groupId>
     <artifactId>bigtable-client-parent</artifactId>
-    <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-parent:current} -->
+    <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-parent:current} -->
   </parent>
 
   <artifactId>bigtable-dataflow-parent</artifactId>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-benchmarks/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-benchmarks/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.google.cloud.bigtable</groupId>
     <artifactId>bigtable-hbase-1.x-parent</artifactId>
-    <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-1x-parent:current} -->
+    <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-1x-parent:current} -->
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
@@ -18,7 +18,7 @@ limitations under the License.
   <parent>
     <artifactId>bigtable-hbase-1.x-parent</artifactId>
     <groupId>com.google.cloud.bigtable</groupId>
-    <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-1x-parent:current} -->
+    <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-1x-parent:current} -->
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -198,7 +198,7 @@ limitations under the License.
       <plugin>
         <groupId>com.google.cloud.bigtable.test</groupId>
         <artifactId>bigtable-build-helper</artifactId>
-        <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
+        <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
 
         <executions>
           <execution>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <groupId>com.google.cloud.bigtable</groupId>
     <artifactId>bigtable-hbase-1.x-parent</artifactId>
-    <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-1x-parent:current} -->
+    <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-1x-parent:current} -->
   </parent>
 
   <artifactId>bigtable-hbase-1.x-integration-tests</artifactId>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <groupId>com.google.cloud.bigtable</groupId>
     <artifactId>bigtable-hbase-1.x-parent</artifactId>
-    <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-1x-parent:current} -->
+    <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-1x-parent:current} -->
   </parent>
 
   <artifactId>bigtable-hbase-1.x-mapreduce</artifactId>
@@ -193,7 +193,7 @@ limitations under the License.
       <plugin>
         <groupId>com.google.cloud.bigtable.test</groupId>
         <artifactId>bigtable-build-helper</artifactId>
-        <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
+        <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
         <executions>
           <execution>
             <id>verify-mirror-deps</id>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -18,7 +18,7 @@ limitations under the License.
   <parent>
     <artifactId>bigtable-hbase-1.x-parent</artifactId>
     <groupId>com.google.cloud.bigtable</groupId>
-    <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-1x-parent:current} -->
+    <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-1x-parent:current} -->
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -339,7 +339,7 @@ limitations under the License.
       <plugin>
         <groupId>com.google.cloud.bigtable.test</groupId>
         <artifactId>bigtable-build-helper</artifactId>
-        <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
+        <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
 
         <executions>
           <execution>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <groupId>com.google.cloud.bigtable</groupId>
     <artifactId>bigtable-hbase-1.x-parent</artifactId>
-    <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-1x-parent:current} -->
+    <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-1x-parent:current} -->
   </parent>
 
   <artifactId>bigtable-hbase-1.x</artifactId>

--- a/bigtable-hbase-1.x-parent/pom.xml
+++ b/bigtable-hbase-1.x-parent/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <groupId>com.google.cloud.bigtable</groupId>
     <artifactId>bigtable-client-parent</artifactId>
-    <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-parent:current} -->
+    <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-parent:current} -->
   </parent>
 
   <artifactId>bigtable-hbase-1.x-parent</artifactId>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
@@ -18,7 +18,7 @@ limitations under the License.
   <parent>
     <artifactId>bigtable-hbase-2.x-parent</artifactId>
     <groupId>com.google.cloud.bigtable</groupId>
-    <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-2x-parent:current} -->
+    <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-2x-parent:current} -->
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -215,7 +215,7 @@ limitations under the License.
       <plugin>
         <groupId>com.google.cloud.bigtable.test</groupId>
         <artifactId>bigtable-build-helper</artifactId>
-        <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
+        <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
 
         <executions>
           <execution>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <groupId>com.google.cloud.bigtable</groupId>
     <artifactId>bigtable-hbase-2.x-parent</artifactId>
-    <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-2x-parent:current} -->
+    <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-2x-parent:current} -->
   </parent>
 
   <artifactId>bigtable-hbase-2.x-integration-tests</artifactId>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
@@ -18,7 +18,7 @@ limitations under the License.
   <parent>
     <artifactId>bigtable-hbase-2.x-parent</artifactId>
     <groupId>com.google.cloud.bigtable</groupId>
-    <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-2x-parent:current} -->
+    <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-2x-parent:current} -->
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -342,7 +342,7 @@ limitations under the License.
       <plugin>
         <groupId>com.google.cloud.bigtable.test</groupId>
         <artifactId>bigtable-build-helper</artifactId>
-        <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
+        <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
 
         <executions>
           <execution>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <groupId>com.google.cloud.bigtable</groupId>
     <artifactId>bigtable-hbase-2.x-parent</artifactId>
-    <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-2x-parent:current} -->
+    <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-2x-parent:current} -->
   </parent>
 
   <properties>

--- a/bigtable-hbase-2.x-parent/pom.xml
+++ b/bigtable-hbase-2.x-parent/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <groupId>com.google.cloud.bigtable</groupId>
     <artifactId>bigtable-client-parent</artifactId>
-    <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-parent:current} -->
+    <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-parent:current} -->
   </parent>
 
   <artifactId>bigtable-hbase-2.x-parent</artifactId>

--- a/bigtable-test/bigtable-build-helper/pom.xml
+++ b/bigtable-test/bigtable-build-helper/pom.xml
@@ -5,13 +5,13 @@
   <parent>
     <artifactId>bigtable-test</artifactId>
     <groupId>com.google.cloud.bigtable</groupId>
-    <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
+    <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.google.cloud.bigtable.test</groupId>
   <artifactId>bigtable-build-helper</artifactId>
-  <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
+  <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
   <packaging>maven-plugin</packaging>
   <description>
     java-bigtable-hbase internal maven extensions.

--- a/bigtable-test/bigtable-build-helper/src/it/verify-mirror-deps-misaligned/pom.xml
+++ b/bigtable-test/bigtable-build-helper/src/it/verify-mirror-deps-misaligned/pom.xml
@@ -35,7 +35,7 @@ limitations under the License.
       <plugin>
         <groupId>com.google.cloud.bigtable.test</groupId>
         <artifactId>bigtable-build-helper</artifactId>
-        <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
+        <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
         <executions>
           <execution>
             <id>test</id>

--- a/bigtable-test/bigtable-build-helper/src/it/verify-mirror-deps-ok/pom.xml
+++ b/bigtable-test/bigtable-build-helper/src/it/verify-mirror-deps-ok/pom.xml
@@ -35,7 +35,7 @@ limitations under the License.
       <plugin>
         <groupId>com.google.cloud.bigtable.test</groupId>
         <artifactId>bigtable-build-helper</artifactId>
-        <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
+        <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
         <executions>
           <execution>
             <id>test</id>

--- a/bigtable-test/bigtable-build-helper/src/it/verify-shaded-exclusions-ok/pom.xml
+++ b/bigtable-test/bigtable-build-helper/src/it/verify-shaded-exclusions-ok/pom.xml
@@ -60,7 +60,7 @@ limitations under the License.
       <plugin>
         <groupId>com.google.cloud.bigtable.test</groupId>
         <artifactId>bigtable-build-helper</artifactId>
-        <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
+        <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
         <executions>
           <execution>
             <id>test</id>

--- a/bigtable-test/bigtable-build-helper/src/it/verify-shaded-exclusions-unpromoted/pom.xml
+++ b/bigtable-test/bigtable-build-helper/src/it/verify-shaded-exclusions-unpromoted/pom.xml
@@ -65,7 +65,7 @@ limitations under the License.
       <plugin>
         <groupId>com.google.cloud.bigtable.test</groupId>
         <artifactId>bigtable-build-helper</artifactId>
-        <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
+        <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
         <executions>
           <execution>
             <id>test</id>

--- a/bigtable-test/bigtable-build-helper/src/it/verify-shaded-jar-entries-leak/pom.xml
+++ b/bigtable-test/bigtable-build-helper/src/it/verify-shaded-jar-entries-leak/pom.xml
@@ -61,7 +61,7 @@ limitations under the License.
       <plugin>
         <groupId>com.google.cloud.bigtable.test</groupId>
         <artifactId>bigtable-build-helper</artifactId>
-        <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
+        <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
         <executions>
           <execution>
             <id>test</id>

--- a/bigtable-test/bigtable-build-helper/src/it/verify-shaded-jar-entries-ok/pom.xml
+++ b/bigtable-test/bigtable-build-helper/src/it/verify-shaded-jar-entries-ok/pom.xml
@@ -81,7 +81,7 @@ limitations under the License.
       <plugin>
         <groupId>com.google.cloud.bigtable.test</groupId>
         <artifactId>bigtable-build-helper</artifactId>
-        <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
+        <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
         <executions>
           <execution>
             <id>test</id>

--- a/bigtable-test/bigtable-emulator-maven-plugin/pom.xml
+++ b/bigtable-test/bigtable-emulator-maven-plugin/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <groupId>com.google.cloud.bigtable</groupId>
     <artifactId>bigtable-test</artifactId>
-    <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
+    <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-test:current} -->
   </parent>
 
 

--- a/bigtable-test/pom.xml
+++ b/bigtable-test/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <groupId>com.google.cloud.bigtable</groupId>
     <artifactId>bigtable-client-parent</artifactId>
-    <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-parent:current} -->
+    <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-parent:current} -->
   </parent>
 
   <artifactId>bigtable-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@ limitations under the License.
 
   <groupId>com.google.cloud.bigtable</groupId>
   <artifactId>bigtable-client-parent</artifactId>
-  <version>1.14.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-parent:current} -->
+  <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-parent:current} -->
   <packaging>pom</packaging>
   <name>${project.groupId}:${project.artifactId}</name>
   <url>https://cloud.google.com/bigtable/</url>

--- a/versions.txt
+++ b/versions.txt
@@ -1,9 +1,9 @@
 # Format:
 # module:released-version:current-version
 
-bigtable-client-parent:1.14.0:1.14.1-SNAPSHOT
-bigtable-client-core-parent:1.14.0:1.14.1-SNAPSHOT
-bigtable-hbase-1x-parent:1.14.0:1.14.1-SNAPSHOT
-bigtable-hbase-2x-parent:1.14.0:1.14.1-SNAPSHOT
-bigtable-dataflow-parent:1.14.0:1.14.1-SNAPSHOT
-bigtable-test:1.14.0:1.14.1-SNAPSHOT
+bigtable-client-parent:1.14.0:2.0.0-alpha-1-SNAPSHOT
+bigtable-client-core-parent:1.14.0:2.0.0-alpha-1-SNAPSHOT
+bigtable-hbase-1x-parent:1.14.0:2.0.0-alpha-1-SNAPSHOT
+bigtable-hbase-2x-parent:1.14.0:2.0.0-alpha-1-SNAPSHOT
+bigtable-dataflow-parent:1.14.0:2.0.0-alpha-1-SNAPSHOT
+bigtable-test:1.14.0:2.0.0-alpha-1-SNAPSHOT


### PR DESCRIPTION
This updates all next versions to be 2.0.0-alpha-1
