### PR TITLE
chore: reset veneer executor to be gRPC default instead of gax

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BigtableHBaseVeneerSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BigtableHBaseVeneerSettings.java
@@ -434,7 +434,7 @@ public class BigtableHBaseVeneerSettings extends BigtableHBaseSettings {
     }
 
     // TODO: remove this once https://github.com/googleapis/gax-java/pull/1355 is resolved
-    // Workaround performance issues due default executor in gax
+    // Workaround performance issues due to the default executor in gax
     {
       final ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder> prevConfigurator =
           channelProvider.getChannelConfigurator();

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BigtableHBaseVeneerSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BigtableHBaseVeneerSettings.java
@@ -405,7 +405,7 @@ public class BigtableHBaseVeneerSettings extends BigtableHBaseSettings {
       LOG.debug("%s is configured at %s", endpointKey, endpointOverride);
     }
 
-    InstantiatingGrpcChannelProvider.Builder channelProvider =
+    final InstantiatingGrpcChannelProvider.Builder channelProvider =
         ((InstantiatingGrpcChannelProvider) stubSettings.getTransportChannelProvider()).toBuilder();
 
     if (configuration.getBoolean(BIGTABLE_USE_PLAINTEXT_NEGOTIATION, false)) {
@@ -432,6 +432,25 @@ public class BigtableHBaseVeneerSettings extends BigtableHBaseSettings {
         channelProvider.setPoolSize(Integer.parseInt(channelCount));
       }
     }
+
+    // TODO: remove this once https://github.com/googleapis/gax-java/pull/1355 is resolved
+    // Workaround performance issues due default executor in gax
+    {
+      final ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder> prevConfigurator =
+          channelProvider.getChannelConfigurator();
+
+      channelProvider.setChannelConfigurator(
+          new ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder>() {
+            @Override
+            public ManagedChannelBuilder apply(ManagedChannelBuilder channelBuilder) {
+              if (prevConfigurator != null) {
+                channelBuilder = prevConfigurator.apply(channelBuilder);
+              }
+              return channelBuilder.executor(null);
+            }
+          });
+    }
+
     stubSettings.setTransportChannelProvider(channelProvider.build());
   }
 


### PR DESCRIPTION
This aligns veneer impl to use the same executor as bigtable-client-core
