### PR TITLE
fix: bigtable-hbase-tools version

### DIFF
--- a/bigtable-hbase-1.x-parent/bigtable-hbase-tools/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-tools/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>bigtable-hbase-1.x-parent</artifactId>
     <groupId>com.google.cloud.bigtable</groupId>
-    <version>1.14.1-SNAPSHOT</version>
+    <version>2.0.0-alpha-1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-1x-parent:current} -->
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
It got out of sync when https://github.com/googleapis/java-bigtable-hbase/pull/2919 was merged
