### PR TITLE
chore(test): improve snapshot tests

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/BigtableEnv.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/BigtableEnv.java
@@ -80,6 +80,11 @@ class BigtableEnv extends SharedTestEnv {
       }
     }
 
+    // Auto expire orphaned snapshots. Minimum ttl is 6h
+    configuration.setIfUnset(
+        "google.bigtable.snapshot.default.ttl.secs",
+        String.valueOf(TimeUnit.HOURS.toSeconds(6) + 1));
+
     // Garbage collect tables that previous runs failed to clean up
     ListeningExecutorService executor = MoreExecutors.listeningDecorator(getExecutor());
     try (Connection connection = ConnectionFactory.createConnection(configuration);

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSnapshots.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSnapshots.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
@@ -45,31 +44,16 @@ public class TestSnapshots extends AbstractTestSnapshot {
   @Before
   public void setUp() throws IOException {
     try (Admin admin = getConnection().getAdmin()) {
-      // Setup a prefix to avoid collisions between concurrent test runs
-      prefix = String.format("020%d", System.currentTimeMillis());
-
-      // clean up stale backups
-      String stalePrefix =
-          String.format("020%d", System.currentTimeMillis() - TimeUnit.HOURS.toMillis(2));
-
-      for (SnapshotDescription snapshotDescription : admin.listSnapshots()) {
-        int i = snapshotDescription.getName().lastIndexOf("/");
-        String backupId = snapshotDescription.getName().substring(i + 1);
-        if (backupId.endsWith(TEST_BACKUP_SUFFIX) && stalePrefix.compareTo(backupId) > 0) {
-          LOG.info("Deleting old snapshot: " + backupId);
-          admin.deleteSnapshot(backupId);
-        }
-      }
       values = createAndPopulateTable(tableName);
     }
   }
 
   @Test
   public void listSnapshots() throws IOException, InterruptedException {
-    String snapshot1 = generateId("snapshot-1");
+    String snapshot1 = newSnapshotId();
     snapshot(snapshot1, tableName);
 
-    String snapshot2 = generateId("snapshot-2");
+    String snapshot2 = newSnapshotId();
     snapshot(snapshot2, tableName);
 
     try (Admin admin = getConnection().getAdmin()) {
@@ -90,13 +74,6 @@ public class TestSnapshots extends AbstractTestSnapshot {
       throws IOException, InterruptedException {
     try (Admin admin = getConnection().getAdmin()) {
       admin.snapshot(snapshotName, tableName);
-    }
-  }
-
-  @Override
-  protected int listSnapshotsSize() throws IOException {
-    try (Admin admin = getConnection().getAdmin()) {
-      return admin.listSnapshots().size();
     }
   }
 

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSnapshots.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSnapshots.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
@@ -47,28 +46,13 @@ public class TestSnapshots extends AbstractTestSnapshot {
   @Before
   public void setUp() throws IOException {
     try (Admin admin = getConnection().getAdmin()) {
-      // Setup a prefix to avoid collisions between concurrent test runs
-      prefix = String.format("020%d", System.currentTimeMillis());
-
-      // clean up stale backups
-      String stalePrefix =
-          String.format("020%d", System.currentTimeMillis() - TimeUnit.HOURS.toMillis(2));
-
-      for (SnapshotDescription snapshotDescription : admin.listSnapshots()) {
-        int i = snapshotDescription.getName().lastIndexOf("/");
-        String backupId = snapshotDescription.getName().substring(i + 1);
-        if (backupId.endsWith(TEST_BACKUP_SUFFIX) && stalePrefix.compareTo(backupId) > 0) {
-          LOG.info("Deleting old snapshot: " + backupId);
-          admin.deleteSnapshot(backupId);
-        }
-      }
       values = createAndPopulateTable(tableName);
     }
   }
 
   @Test
   public void testSnapshotDescription() throws IOException, InterruptedException {
-    String snapshotName = generateId("test-snapshot");
+    String snapshotName = newSnapshotId();
     try {
       SnapshotDescription snapshotDescription =
           new SnapshotDescription(snapshotName, tableName, SnapshotType.FLUSH);
@@ -82,10 +66,10 @@ public class TestSnapshots extends AbstractTestSnapshot {
 
   @Test
   public void listSnapshots() throws IOException, InterruptedException {
-    String snapshot1 = generateId("snapshot-1");
+    String snapshot1 = newSnapshotId();
     snapshot(snapshot1, tableName);
 
-    String snapshot2 = generateId("snapshot-2");
+    String snapshot2 = newSnapshotId();
     snapshot(snapshot2, tableName);
 
     try (Admin admin = getConnection().getAdmin()) {
@@ -113,13 +97,6 @@ public class TestSnapshots extends AbstractTestSnapshot {
       throws IOException, InterruptedException {
     try (Admin admin = getConnection().getAdmin()) {
       admin.snapshot(snapshotDescription);
-    }
-  }
-
-  @Override
-  protected int listSnapshotsSize() throws IOException {
-    try (Admin admin = getConnection().getAdmin()) {
-      return admin.listSnapshots().size();
     }
   }
 

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncSnapshots.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncSnapshots.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import org.apache.hadoop.hbase.TableExistsException;
 import org.apache.hadoop.hbase.TableName;
@@ -55,22 +54,6 @@ public class TestAsyncSnapshots extends AbstractTestSnapshot {
 
   @Before
   public void setUp() throws ExecutionException, InterruptedException, IOException {
-    // Setup a prefix to avoid collisions between concurrent test runs
-    prefix = String.format("020%d", System.currentTimeMillis());
-
-    // clean up stale backups
-    String stalePrefix =
-        String.format("020%d", System.currentTimeMillis() - TimeUnit.HOURS.toMillis(2));
-
-    for (SnapshotDescription snapshotDescription : getAsyncAdmin().listSnapshots().get()) {
-      int i = snapshotDescription.getName().lastIndexOf("/");
-      String backupId = snapshotDescription.getName().substring(i + 1);
-      if (backupId.endsWith(TEST_BACKUP_SUFFIX) && stalePrefix.compareTo(backupId) > 0) {
-        LOG.info("Deleting old snapshot: " + backupId);
-        getAsyncAdmin().deleteSnapshot(backupId);
-      }
-    }
-
     values = createAndPopulateTable(tableName);
   }
 
@@ -103,10 +86,10 @@ public class TestAsyncSnapshots extends AbstractTestSnapshot {
 
   @Test
   public void listSnapshots() throws IOException, InterruptedException, ExecutionException {
-    String snapshot1 = generateId("snapshot-1");
+    String snapshot1 = newSnapshotId();
     snapshot(snapshot1, tableName);
 
-    String snapshot2 = generateId("snapshot-2");
+    String snapshot2 = newSnapshotId();
     snapshot(snapshot2, tableName);
     try {
       List<SnapshotDescription> snapshotDescriptions = getAsyncAdmin().listSnapshots().get();
@@ -200,15 +183,6 @@ public class TestAsyncSnapshots extends AbstractTestSnapshot {
     try {
       Pattern pattern = Pattern.compile(regEx);
       return getAsyncAdmin().listSnapshots(pattern).get().size();
-    } catch (InterruptedException | ExecutionException e) {
-      throw new IOException("Error while listing snapshots size: " + e.getCause());
-    }
-  }
-
-  @Override
-  protected int listSnapshotsSize() throws IOException {
-    try {
-      return getAsyncAdmin().listSnapshots().get().size();
     } catch (InterruptedException | ExecutionException e) {
       throw new IOException("Error while listing snapshots size: " + e.getCause());
     }


### PR DESCRIPTION
* use UUID to avoid collisions
* skip manual cleanup and use snapshot expiration instead
* remove unused methods
