### PR TITLE
fix: use binary search to get region location

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableRegionLocator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableRegionLocator.java
@@ -75,10 +75,11 @@ public abstract class BigtableRegionLocator extends AbstractBigtableRegionLocato
       HRegionLocation regionLocation = regions.get(mid);
       HRegionInfo regionInfo = regionLocation.getRegionInfo();
 
-      // This isn't the last region (endKey != "") and row key is fall outside of it
+      // This isn't the last region (endKey != "") and row key is greater than the current bound
       if (regionInfo.getEndKey().length > 0 && Bytes.compareTo(row, regionInfo.getEndKey()) >= 0) {
         low = mid + 1;
       } else if (Bytes.compareTo(row, regionInfo.getStartKey()) < 0) {
+        // no need to check empty key because it will compare naturally
         high = mid - 1;
       } else {
         return regionLocation;

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableRegionLocator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableRegionLocator.java
@@ -22,6 +22,7 @@ import com.google.cloud.bigtable.core.IBigtableDataClient;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import org.apache.hadoop.hbase.HRegionInfo;
 import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.RegionLocator;
@@ -61,11 +62,29 @@ public abstract class BigtableRegionLocator extends AbstractBigtableRegionLocato
   /** {@inheritDoc} */
   @Override
   public HRegionLocation getRegionLocation(byte[] row, boolean reload) throws IOException {
-    for (HRegionLocation region : getRegions(reload)) {
-      if (region.getRegionInfo().containsRow(row)) {
-        return region;
+    List<HRegionLocation> regions = getRegions(reload);
+    return findRegion(regions, row);
+  }
+
+  private HRegionLocation findRegion(List<HRegionLocation> regions, byte[] row) throws IOException {
+    int low = 0;
+    int high = regions.size() - 1;
+
+    while (low <= high) {
+      int mid = (low + high) >>> 1;
+      HRegionLocation regionLocation = regions.get(mid);
+      HRegionInfo regionInfo = regionLocation.getRegionInfo();
+
+      // This isn't the last region (endKey != "") and row key is fall outside of it
+      if (regionInfo.getEndKey().length > 0 && Bytes.compareTo(row, regionInfo.getEndKey()) >= 0) {
+        low = mid + 1;
+      } else if (Bytes.compareTo(row, regionInfo.getStartKey()) < 0) {
+        high = mid - 1;
+      } else {
+        return regionLocation;
       }
     }
+    // Should never happen because the regions are contiguous
     throw new IOException("Region not found for row: " + Bytes.toStringBinary(row));
   }
 

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase1_x/TestBigtableConnection.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase1_x/TestBigtableConnection.java
@@ -37,6 +37,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HRegionInfo;
+import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -117,6 +118,15 @@ public class TestBigtableConnection {
 
     assertEquals("", Bytes.toString(regionInfoList.get(0).getStartKey()));
     assertEquals("rowKey", Bytes.toString(regionInfoList.get(0).getEndKey()));
+  }
+
+  @Test
+  public void testGetRegionLocation() throws IOException {
+    HRegionLocation regionLocation =
+        connection.getRegionLocator(TABLE_NAME).getRegionLocation("rowKey".getBytes());
+
+    assertEquals("rowKey", Bytes.toString(regionLocation.getRegionInfo().getStartKey()));
+    assertEquals("", Bytes.toString(regionLocation.getRegionInfo().getEndKey()));
   }
 
   private static class FakeDataService extends BigtableGrpc.BigtableImplBase {

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/pom.xml
@@ -152,10 +152,12 @@ limitations under the License.
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>grpc-google-cloud-bigtable-v2</artifactId>
+      <scope>runtime</scope>
     </dependency>
   </dependencies>
   <build>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/pom.xml
@@ -149,6 +149,16 @@ limitations under the License.
       <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>grpc-google-cloud-bigtable-v2</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/pom.xml
@@ -152,12 +152,10 @@ limitations under the License.
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>grpc-google-cloud-bigtable-v2</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/pom.xml
@@ -152,12 +152,10 @@ limitations under the License.
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>grpc-google-cloud-bigtable-v2</artifactId>
-      <scope>runtime</scope>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
Use binary search in `getRegionLocation` instead of iterating through all the regions because the keys returned by SampleRowKeys are sorted. When used in `org.apache.hadoop.hbase.mapreduce.TableInputFormatBase` (https://github.com/apache/hbase/blob/master/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableInputFormatBase.java#L316) to get splits, this can improve the performance from N^2 to Nlog(N).