### PR TITLE
chore(test): optimize beam import tests

### DIFF
--- a/.kokoro/nightly/integration-beam.cfg
+++ b/.kokoro/nightly/integration-beam.cfg
@@ -8,7 +8,7 @@ env_vars: {
 
 env_vars: {
     key: "INTEGRATION_TEST_ARGS"
-    value: "-PbeamIntegrationTest -Dgoogle.bigtable.project.id=gcloud-devel -Dgoogle.bigtable.instance.id=google-cloud-bigtable -Dgoogle.dataflow.stagingLocation=gs://java-bigtable-hbase-testing/staging -Dcloud.test.data.folder=gs://java-bigtable-hbase-testing/hbase-snapshot-import-integration-tests -Dregion=us-central1"
+    value: "-PbeamIntegrationTest -Dgoogle.bigtable.project.id=gcloud-devel -Dgoogle.bigtable.instance.id=google-cloud-bigtable -Dgoogle.dataflow.work-dir=gs://java-bigtable-hbase-testing/work-dir -Dcloud.test.data.folder=gs://java-bigtable-hbase-testing/hbase-snapshot-import-integration-tests -Dregion=us-central1"
 }
 
 env_vars: {

--- a/.kokoro/presubmit/integration-beam.cfg
+++ b/.kokoro/presubmit/integration-beam.cfg
@@ -8,7 +8,7 @@ env_vars: {
 
 env_vars: {
     key: "INTEGRATION_TEST_ARGS"
-    value: "-PbeamIntegrationTest -Dgoogle.bigtable.project.id=gcloud-devel -Dgoogle.bigtable.instance.id=google-cloud-bigtable -Dgoogle.dataflow.stagingLocation=gs://java-bigtable-hbase-testing/staging -Dcloud.test.data.folder=gs://java-bigtable-hbase-testing/hbase-snapshot-import-integration-tests -Dregion=us-central1"
+    value: "-PbeamIntegrationTest -Dgoogle.bigtable.project.id=gcloud-devel -Dgoogle.bigtable.instance.id=google-cloud-bigtable -Dgoogle.dataflow.work-dir=gs://java-bigtable-hbase-testing/work-dir -Dcloud.test.data.folder=gs://java-bigtable-hbase-testing/hbase-snapshot-import-integration-tests -Dregion=us-central1"
 }
 
 env_vars: {

--- a/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
@@ -376,11 +376,20 @@ limitations under the License.
             </goals>
             <configuration>
               <excludes>
-                <exclude>com.google.cloud.bigtable.beam.it*/*.java</exclude>
+                <exclude>**/*IT.java</exclude>
               </excludes>
             </configuration>
           </execution>
         </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <!-- disable integration tests by default, opt-in via profile -->
+          <skip>true</skip>
+        </configuration>
       </plugin>
 
       <plugin>
@@ -406,20 +415,13 @@ limitations under the License.
           </execution>
         </executions>
       </plugin>
-
-
     </plugins>
   </build>
 
   <profiles>
+    <!-- TODO: remove the sequence file profile after kokoro jobs are migrated -->
     <profile>
       <id>sequencefileIntegrationTest</id>
-      <!-- Required properties:
-         google.bigtable.project.id
-         google.bigtable.instance.id
-         google.dataflow.stagingLocation
-         cloud.test.data.folder
-     -->
       <build>
         <plugins>
           <plugin>
@@ -432,16 +434,20 @@ limitations under the License.
                   <goal>integration-test</goal>
                   <goal>verify</goal>
                 </goals>
-                <phase>integration-test</phase>
                 <configuration>
-                  <forkCount>1</forkCount>
+                  <skip>false</skip>
                   <includes>
                     <include>**/sequencefiles/*IT.java</include>
                   </includes>
                   <!-- Use Isolated Classloader so that dataflow can find all files
-                       that must be staged.
-                  -->
+                                         that must be staged.
+                                    -->
+                  <forkCount>1</forkCount>
                   <useSystemClassLoader>false</useSystemClassLoader>
+
+                  <!-- prevent multiple executions from clobering each other -->
+                  <summaryFile>${project.build.directory}/failsafe-reports/sequencefile-tests/failsafe-summary.xml</summaryFile>
+                  <reportsDirectory>${project.build.directory}/failsafe-reports/sequencefile-tests</reportsDirectory>
                 </configuration>
               </execution>
             </executions>
@@ -450,56 +456,37 @@ limitations under the License.
       </build>
     </profile>
 
-    <!-- profile to run all integration tests -->
     <profile>
       <id>beamIntegrationTest</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>beam-integration-test</id>
-                <goals>
-                  <goal>test</goal>
-                </goals>
-                <phase>integration-test</phase>
-                <configuration>
-                  <forkCount>1</forkCount>
-                  <includes>
-                    <include>**/CloudBigtableBeamITTest.java</include>
-                    <include>**/*IT.java</include>
-                  </includes>
-                  <reportNameSuffix>bigtable-beam</reportNameSuffix>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>hbasesnapshotsIntegrationTest</id>
+      <!-- Requires system properties to be set, see TestProperties.java -->
       <build>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
+            <version>3.0.0-M4</version>
             <executions>
               <execution>
-                <id>hbasesnapshots-integration-test</id>
+                <id>beam-integration-test</id>
                 <goals>
                   <goal>integration-test</goal>
+                  <goal>verify</goal>
                 </goals>
-                <phase>integration-test</phase>
+
                 <configuration>
-                  <forkCount>1</forkCount>
+                  <skip>false</skip>
                   <includes>
-                    <include>**/hbasesnapshots/*IT.java</include>
+                    <include>**/*IT.java</include>
                   </includes>
+                  <!-- Use Isolated Classloader so that dataflow can find all files
+                       that must be staged.
+                  -->
+                  <forkCount>1</forkCount>
                   <useSystemClassLoader>false</useSystemClassLoader>
+
+                  <!-- Run tests in parallel -->
+                  <parallel>methods</parallel>
+                  <threadCount>10</threadCount>
                 </configuration>
               </execution>
             </executions>

--- a/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
@@ -379,7 +379,6 @@ limitations under the License.
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <trimStackTrace>false</trimStackTrace>
-          <skip>true</skip>
         </configuration>
         <executions>
           <execution>

--- a/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
@@ -86,6 +86,19 @@ limitations under the License.
       <artifactId>beam-sdks-java-io-hadoop-format</artifactId>
     </dependency>
 
+    <!-- Used transitively by beam, and directly in tests -->
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-runners-core-construction-java</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-vendor-guava-26_0-jre</artifactId>
+      <version>0.1</version>
+      <scope>runtime</scope>
+    </dependency>
+
     <!-- Bigtable Group: ordering doesn't matter since everything is shaded -->
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -366,6 +379,7 @@ limitations under the License.
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <trimStackTrace>false</trimStackTrace>
+          <skip>true</skip>
         </configuration>
         <executions>
           <execution>
@@ -485,7 +499,7 @@ limitations under the License.
                   <useSystemClassLoader>false</useSystemClassLoader>
 
                   <!-- Run tests in parallel -->
-                  <parallel>methods</parallel>
+                  <parallel>all</parallel>
                   <threadCount>10</threadCount>
                 </configuration>
               </execution>

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/hbasesnapshots/ImportJobFromHbaseSnapshot.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/hbasesnapshots/ImportJobFromHbaseSnapshot.java
@@ -106,7 +106,6 @@ public class ImportJobFromHbaseSnapshot {
             .setProjectId(opts.getProject())
             .setHbaseSnapshotSourceDir(opts.getHbaseSnapshotSourceDir())
             .setSnapshotName(opts.getSnapshotName())
-            .setRestoreDirSuffix(opts.getJobName())
             .setRestoreDirSuffix(opts.getJobName());
     PCollection<KV<ImmutableBytesWritable, Result>> readResult =
         pipeline.apply(

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/test/java/com/google/cloud/bigtable/beam/hbasesnapshots/EndToEndIT.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/test/java/com/google/cloud/bigtable/beam/hbasesnapshots/EndToEndIT.java
@@ -15,20 +15,19 @@
  */
 package com.google.cloud.bigtable.beam.hbasesnapshots;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.api.services.storage.model.Objects;
+import com.google.api.services.storage.model.StorageObject;
 import com.google.bigtable.repackaged.com.google.gson.Gson;
 import com.google.cloud.bigtable.beam.hbasesnapshots.ImportJobFromHbaseSnapshot.ImportOptions;
 import com.google.cloud.bigtable.beam.sequencefiles.HBaseResultToMutationFn;
+import com.google.cloud.bigtable.beam.test_env.EnvSetup;
+import com.google.cloud.bigtable.beam.test_env.TestProperties;
 import com.google.cloud.bigtable.beam.validation.HadoopHashTableSource.RangeHash;
 import com.google.cloud.bigtable.beam.validation.SyncTableJob;
 import com.google.cloud.bigtable.beam.validation.SyncTableJob.SyncTableOptions;
 import com.google.cloud.bigtable.hbase.BigtableConfiguration;
-import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.ByteBuffer;
@@ -39,7 +38,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-import org.apache.beam.runners.dataflow.DataflowRunner;
 import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.PipelineResult.State;
@@ -72,77 +70,53 @@ import org.slf4j.LoggerFactory;
  * validates the imported data with SyncTable.
  * Prepare test data with gsutil(https://cloud.google.com/storage/docs/quickstart-gsutil):
  * gsutil -m cp -r <PATH_TO_REPO>/bigtable-dataflow-parent/bigtable-beam-import/src/test/integration-test \
- *  gs://<test_bucket>/
- *
- * Setup GCP credential: https://cloud.google.com/docs/authentication
- *  Ensure your credential have access to Bigtable and Dataflow
- *
- * Run with:
- * mvn integration-test -PhbasesnapshotsIntegrationTest \
- * -Dgoogle.bigtable.project.id=<project_id> \
- * -Dgoogle.bigtable.instance.id=<instance_id> \
- * -Dgoogle.dataflow.stagingLocation=gs://<test_bucket>/staging \
- * -Dcloud.test.data.folder=gs://<test_bucket>/integration-test/
+ *  gs://<test_bucket>/cloud-data-dir/
  */
 public class EndToEndIT {
-
   private static Logger LOG = LoggerFactory.getLogger(HBaseResultToMutationFn.class);
   private static final String TEST_SNAPSHOT_NAME = "test-snapshot";
-  // Location of test data hosted on Google Cloud Storage, for on-cloud dataflow tests.
-  private static final String CLOUD_TEST_DATA_FOLDER = "cloud.test.data.folder";
-  private static final String DATAFLOW_REGION = "region";
-
-  // Column family name used in all test bigtables.
   private static final String CF = "cf";
 
-  // Full path of the Cloud Storage folder where dataflow jars are uploaded to.
-  private static final String GOOGLE_DATAFLOW_STAGING_LOCATION = "google.dataflow.stagingLocation";
+  private TestProperties properties;
 
   private Connection connection;
-  private String projectId;
-  private String instanceId;
-  private String tableId;
-  private String region;
-
   private GcsUtil gcsUtil;
-  private String dataflowStagingLocation;
-  private String workDir;
   private byte[][] keySplits;
 
-  // Snapshot data setup
+  // Input setup
   private String hbaseSnapshotDir;
   private String hashDir;
+
+  // Output
+  private String workDir;
+  private String tempDir;
   private String syncTableOutputDir;
+  private String tableId;
 
   @Before
   public void setup() throws Exception {
-    projectId = getTestProperty(BigtableOptionsFactory.PROJECT_ID_KEY);
-    instanceId = getTestProperty(BigtableOptionsFactory.INSTANCE_ID_KEY);
-    dataflowStagingLocation = getTestProperty(GOOGLE_DATAFLOW_STAGING_LOCATION);
-    region = getTestProperty(DATAFLOW_REGION);
-    String cloudTestDataFolder = getTestProperty(CLOUD_TEST_DATA_FOLDER);
-    if (!cloudTestDataFolder.endsWith(File.separator)) {
-      cloudTestDataFolder = cloudTestDataFolder + File.separator;
-    }
+    EnvSetup.initialize();
+    properties = TestProperties.fromSystem();
 
-    hbaseSnapshotDir = cloudTestDataFolder + "data/";
-    UUID test_uuid = UUID.randomUUID();
-    hashDir = cloudTestDataFolder + "hashtable/";
+    // Configure inputs
+    hbaseSnapshotDir = properties.getCloudDataDir() + "data/";
+    hashDir = properties.getCloudDataDir() + "hashtable/";
 
-    syncTableOutputDir = dataflowStagingLocation;
-    if (!syncTableOutputDir.endsWith(File.separator)) {
-      syncTableOutputDir = syncTableOutputDir + File.separator;
-    }
-    syncTableOutputDir = syncTableOutputDir + "sync-table-output/" + test_uuid + "/";
+    // Configure output
+    workDir = properties.getTestWorkdir(UUID.randomUUID());
+    tempDir = workDir + "temp/";
+    syncTableOutputDir = workDir + "output/";
 
     // Cloud Storage config
     GcpOptions gcpOptions = PipelineOptionsFactory.create().as(GcpOptions.class);
-    gcpOptions.setProject(projectId);
+    properties.applyTo(gcpOptions);
     gcsUtil = new GcsUtil.GcsUtilFactory().create(gcpOptions);
 
     // Bigtable config
-    connection = BigtableConfiguration.connect(projectId, instanceId);
-    tableId = "test_" + UUID.randomUUID().toString();
+    connection =
+        BigtableConfiguration.connect(properties.getProjectId(), properties.getInstanceId());
+    // TODO: use timebased names to allow for gc
+    tableId = "test_" + UUID.randomUUID();
 
     LOG.info("Setting up integration tests");
 
@@ -159,13 +133,9 @@ public class EndToEndIT {
     connection.getAdmin().createTable(descriptor, SnapshotTestingUtils.getSplitKeys());
   }
 
-  private static String getTestProperty(String name) {
-    return checkNotNull(System.getProperty(name), "Required property missing: " + name);
-  }
-
   @After
   public void teardown() throws IOException {
-    final List<GcsPath> paths = gcsUtil.expand(GcsPath.fromUri(syncTableOutputDir + "/*"));
+    final List<GcsPath> paths = gcsUtil.expand(GcsPath.fromUri(syncTableOutputDir + "*"));
 
     if (!paths.isEmpty()) {
       final List<String> pathStrs = new ArrayList<>();
@@ -178,27 +148,19 @@ public class EndToEndIT {
       this.gcsUtil.remove(pathStrs);
     }
 
+    connection.getAdmin().deleteTable(TableName.valueOf(tableId));
     connection.close();
-
-    // delete test table
-    BigtableConfiguration.connect(projectId, instanceId)
-        .getAdmin()
-        .deleteTable(TableName.valueOf(tableId));
   }
 
   private SyncTableOptions createSyncTableOptions() {
     DataflowPipelineOptions syncTableOpts =
         PipelineOptionsFactory.as(DataflowPipelineOptions.class);
-    syncTableOpts.setRunner(DataflowRunner.class);
-    syncTableOpts.setGcpTempLocation(dataflowStagingLocation);
-    syncTableOpts.setNumWorkers(1);
-    syncTableOpts.setProject(projectId);
-    syncTableOpts.setRegion(region);
+    properties.applyTo(syncTableOpts);
 
     SyncTableOptions syncOpts = syncTableOpts.as(SyncTableOptions.class);
     // Setup Bigtable params
-    syncOpts.setBigtableProject(StaticValueProvider.of(projectId));
-    syncOpts.setBigtableInstanceId(StaticValueProvider.of(instanceId));
+    syncOpts.setBigtableProject(StaticValueProvider.of(properties.getProjectId()));
+    syncOpts.setBigtableInstanceId(StaticValueProvider.of(properties.getInstanceId()));
     syncOpts.setBigtableTableId(StaticValueProvider.of(tableId));
     syncOpts.setBigtableAppProfileId(null);
 
@@ -211,17 +173,13 @@ public class EndToEndIT {
   private ImportOptions createImportOptions() {
     DataflowPipelineOptions importPipelineOpts =
         PipelineOptionsFactory.as(DataflowPipelineOptions.class);
-    importPipelineOpts.setRunner(DataflowRunner.class);
-    importPipelineOpts.setGcpTempLocation(dataflowStagingLocation);
-    importPipelineOpts.setNumWorkers(1);
-    importPipelineOpts.setProject(projectId);
-    importPipelineOpts.setRegion(region);
+    properties.applyTo(importPipelineOpts);
 
     ImportOptions importOpts = importPipelineOpts.as(ImportOptions.class);
 
     // setup Bigtable options
-    importOpts.setBigtableProject(StaticValueProvider.of(projectId));
-    importOpts.setBigtableInstanceId(StaticValueProvider.of(instanceId));
+    importOpts.setBigtableProject(StaticValueProvider.of(properties.getProjectId()));
+    importOpts.setBigtableInstanceId(StaticValueProvider.of(properties.getInstanceId()));
     importOpts.setBigtableTableId(StaticValueProvider.of(tableId));
 
     // setup HBase snapshot info
@@ -292,7 +250,6 @@ public class EndToEndIT {
 
   @Test
   public void testHBaseSnapshotImport() throws Exception {
-
     // Start import
     ImportOptions importOpts = createImportOptions();
 
@@ -301,14 +258,26 @@ public class EndToEndIT {
     Assert.assertEquals(State.DONE, state);
 
     // check that the .restore dir used for temp files has been removed
-    Objects objects =
-        gcsUtil.listObjects(
-            GcsPath.fromUri(hbaseSnapshotDir).getBucket(),
-            CleanupHBaseSnapshotRestoreFilesFn.getListPrefix(
-                HBaseSnapshotInputConfigBuilder.RESTORE_DIR),
-            null);
-    Assert.assertNull(objects.getItems());
+    // The restore directory is stored relative to the snapshot directory and contains the job name
+    String bucket = GcsPath.fromUri(hbaseSnapshotDir).getBucket();
+    String restorePathPrefix =
+        CleanupHBaseSnapshotRestoreFilesFn.getListPrefix(
+            HBaseSnapshotInputConfigBuilder.RESTORE_DIR);
+    List<StorageObject> allObjects = new ArrayList<>();
+    String nextToken;
+    do {
+      Objects objects = gcsUtil.listObjects(bucket, restorePathPrefix, null);
+      allObjects.addAll(objects.getItems());
+      nextToken = objects.getNextPageToken();
+    } while (nextToken != null);
 
+    List<StorageObject> myObjects =
+        allObjects.stream()
+            .filter(o -> o.getName().contains(importOpts.getJobName()))
+            .collect(Collectors.toList());
+    Assert.assertTrue("Restore directory wasn't deleted", myObjects.isEmpty());
+
+    // Verify the import using the sync job
     SyncTableOptions syncOpts = createSyncTableOptions();
 
     PipelineResult result = SyncTableJob.buildPipeline(syncOpts).run();

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/test/java/com/google/cloud/bigtable/beam/hbasesnapshots/EndToEndIT.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/test/java/com/google/cloud/bigtable/beam/hbasesnapshots/EndToEndIT.java
@@ -267,7 +267,10 @@ public class EndToEndIT {
     String nextToken;
     do {
       Objects objects = gcsUtil.listObjects(bucket, restorePathPrefix, null);
-      allObjects.addAll(objects.getItems());
+      List<StorageObject> items = objects.getItems();
+      if (items != null) {
+        allObjects.addAll(items);
+      }
       nextToken = objects.getNextPageToken();
     } while (nextToken != null);
 

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/test/java/com/google/cloud/bigtable/beam/it/CloudBigtableBeamIT.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/test/java/com/google/cloud/bigtable/beam/it/CloudBigtableBeamIT.java
@@ -97,8 +97,10 @@ public class CloudBigtableBeamIT {
 
     Configuration config =
         BigtableConfiguration.configure(properties.getProjectId(), properties.getInstanceId());
-    properties.getDataEndpoint().ifPresent(s -> config.set(BIGTABLE_HOST_KEY, s));
-    properties.getAdminEndpoint().ifPresent(s -> config.set(BIGTABLE_ADMIN_HOST_KEY, s));
+    properties.getDataEndpoint().ifPresent(endpoint -> config.set(BIGTABLE_HOST_KEY, endpoint));
+    properties
+        .getAdminEndpoint()
+        .ifPresent(endpoint -> config.set(BIGTABLE_ADMIN_HOST_KEY, endpoint));
 
     connection = BigtableConfiguration.connect(config);
 
@@ -151,10 +153,10 @@ public class CloudBigtableBeamIT {
 
     properties
         .getDataEndpoint()
-        .ifPresent(s -> configBuilder.withConfiguration(BIGTABLE_HOST_KEY, s));
+        .ifPresent(endpoint -> configBuilder.withConfiguration(BIGTABLE_HOST_KEY, endpoint));
     properties
         .getAdminEndpoint()
-        .ifPresent(s -> configBuilder.withConfiguration(BIGTABLE_ADMIN_HOST_KEY, s));
+        .ifPresent(endpoint -> configBuilder.withConfiguration(BIGTABLE_ADMIN_HOST_KEY, endpoint));
 
     CloudBigtableTableConfiguration config = configBuilder.build();
 
@@ -219,10 +221,10 @@ public class CloudBigtableBeamIT {
 
     properties
         .getDataEndpoint()
-        .ifPresent(s -> configBuilder.withConfiguration(BIGTABLE_HOST_KEY, s));
+        .ifPresent(endpoint -> configBuilder.withConfiguration(BIGTABLE_HOST_KEY, endpoint));
     properties
         .getAdminEndpoint()
-        .ifPresent(s -> configBuilder.withConfiguration(BIGTABLE_ADMIN_HOST_KEY, s));
+        .ifPresent(endpoint -> configBuilder.withConfiguration(BIGTABLE_ADMIN_HOST_KEY, endpoint));
 
     CloudBigtableScanConfiguration config = configBuilder.build();
 

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/test/java/com/google/cloud/bigtable/beam/test_env/EnvSetup.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/test/java/com/google/cloud/bigtable/beam/test_env/EnvSetup.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2021 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.beam.test_env;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.beam.runners.core.construction.Environments;
+import org.apache.beam.runners.core.construction.resources.PipelineResources;
+import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
+import org.apache.beam.runners.dataflow.util.GcsStager;
+import org.apache.beam.runners.dataflow.util.PackageUtil;
+import org.apache.beam.sdk.io.FileSystems;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.hash.HashCode;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.hash.Hashing;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.io.Files;
+
+public class EnvSetup {
+  private final TestProperties properties;
+  private static boolean isInitialized = false;
+
+  public static synchronized boolean initialize() {
+    if (!isInitialized) {
+      new EnvSetup(TestProperties.fromSystem()).run();
+      isInitialized = true;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  public EnvSetup(TestProperties properties) {
+    this.properties = properties;
+  }
+
+  public void run() {
+    // Register filesystems
+    DataflowPipelineOptions opts = PipelineOptionsFactory.as(DataflowPipelineOptions.class);
+    opts.setProject(properties.getProjectId());
+    opts.setRegion(properties.getDataflowRegion());
+    opts.setStagingLocation(properties.getDataflowStagingDir());
+    FileSystems.setDefaultPipelineOptions(opts);
+
+    // TODO: stage test/integration-test/{data,hashtable}
+    stageJars();
+  }
+
+  /**
+   * Pre-emptively upload dependencies.
+   *
+   * <p>This is an optimization to avoid having each of the parallel test threads racing to upload
+   * the same files. This implementation is based on
+   * https://github.com/apache/beam/blob/master/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/util/GCSUploadMain.java
+   */
+  private void stageJars() {
+    DataflowPipelineOptions opts = PipelineOptionsFactory.as(DataflowPipelineOptions.class);
+    opts.setProject(properties.getProjectId());
+    opts.setRegion(properties.getDataflowRegion());
+    opts.setStagingLocation(properties.getDataflowStagingDir());
+
+    List<String> files =
+        PipelineResources.detectClassPathResourcesToStage(EnvSetup.class.getClassLoader(), opts)
+            .stream()
+            .filter(p -> new File(p).exists())
+            .collect(Collectors.toList());
+    opts.setFilesToStage(files);
+
+    GcsStager.fromOptions(opts)
+        .stageFiles(
+            opts.getFilesToStage().stream()
+                .map(File::new)
+                // The real dataflow upload will zip directories. However uploading just the files
+                // will handle 90% of the upload, without introducing too much ccomplexity
+                .filter(File::isFile)
+                .map(
+                    file -> {
+                      try {
+                        HashCode hashCode = Files.asByteSource(file).hash(Hashing.sha256());
+                        return PackageUtil.StagedFile.of(
+                            file.getAbsolutePath(),
+                            hashCode.toString(),
+                            Environments.createStagingFileName(file, hashCode));
+                      } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                      }
+                    })
+                .collect(Collectors.toList()));
+  }
+}

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/test/java/com/google/cloud/bigtable/beam/test_env/TestProperties.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/test/java/com/google/cloud/bigtable/beam/test_env/TestProperties.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2021 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.beam.test_env;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
+import java.util.Optional;
+import java.util.UUID;
+import org.apache.beam.runners.dataflow.DataflowRunner;
+import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
+import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
+
+@AutoValue
+public abstract class TestProperties {
+  public abstract String getProjectId();
+
+  public abstract String getInstanceId();
+
+  public abstract String getDataflowRegion();
+
+  /**
+   * Directory that will store ephemeral data that can be re-populated but the test
+   *
+   * <p>Expected Structure:
+   *
+   * <ul>
+   *   <li>staging - dataflow staged jars
+   *   <li>workdir-${uuid} - temporary workdir directory for the a test
+   */
+  public abstract String getWorkdir();
+
+  public String getDataflowStagingDir() {
+    return ensureTrailingSlash(getWorkdir()) + "staging/";
+  }
+
+  public String getTestWorkdir(UUID testId) {
+    return ensureTrailingSlash(getWorkdir()) + "workdir-" + testId + "/";
+  }
+
+  // TODO: make this ephemeral
+  /** Contains persistent fixture data */
+  public abstract String getCloudDataDir();
+
+  public abstract Optional<String> getDataEndpoint();
+
+  public abstract Optional<String> getAdminEndpoint();
+
+  public abstract Optional<Integer> getCellSize();
+
+  public abstract Optional<Integer> getTotalRowCount();
+
+  public abstract Optional<Integer> getPrefixCount();
+
+  public static TestProperties fromSystem() {
+    // TODO: once all of the kokoro configs are updated replace this with
+    // getProp("dataflow.work-dir")
+    String workDirKey = "google.dataflow.work-dir";
+    String workDir = System.getProperty(workDirKey);
+    // backwards compat for old setup
+    if (workDir == null) {
+      workDir = System.getProperty("google.dataflow.stagingLocation");
+    }
+    Preconditions.checkNotNull(workDir, "The system property " + workDirKey + " must be specified");
+
+    return new AutoValue_TestProperties(
+        getProp("google.bigtable.project.id"),
+        getProp("google.bigtable.instance.id"),
+        getProp("region"),
+        ensureTrailingSlash(workDir),
+        ensureTrailingSlash(getProp("cloud.test.data.folder")),
+        Optional.ofNullable(System.getProperty(" google.bigtable.endpoint.host")),
+        Optional.ofNullable(System.getProperty("google.bigtable.admin.endpoint.host")),
+        Optional.ofNullable(System.getProperty("cell_size")).map(Integer::parseInt),
+        Optional.ofNullable(System.getProperty("total_row_count")).map(Integer::parseInt),
+        Optional.ofNullable(System.getProperty("prefix_count")).map(Integer::parseInt));
+  }
+
+  public void applyTo(DataflowPipelineOptions opts) {
+    opts.setRunner(DataflowRunner.class);
+    opts.setProject(getProjectId());
+    opts.setRegion(getDataflowRegion());
+    opts.setStagingLocation(getDataflowStagingDir());
+  }
+
+  public void applyTo(GcpOptions opts) {
+    opts.setRunner(DataflowRunner.class);
+    opts.setProject(getProjectId());
+  }
+
+  private static String getProp(String name) {
+    String value = System.getProperty(name);
+    Preconditions.checkNotNull(value, "The system property " + name + " must be specified");
+
+    return value;
+  }
+
+  private static String ensureTrailingSlash(String path) {
+    if (path.endsWith("/")) {
+      return path;
+    }
+    return path + "/";
+  }
+}

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/test/java/com/google/cloud/bigtable/beam/test_env/TestProperties.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/test/java/com/google/cloud/bigtable/beam/test_env/TestProperties.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.bigtable.beam.test_env;
 
-import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
 import java.util.Optional;
 import java.util.UUID;
@@ -23,13 +22,39 @@ import org.apache.beam.runners.dataflow.DataflowRunner;
 import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
 
-@AutoValue
-public abstract class TestProperties {
-  public abstract String getProjectId();
+public class TestProperties {
+  private final String projectId;
+  private final String instanceId;
+  private final String dataflowRegion;
+  private final String workdir;
+  private final String cloudDataDir;
+  private final Optional<String> dataEndpoint;
+  private final Optional<String> adminEndpoint;
 
-  public abstract String getInstanceId();
+  public TestProperties(String projectId, String instanceId, String dataflowRegion,
+      String workdir, String cloudDataDir, Optional<String> dataEndpoint,
+      Optional<String> adminEndpoint) {
+    this.projectId = projectId;
+    this.instanceId = instanceId;
+    this.dataflowRegion = dataflowRegion;
+    this.workdir = workdir;
+    this.cloudDataDir = cloudDataDir;
+    this.dataEndpoint = dataEndpoint;
+    this.adminEndpoint = adminEndpoint;
+  }
 
-  public abstract String getDataflowRegion();
+
+  public String getProjectId() {
+    return projectId;
+  }
+
+  public String getInstanceId() {
+    return instanceId;
+  }
+
+  public String getDataflowRegion() {
+    return dataflowRegion;
+  }
 
   /**
    * Directory that will store ephemeral data that can be re-populated but the test
@@ -40,7 +65,9 @@ public abstract class TestProperties {
    *   <li>staging - dataflow staged jars
    *   <li>workdir-${uuid} - temporary workdir directory for the a test
    */
-  public abstract String getWorkdir();
+  public String getWorkdir() {
+    return workdir;
+  }
 
   public String getDataflowStagingDir() {
     return ensureTrailingSlash(getWorkdir()) + "staging/";
@@ -51,18 +78,20 @@ public abstract class TestProperties {
   }
 
   // TODO: make this ephemeral
+  public String getCloudDataDir() {
+    return cloudDataDir;
+  }
+
+  public Optional<String> getDataEndpoint() {
+    return dataEndpoint;
+  }
+
+  public Optional<String> getAdminEndpoint() {
+    return adminEndpoint;
+  }
+
   /** Contains persistent fixture data */
-  public abstract String getCloudDataDir();
 
-  public abstract Optional<String> getDataEndpoint();
-
-  public abstract Optional<String> getAdminEndpoint();
-
-  public abstract Optional<Integer> getCellSize();
-
-  public abstract Optional<Integer> getTotalRowCount();
-
-  public abstract Optional<Integer> getPrefixCount();
 
   public static TestProperties fromSystem() {
     // TODO: once all of the kokoro configs are updated replace this with
@@ -75,17 +104,14 @@ public abstract class TestProperties {
     }
     Preconditions.checkNotNull(workDir, "The system property " + workDirKey + " must be specified");
 
-    return new AutoValue_TestProperties(
+    return new TestProperties(
         getProp("google.bigtable.project.id"),
         getProp("google.bigtable.instance.id"),
         getProp("region"),
         ensureTrailingSlash(workDir),
         ensureTrailingSlash(getProp("cloud.test.data.folder")),
         Optional.ofNullable(System.getProperty(" google.bigtable.endpoint.host")),
-        Optional.ofNullable(System.getProperty("google.bigtable.admin.endpoint.host")),
-        Optional.ofNullable(System.getProperty("cell_size")).map(Integer::parseInt),
-        Optional.ofNullable(System.getProperty("total_row_count")).map(Integer::parseInt),
-        Optional.ofNullable(System.getProperty("prefix_count")).map(Integer::parseInt));
+        Optional.ofNullable(System.getProperty("google.bigtable.admin.endpoint.host")));
   }
 
   public void applyTo(DataflowPipelineOptions opts) {

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/test/java/com/google/cloud/bigtable/beam/test_env/TestProperties.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/test/java/com/google/cloud/bigtable/beam/test_env/TestProperties.java
@@ -114,8 +114,8 @@ public class TestProperties {
         getProp("region"),
         ensureTrailingSlash(workDir),
         ensureTrailingSlash(getProp("cloud.test.data.folder")),
-        Optional.ofNullable(System.getProperty("google.bigtable.endpoint.host")),
-        Optional.ofNullable(System.getProperty("google.bigtable.admin.endpoint.host")));
+        Optional.ofNullable(System.getProperty(BigtableOptionsFactory.BIGTABLE_HOST_KEY)),
+        Optional.ofNullable(System.getProperty(BigtableOptionsFactory.BIGTABLE_ADMIN_HOST_KEY)));
   }
 
   public void applyTo(DataflowPipelineOptions opts) {

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/test/resources/log4j.properties
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/test/resources/log4j.properties
@@ -20,3 +20,6 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+
+# print the job url
+log4j.logger.org.apache.beam.runners.dataflow=INFO


### PR DESCRIPTION
This should significantly reduce test execution time. However it does have a negative repercussion of the log being buffered until all of the tests finish. This cuts the runtime by 50%

* run all tests in parallel threads
* pre-stage files to ensure that parallel threads aren't clobbering each other
* fix report paths
* extract all system props into a common helper
* stop using surefire for integration tests
* rename staging dir prop to be a workdir prop which can contain other ephemeral files
* allow dataflow runner to log so that job urls are logged
* update rad/write test to run in parallel and lower # of rows
