### PR TITLE
feat: improve handling when crossing async and sync boundaries

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
@@ -16,7 +16,6 @@
 package com.google.cloud.bigtable.hbase;
 
 import com.google.api.core.InternalApi;
-import com.google.api.gax.rpc.ApiExceptions;
 import com.google.cloud.bigtable.data.v2.models.ConditionalRowMutation;
 import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
@@ -26,6 +25,7 @@ import com.google.cloud.bigtable.hbase.adapters.CheckAndMutateUtil;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.cloud.bigtable.hbase.adapters.read.GetAdapter;
 import com.google.cloud.bigtable.hbase.util.ByteStringer;
+import com.google.cloud.bigtable.hbase.util.FutureUtil;
 import com.google.cloud.bigtable.hbase.util.Logger;
 import com.google.cloud.bigtable.hbase.wrappers.BigtableApi;
 import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
@@ -162,10 +162,14 @@ public abstract class AbstractBigtableTable implements Table {
       Filters.Filter filter =
           Adapters.GET_ADAPTER.buildFilter(GetAdapter.setCheckExistenceOnly(get));
 
-      return !ApiExceptions.callAndTranslateApiException(
-              clientWrapper.readRowAsync(
-                  tableName.getNameAsString(), ByteStringer.wrap(get.getRow()), filter))
-          .isEmpty();
+      try {
+        return FutureUtil.unwrap(
+                clientWrapper.readRowAsync(
+                    tableName.getNameAsString(), ByteStringer.wrap(get.getRow()), filter))
+            .isEmpty();
+      } catch (Exception e) {
+        throw createRetriesExhaustedWithDetailsException(e, get);
+      }
     }
   }
 
@@ -266,9 +270,13 @@ public abstract class AbstractBigtableTable implements Table {
         Timer.Context ignored = metrics.getTimer.time()) {
 
       Filters.Filter filter = Adapters.GET_ADAPTER.buildFilter(get);
-      return ApiExceptions.callAndTranslateApiException(
-          clientWrapper.readRowAsync(
-              tableName.getNameAsString(), ByteStringer.wrap(get.getRow()), filter));
+      try {
+        return FutureUtil.unwrap(
+            clientWrapper.readRowAsync(
+                tableName.getNameAsString(), ByteStringer.wrap(get.getRow()), filter));
+      } catch (Exception e) {
+        throw createRetriesExhaustedWithDetailsException(e, get);
+      }
     }
   }
 
