### PR TITLE
chore(test): use same the same resource name pattern as java-bigtable tests

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/BigtableEnv.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/BigtableEnv.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.TableName;
@@ -87,24 +86,17 @@ class BigtableEnv extends SharedTestEnv {
         Admin admin = connection.getAdmin()) {
       List<ListenableFuture<?>> futures = new ArrayList<>();
 
-      // Limit clean up to specific prefixes. In 12/2018, the table name pattern was modified to
-      // always start with test_table2 and to include a timestamp. In the transition, the old
-      // patterns are retained.
-      for (final TableName tableName :
-          admin.listTableNames(Pattern.compile("(test_table|list_table[12]|TestTable).*"))) {
+      String stalePrefix =
+          SharedTestEnvRule.newTimePrefix(
+              TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis())
+                  - TimeUnit.HOURS.toSeconds(6));
 
-        // If this is a new style table name, only clean it up if it been lingering for more than 30
-        // minutes. This avoids concurrent tests deleting each other's tables.
-        // The name is created in SharedTestEnvRule.newTestTableName()
-        Pattern timestampPattern = Pattern.compile("test_table2-([0-9a-f]{16})-.*");
-        Matcher matcher = timestampPattern.matcher(tableName.getNameAsString());
-        if (matcher.matches()) {
-          String timestampStr = matcher.group(1);
-          long timestamp = Long.parseLong(timestampStr, 16);
-          if (System.currentTimeMillis() - timestamp < TimeUnit.MINUTES.toMillis(15)) {
-            LOG.info("Found fresh table, ignoring: " + tableName);
-            continue;
-          }
+      for (final TableName tableName :
+          admin.listTableNames(Pattern.compile(SharedTestEnvRule.PREFIX + ".*"))) {
+
+        if (tableName.getNameAsString().compareTo(stalePrefix) > 0) {
+          LOG.info("Found fresh table, ignoring: " + tableName);
+          continue;
         }
 
         futures.add(

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnvRule.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnvRule.java
@@ -22,6 +22,8 @@ import java.util.Map.Entry;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -34,6 +36,10 @@ import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.rules.ExternalResource;
 
 public class SharedTestEnvRule extends ExternalResource {
+  static final String PREFIX = "temp-";
+  private static final int SUFFIX = new Random().nextInt(Integer.MAX_VALUE);
+  private static final AtomicInteger prefixCounter = new AtomicInteger(0);
+
   private static final String HBASE_CONN_KEY = "hbase_conn";
 
   public static final int MAX_VERSIONS = 6;
@@ -141,9 +147,16 @@ public class SharedTestEnvRule extends ExternalResource {
   }
 
   public TableName newTestTableName() {
-    String suffix =
-        String.format("%016x-%016x", System.currentTimeMillis(), new Random().nextLong());
-    return TableName.valueOf("test_table2-" + suffix);
+    // Sortable resource prefix - time, process identifier, serial counterck
+    long epoch = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
+    String nameStr =
+        String.format("%s-%x-%x", newTimePrefix(epoch), SUFFIX, prefixCounter.getAndIncrement());
+
+    return TableName.valueOf(nameStr);
+  }
+
+  static String newTimePrefix(long epochSecs) {
+    return String.format(PREFIX + "08%x", epochSecs);
   }
 
   public ExecutorService getExecutor() {


### PR DESCRIPTION
Use the pattern temp-${secs since epoch}-${random}-${process counter} to create new tables. This should guarantee test uniqueness when running multiple tests concurrently
