### PR TITLE
fix: retry rst stream

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
@@ -25,6 +25,7 @@ import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.cloud.bigtable.grpc.DeadlineGenerator;
 import com.google.cloud.bigtable.grpc.io.ChannelPool;
 import com.google.cloud.bigtable.grpc.scanner.BigtableRetriesExhaustedException;
+import com.google.cloud.bigtable.grpc.scanner.RetryingReadRowsOperation;
 import com.google.cloud.bigtable.metrics.Timer;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
@@ -265,7 +266,7 @@ public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
   }
 
   private boolean isRstStream(Status status) {
-    if (status.getCode() != Code.INTERNAL) {
+    if (!(this instanceof RetryingReadRowsOperation) || status.getCode() != Code.INTERNAL) {
       return false;
     }
     String description = status.getDescription();

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
@@ -203,7 +203,7 @@ public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
     String channelId = ChannelPool.extractIdentifier(trailers);
     // Non retry scenario
     if (!retryOptions.enableRetries()
-        || !(retryOptions.isRetryable(code) || isStatusRetryable(status))
+        || !isStatusRetryable(status)
         // Unauthenticated is special because the request never made it to
         // to the server, so all requests are retryable
         || !(isRequestRetryable() || code == Code.UNAUTHENTICATED || code == Code.UNAVAILABLE)) {
@@ -264,7 +264,7 @@ public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
   }
 
   protected boolean isStatusRetryable(Status status) {
-    return false;
+    return retryOptions.isRetryable(status.getCode());
   }
 
   protected void setException(Exception exception) {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperation.java
@@ -247,18 +247,17 @@ public class RetryingReadRowsOperation
   /** Read rows requests are retryable if the status is a rst stream error. */
   @Override
   protected boolean isStatusRetryable(Status status) {
-    return isRstStream(status);
+    return retryOptions.isRetryable(status.getCode()) || isRstStream(status);
   }
 
   private boolean isRstStream(Status status) {
-    if (!(this instanceof RetryingReadRowsOperation) || status.getCode() != Code.INTERNAL) {
-      return false;
-    }
-    String description = status.getDescription();
-    if (description != null) {
-      return description.contains("Received Rst stream")
-          || description.contains("RST_STREAM closed stream")
-          || description.contains("Received RST_STREAM");
+    if (status.getCode() == Code.INTERNAL) {
+      String description = status.getDescription();
+      if (description != null) {
+        return description.contains("Received Rst stream")
+            || description.contains("RST_STREAM closed stream")
+            || description.contains("Received RST_STREAM");
+      }
     }
     return false;
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperationTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/scanner/RetryingReadRowsOperationTest.java
@@ -513,6 +513,26 @@ public class RetryingReadRowsOperationTest {
     Assert.assertTrue(underTest.getRowMerger().isComplete());
   }
 
+  @Test
+  public void testRetryRstStream() throws Exception {
+    RetryingReadRowsOperation underTest = createOperation();
+    start(underTest);
+
+    ByteString key1 = ByteString.copyFrom("SomeKey1", "UTF-8");
+    ByteString key2 = ByteString.copyFrom("SomeKey2", "UTF-8");
+    underTest.onMessage(buildResponse(key1));
+    underTest.onClose(
+        Status.INTERNAL.withDescription("HTTP/2 error code: INTERNAL_ERROR\nReceived Rst stream"),
+        null);
+    Assert.assertFalse(underTest.getRowMerger().isComplete());
+    underTest.onMessage(buildResponse(key2));
+    verify(mockFlatRowObserver, times(2)).onNext(any(FlatRow.class));
+    checkRetryRequest(underTest, key2, 8);
+    verify(mockClientCall, times(4)).request(eq(1));
+
+    finishOK(underTest, 1);
+  }
+
   protected void performTimeout(RetryingReadRowsOperation underTest) {
     underTest.onClose(
         Status.CANCELLED.withCause(


### PR DESCRIPTION
This was fixed in veneer client in https://github.com/googleapis/java-bigtable/pull/586/files but not fixed in bigtable-client-core.

I also noticed different error messages: 

- "Received Rst stream"   mentioned in the original issue

- "RST_STREAM closed stream"  from b/189326784

- "Received RST_STREAM" mentioned in b/179093825

So checking all 3 cases.


Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable-hbase/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #2177  ☕️