@@ -454,8 +462,7 @@ public abstract class AbstractBigtableTable implements Table {
       throws IOException {
     Span span = TRACER.spanBuilder("BigtableTable." + type).startSpan();
     try (Scope scope = TRACER.withSpan(span)) {
-      Boolean wasApplied =
-          ApiExceptions.callAndTranslateApiException(clientWrapper.checkAndMutateRowAsync(request));
+      Boolean wasApplied = FutureUtil.unwrap(clientWrapper.checkAndMutateRowAsync(request));
       return CheckAndMutateUtil.wasMutationApplied(request, wasApplied);
     } catch (Throwable t) {
       span.setStatus(Status.UNKNOWN);
@@ -469,7 +476,7 @@ public abstract class AbstractBigtableTable implements Table {
       throws IOException {
     Span span = TRACER.spanBuilder("BigtableTable." + type).startSpan();
     try (Scope scope = TRACER.withSpan(span)) {
-      ApiExceptions.callAndTranslateApiException(clientWrapper.mutateRowAsync(rowMutation));
+      FutureUtil.unwrap(clientWrapper.mutateRowAsync(rowMutation));
     } catch (Throwable t) {
       span.setStatus(Status.UNKNOWN);
       throw logAndCreateIOException(type, mutation.getRow(), t);
@@ -487,8 +494,7 @@ public abstract class AbstractBigtableTable implements Table {
     }
     Span span = TRACER.spanBuilder("BigtableTable.mutateRow").startSpan();
     try (Scope scope = TRACER.withSpan(span)) {
-      ApiExceptions.callAndTranslateApiException(
-          clientWrapper.mutateRowAsync(hbaseAdapter.adapt(rowMutations)));
+      FutureUtil.unwrap(clientWrapper.mutateRowAsync(hbaseAdapter.adapt(rowMutations)));
     } catch (Throwable t) {
       span.setStatus(Status.UNKNOWN);
       throw logAndCreateIOException("mutateRow", rowMutations.getRow(), t);
@@ -504,8 +510,7 @@ public abstract class AbstractBigtableTable implements Table {
     Span span = TRACER.spanBuilder("BigtableTable.append").startSpan();
     try (Scope scope = TRACER.withSpan(span)) {
       Result response =
-          ApiExceptions.callAndTranslateApiException(
-              clientWrapper.readModifyWriteRowAsync(hbaseAdapter.adapt(append)));
+          FutureUtil.unwrap(clientWrapper.readModifyWriteRowAsync(hbaseAdapter.adapt(append)));
       // The bigtable API will always return the mutated results. In order to maintain
       // compatibility, simply return null when results were not requested.
       if (append.isReturnResults()) {
@@ -528,8 +533,7 @@ public abstract class AbstractBigtableTable implements Table {
     Span span = TRACER.spanBuilder("BigtableTable.increment").startSpan();
     try (Scope scope = TRACER.withSpan(span)) {
       ReadModifyWriteRow request = hbaseAdapter.adapt(increment);
-      return ApiExceptions.callAndTranslateApiException(
-          clientWrapper.readModifyWriteRowAsync(request));
+      return FutureUtil.unwrap(clientWrapper.readModifyWriteRowAsync(request));
     } catch (Throwable t) {
       span.setStatus(Status.UNKNOWN);
       throw logAndCreateIOException("increment", increment.getRow(), t);

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
@@ -163,7 +163,7 @@ public abstract class AbstractBigtableTable implements Table {
           Adapters.GET_ADAPTER.buildFilter(GetAdapter.setCheckExistenceOnly(get));
 
       try {
-        return FutureUtil.unwrap(
+        return !FutureUtil.unwrap(
                 clientWrapper.readRowAsync(
                     tableName.getNameAsString(), ByteStringer.wrap(get.getRow()), filter))
             .isEmpty();

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/util/FutureUtil.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/util/FutureUtil.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.util;
+
+import com.google.api.core.InternalApi;
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+/** Helpers to handle async operations inside the hbase adapter. */
+@InternalApi
+public class FutureUtil {
+
+  /**
+   * Extract the underlying causes for the future's failure.
+   *
+   * <p>The future's and the callers stacktraces will be merged to ease debugging.
+   */
+  // This functionality was extracted from HBase 2.x
+  public static <T> T unwrap(Future<T> future) throws IOException {
+    try {
+      return future.get();
+    } catch (InterruptedException e) {
+      throw (IOException) new InterruptedIOException().initCause(e);
+    } catch (ExecutionException e) {
+      throw rethrow(e.getCause());
+    }
+  }
+
+  private static IOException rethrow(Throwable error) throws IOException {
+    if (error instanceof IOException) {
+      setStackTrace(error);
+      throw (IOException) error;
+    } else if (error instanceof RuntimeException) {
+      setStackTrace(error);
+      throw (RuntimeException) error;
+    } else if (error instanceof Error) {
+      setStackTrace(error);
+      throw (Error) error;
+    } else {
+      throw new IOException(error);
+    }
+  }
+
+  private static void setStackTrace(Throwable error) {
+    StackTraceElement[] localStackTrace = Thread.currentThread().getStackTrace();
+    StackTraceElement[] originalStackTrace = error.getStackTrace();
+    StackTraceElement[] newStackTrace =
+        new StackTraceElement[localStackTrace.length + originalStackTrace.length + 1];
+    System.arraycopy(localStackTrace, 0, newStackTrace, 0, localStackTrace.length);
+    newStackTrace[localStackTrace.length] =
+        new StackTraceElement("--------Future", "get--------", null, -1);
+    System.arraycopy(
+        originalStackTrace,
+        0,
+        newStackTrace,
+        localStackTrace.length + 1,
+        originalStackTrace.length);
+    error.setStackTrace(newStackTrace);
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/util/FutureUtilTest.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/util/FutureUtilTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.util;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class FutureUtilTest {
+  private ExecutorService executor;
+
+  @Before
+  public void setUp() throws Exception {
+    executor = Executors.newCachedThreadPool();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    executor.shutdown();
+  }
+
+  @Test
+  public void unwrapBubblesErrorsBare() {
+    Set<Class<? extends Throwable>> unwrappedErrors =
+        ImmutableSet.of(IOException.class, RuntimeException.class, Error.class);
+
+    for (Class<? extends Throwable> cls : unwrappedErrors) {
+      final Future<?> future = executor.submit(new ErrorCreator(cls));
+      Throwable actualException =
+          assertThrows(
+              cls,
+              new ThrowingRunnable() {
+                @Override
+                public void run() throws Throwable {
+                  FutureUtil.unwrap(future);
+                }
+              });
+
+      assertThat(actualException).hasMessageThat().isEqualTo("fake error");
+      assertThat(actualException).hasCauseThat().isNull();
+    }
+  }
+
+  @Test
+  public void unwrapWrapsOtherErrors() {
+    final Future<?> future = executor.submit(new ErrorCreator(TimeoutException.class));
+    IOException actualException =
+        assertThrows(
+            IOException.class,
+            new ThrowingRunnable() {
+              @Override
+              public void run() throws Throwable {
+                FutureUtil.unwrap(future);
+              }
+            });
+    assertThat(actualException)
+        .hasMessageThat()
+        .isEqualTo("java.util.concurrent.TimeoutException: fake error");
+    assertThat(actualException).hasCauseThat().isInstanceOf(TimeoutException.class);
+    assertThat(actualException).hasCauseThat().hasMessageThat().isEqualTo("fake error");
+  }
+
+  @Test
+  public void concatsStacktraces() {
+    final Future<Void> future = executor.submit(new ErrorCreator(IOException.class));
+
+    List<StackTraceElement> originalStack =
+        ImmutableList.copyOf(
+            assertThrows(
+                    ExecutionException.class,
+                    new ThrowingRunnable() {
+                      @Override
+                      public void run() throws Throwable {
+                        future.get();
+                      }
+                    })
+                .getCause()
+                .getStackTrace());
+
+    List<StackTraceElement> augmentedStack =
+        ImmutableList.copyOf(
+            assertThrows(
+                    IOException.class,
+                    new ThrowingRunnable() {
+                      @Override
+                      public void run() throws Throwable {
+                        FutureUtil.unwrap(future);
+                      }
+                    })
+                .getStackTrace());
+
+    // Make sure that the original stacktrace is preserved
+    assertThat(augmentedStack).containsAtLeastElementsIn(originalStack);
+
+    // Ensure that the caller's portion of the stacktrace is present
+    StackTraceElement[] topTrace = Thread.currentThread().getStackTrace();
+    List<StackTraceElement> relevantTopTrace = Arrays.asList(topTrace).subList(2, topTrace.length);
+    assertThat(augmentedStack).containsAtLeastElementsIn(relevantTopTrace);
+  }
+
+  private static class ErrorCreator implements Callable<Void> {
+    private final Class errorClass;
+
+    private ErrorCreator(Class errorClass) {
+      this.errorClass = errorClass;
+    }
+
+    @Override
+    public Void call() throws Exception {
+      method1();
+      return null;
+    }
+
+    private void method1() throws Exception {
+      Throwable t = (Throwable) errorClass.getConstructor(String.class).newInstance("fake error");
+      if (Error.class.isAssignableFrom(errorClass)) {
+        throw (Error) t;
+      } else {
+        throw (Exception) t;
+      }
+    }
+  }
+}

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/pom.xml
@@ -99,10 +99,6 @@ limitations under the License.
       <artifactId>grpc-core</artifactId>
       <scope>compile</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.api</groupId>
-      <artifactId>gax</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>com.google.api</groupId>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableTable.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableTable.java
@@ -16,11 +16,11 @@
 package com.google.cloud.bigtable.hbase2_x;
 
 import com.google.api.core.InternalApi;
-import com.google.api.gax.rpc.ApiExceptions;
 import com.google.cloud.bigtable.data.v2.models.ConditionalRowMutation;
 import com.google.cloud.bigtable.hbase.AbstractBigtableTable;
 import com.google.cloud.bigtable.hbase.adapters.CheckAndMutateUtil;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
+import com.google.cloud.bigtable.hbase.util.FutureUtil;
 import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.List;
@@ -224,11 +224,10 @@ public class BigtableTable extends AbstractBigtableTable {
         }
       }
 
-      private boolean call() {
+      private boolean call() throws IOException {
         ConditionalRowMutation conditionalRowMutation = builder.build();
         Boolean response =
-            ApiExceptions.callAndTranslateApiException(
-                clientWrapper.checkAndMutateRowAsync(conditionalRowMutation));
+            FutureUtil.unwrap(clientWrapper.checkAndMutateRowAsync(conditionalRowMutation));
         return CheckAndMutateUtil.wasMutationApplied(conditionalRowMutation, response);
       }
     };

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
@@ -16,7 +16,6 @@
 package org.apache.hadoop.hbase.client;
 
 import com.google.api.core.InternalApi;
-import com.google.api.gax.rpc.ApiExceptions;
 import com.google.bigtable.v2.SampleRowKeysRequest;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.data.v2.internal.NameUtil;
@@ -25,6 +24,7 @@ import com.google.cloud.bigtable.hbase.adapters.Adapters;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter.MutationAdapters;
 import com.google.cloud.bigtable.hbase.adapters.SampledRowKeysAdapter;
+import com.google.cloud.bigtable.hbase.util.FutureUtil;
 import com.google.cloud.bigtable.hbase.util.Logger;
 import com.google.cloud.bigtable.hbase.wrappers.BigtableApi;
 import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
@@ -384,7 +384,7 @@ public class BigtableAsyncConnection implements AsyncConnection, CommonConnectio
         NameUtil.formatTableName(
             settings.getProjectId(), settings.getInstanceId(), tableName.getNameAsString()));
     List<KeyOffset> sampleRowKeyResponse =
-        ApiExceptions.callAndTranslateApiException(
+        FutureUtil.unwrap(
             this.bigtableApi.getDataClient().sampleRowKeysAsync(tableName.getNameAsString()));
 
     return getSampledRowKeysAdapter(tableName, serverName).adaptResponse(sampleRowKeyResponse)


### PR DESCRIPTION
Previously we would blindly uses ApiExceptions.callAndTranslateApiException and Futures.getUnchecked to await future results. This created a number of problems:
* It would bubble ApiExceptions & CheckExceptions to the surface, which is quite unexpected for an hbase client
* It would hide hbase specific IOExceptions

This PR introduces FutureUtil#unwrap, which will try to preserve the original exception. However to aid in debugging, it will augment the stacktrace to include the caller. This is a similar approach as hbase took in:
https://github.com/apache/hbase/blob/5b9940907e695e20d24968cbc725277a19ce2170/hbase-common/src/main/java/org/apache/hadoop/hbase/util/FutureUtils.java#L129-L140

Unfortunately we can't just call that utility because it only exists in hbase 2x, so I inlined relevant bits

Also, a couple methods would skip the HBaseIOException wrapping, so I patched that in