### PR TITLE
fix: multithreaded batch operations

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationGCJClient.java
@@ -47,13 +47,13 @@ public class BulkMutationGCJClient implements IBulkMutation {
 
   /** {@inheritDoc} */
   @Override
-  public void sendUnsent() {
+  public synchronized void sendUnsent() {
     bulkMutateBatcher.sendOutstanding();
   }
 
   /** {@inheritDoc} */
   @Override
-  public void flush() {
+  public synchronized void flush() {
     try {
       bulkMutateBatcher.flush();
     } catch (InterruptedException ex) {
@@ -62,7 +62,7 @@ public class BulkMutationGCJClient implements IBulkMutation {
   }
 
   @Override
-  public void close() throws IOException {
+  public synchronized void close() throws IOException {
     try {
       bulkMutateBatcher.close();
     } catch (InterruptedException e) {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkRead.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkRead.java
@@ -130,7 +130,7 @@ public class BulkRead {
    * Sends all remaining requests to the server. This method does not wait for the method to
    * complete.
    */
-  public void flush() {
+  public synchronized void flush() {
     for (Batch batch : batches.values()) {
       Collection<Batch> subbatches = batch.split();
       for (Batch miniBatch : subbatches) {


### PR DESCRIPTION
Fix thread safety issues with batch operations on BigtableTable
