### PR TITLE
build: have release-please app create GitHub release

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,6 +1,8 @@
 releaseType: java-yoshi
 bumpMinorPreMajor: true
+handleGHRelease: true
 branches:
   - branch: bigtable-1.x
     releaseType: java-yoshi
     bumpMinorPreMajor: true
+    handleGHRelease: true


### PR DESCRIPTION
We are migrating release tagging to the GitHub app. A template update would have updated this, but it's ignored in synth.py.