### PR TITLE
chore(deps): upgrade java-bigtable to 1.27.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@ limitations under the License.
     <compileSource.1.8>1.8</compileSource.1.8>
 
     <!-- core dependency versions -->
-    <bigtable.version>1.23.2</bigtable.version>
+    <bigtable.version>1.27.0</bigtable.version>
     <grpc-conscrypt.version>2.5.1</grpc-conscrypt.version>
     <!--  keeping at this version to align with hbase-->
     <slf4j.version>1.7.25</slf4j.version>


### PR DESCRIPTION
Blocked on maven central propagation 