### PR TITLE
chore(revert): revert typo fix to match 1x branch

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AbstractRetryingOperation.java
@@ -236,7 +236,7 @@ public abstract class AbstractRetryingOperation<RequestT, ResponseT, ResultT>
 
   protected BigtableRetriesExhaustedException getExhaustedRetriesException(Status status) {
     operationSpan.addAnnotation("exhaustedRetries");
-    rpc.getRpcMetrics().markRetriesExhausted();
+    rpc.getRpcMetrics().markRetriesExhasted();
     finalizeStats(status);
     String message = String.format("Exhausted retries after %d failures.", failedCount);
     return new BigtableRetriesExhaustedException(message, status.asRuntimeException());

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingMutateRowsOperation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/RetryingMutateRowsOperation.java
@@ -102,7 +102,7 @@ public class RetryingMutateRowsOperation
     Long nextBackOff = getNextBackoff();
     if (nextBackOff == null) {
       // Return the response as is, and don't retry;
-      rpc.getRpcMetrics().markRetriesExhausted();
+      rpc.getRpcMetrics().markRetriesExhasted();
       completionFuture.set(Arrays.asList(requestManager.buildResponse()));
       operationSpan.addAnnotation(
           "MutationCount",

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/metrics/MetricsApiTracerAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/metrics/MetricsApiTracerAdapter.java
@@ -85,7 +85,7 @@ public class MetricsApiTracerAdapter implements ApiTracer {
   @Override
   public void operationFailed(Throwable error) {
     if (lastRetryStatus == RetryStatus.RETRIES_EXHAUSTED) {
-      rpcMetrics.markRetriesExhausted();
+      rpcMetrics.markRetriesExhasted();
     } else {
       rpcMetrics.markFailure();
     }

--- a/bigtable-client-core-parent/bigtable-metrics-api/src/main/java/com/google/cloud/bigtable/metrics/RpcMetrics.java
+++ b/bigtable-client-core-parent/bigtable-metrics-api/src/main/java/com/google/cloud/bigtable/metrics/RpcMetrics.java
@@ -65,7 +65,7 @@ public class RpcMetrics {
     failureMeter.mark();
   }
 
-  public void markRetriesExhausted() {
+  public void markRetriesExhasted() {
     retriesExhaustedMeter.mark();
   }
 }


### PR DESCRIPTION
Original API: https://github.com/googleapis/java-bigtable-hbase/blob/bigtable-1.x/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BigtableAsyncRpc.java#L84