### PR TITLE
chore: Wrapping local test Server starts within a retry to reduce test flakiness

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -215,6 +215,13 @@ limitations under the License.
 
     <!-- Test -->
     <dependency>
+      <groupId>com.google.cloud.bigtable</groupId>
+      <artifactId>bigtable-internal-test-helper</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <!-- bigtable-client-core uses gson for test only, however

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestAppProfile.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestAppProfile.java
@@ -34,16 +34,15 @@ import com.google.cloud.bigtable.config.CredentialOptions;
 import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.cloud.bigtable.grpc.async.BulkMutation;
 import com.google.cloud.bigtable.grpc.async.BulkRead;
+import com.google.cloud.bigtable.test.helper.TestServerBuilder;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Queues;
 import com.google.protobuf.ByteString;
 import com.google.rpc.Code;
 import com.google.rpc.Status;
 import io.grpc.Server;
-import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
@@ -65,18 +64,13 @@ public class TestAppProfile {
   public void setUp() throws IOException {
     fakeDataService = new FakeDataService();
 
-    final int port;
-    try (ServerSocket s = new ServerSocket(0)) {
-      port = s.getLocalPort();
-    }
-    server = ServerBuilder.forPort(port).addService(fakeDataService).build();
-    server.start();
+    server = TestServerBuilder.newInstance().addService(fakeDataService).buildAndStart();
 
     BigtableOptions opts =
         BigtableOptions.builder()
             .setDataHost("localhost")
             .setAdminHost("localhost")
-            .setPort(port)
+            .setPort(server.getPort())
             .setProjectId("fake-project")
             .setInstanceId("fake-instance")
             .setUserAgent("fake-agent")

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestHeaders.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestHeaders.java
@@ -146,7 +146,6 @@ public class TestHeaders {
                 ServerInterceptors.intercept(
                     new BigtableAdminExtendedImpl(), new HeaderServerInterceptor()))
             .buildAndStart();
-    server.start();
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-hbase/pom.xml
+++ b/bigtable-client-core-parent/bigtable-hbase/pom.xml
@@ -176,6 +176,12 @@ limitations under the License.
 
     <!-- Test -->
     <dependency>
+      <groupId>com.google.cloud.bigtable</groupId>
+      <artifactId>bigtable-internal-test-helper</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>grpc-google-common-protos</artifactId>
       <scope>test</scope>

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBigtableClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBigtableClassicApi.java
@@ -30,13 +30,12 @@ import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
 import com.google.cloud.bigtable.hbase.wrappers.BigtableApi;
 import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
+import com.google.cloud.bigtable.test.helper.TestServerBuilder;
 import com.google.common.collect.Queues;
 import com.google.protobuf.Empty;
 import io.grpc.Server;
-import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
@@ -59,22 +58,17 @@ public class TestBigtableClassicApi {
   private static FakeDataService fakeDataService = new FakeDataService();
   private static FakeAdminService fakeAdminService = new FakeAdminService();
   private static Server server;
-  private static int port;
 
   private BigtableHBaseSettings bigtableHBaseSettings;
   private BigtableApi bigtableApi;
 
   @BeforeClass
   public static void setUpServer() throws IOException {
-    try (ServerSocket s = new ServerSocket(0)) {
-      port = s.getLocalPort();
-    }
     server =
-        ServerBuilder.forPort(port)
+        TestServerBuilder.newInstance()
             .addService(fakeDataService)
             .addService(fakeAdminService)
-            .build();
-    server.start();
+            .buildAndStart();
   }
 
   @AfterClass
@@ -92,7 +86,7 @@ public class TestBigtableClassicApi {
     configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, TEST_INSTANCE_ID);
     configuration.set(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, "true");
     configuration.set(BigtableOptionsFactory.BIGTABLE_DATA_CHANNEL_COUNT_KEY, "1");
-    configuration.set(BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + port);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + server.getPort());
     configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_USE_GCJ_CLIENT, false);
     bigtableHBaseSettings = BigtableHBaseClassicSettings.create(configuration);
     bigtableApi = BigtableApi.create(bigtableHBaseSettings);

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBigtableClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBigtableClassicApi.java
@@ -86,7 +86,8 @@ public class TestBigtableClassicApi {
     configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, TEST_INSTANCE_ID);
     configuration.set(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, "true");
     configuration.set(BigtableOptionsFactory.BIGTABLE_DATA_CHANNEL_COUNT_KEY, "1");
-    configuration.set(BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + server.getPort());
+    configuration.set(
+        BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + server.getPort());
     configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_USE_GCJ_CLIENT, false);
     bigtableHBaseSettings = BigtableHBaseClassicSettings.create(configuration);
     bigtableApi = BigtableApi.create(bigtableHBaseSettings);

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestAdminClientVeneerApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestAdminClientVeneerApi.java
@@ -26,6 +26,7 @@ import com.google.cloud.bigtable.admin.v2.models.ModifyColumnFamiliesRequest;
 import com.google.cloud.bigtable.admin.v2.models.Table;
 import com.google.cloud.bigtable.grpc.BigtableClusterName;
 import com.google.cloud.bigtable.grpc.BigtableInstanceName;
+import com.google.cloud.bigtable.test.helper.TestServerBuilder;
 import com.google.common.collect.Queues;
 import com.google.longrunning.GetOperationRequest;
 import com.google.longrunning.Operation;
@@ -34,9 +35,7 @@ import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
 import io.grpc.Server;
-import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
-import java.net.ServerSocket;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
@@ -75,20 +74,14 @@ public class TestAdminClientVeneerApi {
 
   @Before
   public void setUp() throws Exception {
-    final int port;
-    try (ServerSocket serverSocket = new ServerSocket(0)) {
-      port = serverSocket.getLocalPort();
-    }
-
     server =
-        ServerBuilder.forPort(port)
+        TestServerBuilder.newInstance()
             .addService(fakeOperationsGrpc)
             .addService(fakeAdminService)
-            .build();
-    server.start();
+            .buildAndStart();
     adminClientV2 =
         BigtableTableAdminClient.create(
-            BigtableTableAdminSettings.newBuilderForEmulator(port)
+            BigtableTableAdminSettings.newBuilderForEmulator(server.getPort())
                 .setProjectId(PROJECT_ID)
                 .setInstanceId(INSTANCE_ID)
                 .build());

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBigtableHBaseVeneerSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBigtableHBaseVeneerSettings.java
@@ -395,7 +395,8 @@ public class TestBigtableHBaseVeneerSettings {
 
   @Test
   public void testDataSettingsWithEmulator() throws IOException {
-    // A real port isn't required for this test; only verifying the configs can be stored and retrieved.
+    // A real port isn't required for this test; only verifying the configs can be stored and
+    // retrieved.
     final int availablePort = 987654321;
     String emulatorHost = "localhost:" + availablePort;
     configuration.set(BIGTABLE_EMULATOR_HOST_KEY, emulatorHost);
@@ -411,7 +412,8 @@ public class TestBigtableHBaseVeneerSettings {
 
   @Test
   public void testAdminSettingsWithEmulator() throws IOException {
-    // A real port isn't required for this test; only verifying the configs can be stored and retrieved.
+    // A real port isn't required for this test; only verifying the configs can be stored and
+    // retrieved.
     final int availablePort = 987654321;
     String emulatorHost = "localhost:" + availablePort;
     configuration.set(BIGTABLE_EMULATOR_HOST_KEY, emulatorHost);

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBigtableHBaseVeneerSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBigtableHBaseVeneerSettings.java
@@ -67,7 +67,6 @@ import com.google.cloud.bigtable.hbase.wrappers.veneer.metrics.MetricsApiTracerA
 import com.google.common.base.Optional;
 import io.grpc.internal.GrpcUtil;
 import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Before;
@@ -396,9 +395,8 @@ public class TestBigtableHBaseVeneerSettings {
 
   @Test
   public void testDataSettingsWithEmulator() throws IOException {
-    ServerSocket serverSocket = new ServerSocket(0);
-    final int availablePort = serverSocket.getLocalPort();
-    serverSocket.close();
+    // A real port isn't required for this test; only verifying the configs can be stored and retrieved.
+    final int availablePort = 987654321;
     String emulatorHost = "localhost:" + availablePort;
     configuration.set(BIGTABLE_EMULATOR_HOST_KEY, emulatorHost);
 
@@ -413,9 +411,8 @@ public class TestBigtableHBaseVeneerSettings {
 
   @Test
   public void testAdminSettingsWithEmulator() throws IOException {
-    ServerSocket serverSocket = new ServerSocket(0);
-    final int availablePort = serverSocket.getLocalPort();
-    serverSocket.close();
+    // A real port isn't required for this test; only verifying the configs can be stored and retrieved.
+    final int availablePort = 987654321;
     String emulatorHost = "localhost:" + availablePort;
     configuration.set(BIGTABLE_EMULATOR_HOST_KEY, emulatorHost);
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBigtableVeneerApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBigtableVeneerApi.java
@@ -72,7 +72,8 @@ public class TestBigtableVeneerApi {
     configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, TEST_INSTANCE_ID);
     configuration.set(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, "true");
     configuration.set(BigtableOptionsFactory.BIGTABLE_DATA_CHANNEL_COUNT_KEY, "1");
-    configuration.set(BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + server.getPort());
+    configuration.set(
+        BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + server.getPort());
     configuration.set(BigtableOptionsFactory.BIGTABLE_USE_GCJ_CLIENT, "true");
     bigtableHBaseSettings = BigtableHBaseClassicSettings.create(configuration);
     bigtableApi = BigtableApi.create(bigtableHBaseSettings);

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBulkReadVeneerApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBulkReadVeneerApi.java
@@ -29,12 +29,11 @@ import com.google.cloud.bigtable.data.v2.BigtableDataClient;
 import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
 import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.cloud.bigtable.hbase.wrappers.BulkReadWrapper;
+import com.google.cloud.bigtable.test.helper.TestServerBuilder;
 import com.google.protobuf.ByteString;
 import io.grpc.Server;
-import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -58,17 +57,11 @@ public class TestBulkReadVeneerApi {
 
   @Before
   public void setUp() throws IOException {
-    final int port;
-    try (ServerSocket s = new ServerSocket(0)) {
-      port = s.getLocalPort();
-    }
-
     fakeDataService = new FakeDataService();
-    server = ServerBuilder.forPort(port).addService(fakeDataService).build();
-    server.start();
+    server = TestServerBuilder.newInstance().addService(fakeDataService).buildAndStart();
 
     settingsBuilder =
-        BigtableDataSettings.newBuilderForEmulator(port)
+        BigtableDataSettings.newBuilderForEmulator(server.getPort())
             .setProjectId("fake-project")
             .setInstanceId("fake-instance");
   }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/org/apache/hadoop/hbase/client/TestAbstractBigtableConnection.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/org/apache/hadoop/hbase/client/TestAbstractBigtableConnection.java
@@ -107,7 +107,8 @@ public class TestAbstractBigtableConnection {
     configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, INSTANCE_ID);
     configuration.set(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, "true");
     configuration.set(BigtableOptionsFactory.BIGTABLE_DATA_CHANNEL_COUNT_KEY, "1");
-    configuration.set(BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, HOST_NAME + ":" + server.getPort());
+    configuration.set(
+        BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, HOST_NAME + ":" + server.getPort());
     connection = new TestBigtableConnectionImpl(configuration);
   }
 
@@ -125,7 +126,8 @@ public class TestAbstractBigtableConnection {
     assertEquals(regionInfo, connection.getAllRegionInfos(TABLE_NAME).get(0));
 
     List<HRegionLocation> expectedRegionLocations =
-        ImmutableList.of(new HRegionLocation(regionInfo, ServerName.valueOf(HOST_NAME, server.getPort(), 0)));
+        ImmutableList.of(
+            new HRegionLocation(regionInfo, ServerName.valueOf(HOST_NAME, server.getPort(), 0)));
 
     when(mockSampledAdapter.adaptResponse(Mockito.<List<KeyOffset>>any()))
         .thenReturn(expectedRegionLocations);

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/org/apache/hadoop/hbase/client/TestAbstractBigtableConnection.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/org/apache/hadoop/hbase/client/TestAbstractBigtableConnection.java
@@ -33,13 +33,13 @@ import com.google.cloud.bigtable.hbase.AbstractBigtableTable;
 import com.google.cloud.bigtable.hbase.BigtableHBaseVersion;
 import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
 import com.google.cloud.bigtable.hbase.adapters.SampledRowKeysAdapter;
+import com.google.cloud.bigtable.test.helper.TestServerBuilder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Queues;
 import com.google.common.truth.Truth;
 import io.grpc.Metadata;
 import io.grpc.Metadata.Key;
 import io.grpc.Server;
-import io.grpc.ServerBuilder;
 import io.grpc.ServerCall;
 import io.grpc.ServerCall.Listener;
 import io.grpc.ServerCallHandler;
@@ -47,7 +47,6 @@ import io.grpc.ServerInterceptor;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
@@ -86,7 +85,6 @@ public class TestAbstractBigtableConnection {
   private static final FakeDataService fakeDataService = new FakeDataService();
 
   private static Server server;
-  private static int port;
   private ServerHeaderInterceptor headerInterceptor;
 
   @Mock private AbstractBigtableAdmin mockBigtableAdmin;
@@ -97,23 +95,19 @@ public class TestAbstractBigtableConnection {
 
   @Before
   public void setUp() throws IOException {
-    try (ServerSocket s = new ServerSocket(0)) {
-      port = s.getLocalPort();
-    }
     headerInterceptor = new ServerHeaderInterceptor();
     server =
-        ServerBuilder.forPort(port)
+        TestServerBuilder.newInstance()
             .intercept(headerInterceptor)
             .addService(fakeDataService)
-            .build();
-    server.start();
+            .buildAndStart();
 
     Configuration configuration = new Configuration(false);
     configuration.set(BigtableOptionsFactory.PROJECT_ID_KEY, PROJECT_ID);
     configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, INSTANCE_ID);
     configuration.set(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, "true");
     configuration.set(BigtableOptionsFactory.BIGTABLE_DATA_CHANNEL_COUNT_KEY, "1");
-    configuration.set(BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, HOST_NAME + ":" + port);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, HOST_NAME + ":" + server.getPort());
     connection = new TestBigtableConnectionImpl(configuration);
   }
 
@@ -131,7 +125,7 @@ public class TestAbstractBigtableConnection {
     assertEquals(regionInfo, connection.getAllRegionInfos(TABLE_NAME).get(0));
 
     List<HRegionLocation> expectedRegionLocations =
-        ImmutableList.of(new HRegionLocation(regionInfo, ServerName.valueOf(HOST_NAME, port, 0)));
+        ImmutableList.of(new HRegionLocation(regionInfo, ServerName.valueOf(HOST_NAME, server.getPort(), 0)));
 
     when(mockSampledAdapter.adaptResponse(Mockito.<List<KeyOffset>>any()))
         .thenReturn(expectedRegionLocations);

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
@@ -249,6 +249,12 @@ limitations under the License.
       </exclusions>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.cloud.bigtable</groupId>
+      <artifactId>bigtable-internal-test-helper</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
 
     <!-- java-bigtable Modules -->
     <dependency>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestRpcRetryBehavior.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestRpcRetryBehavior.java
@@ -32,14 +32,13 @@ import com.google.bigtable.v2.ReadModifyWriteRowResponse;
 import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.v2.ReadRowsResponse;
 import com.google.cloud.bigtable.config.Logger;
+import com.google.cloud.bigtable.test.helper.TestServerBuilder;
 import com.google.common.collect.ImmutableMap;
 import io.grpc.Server;
-import io.grpc.ServerBuilder;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.lang.time.StopWatch;
@@ -222,12 +221,7 @@ public abstract class TestRpcRetryBehavior {
     final BigtableGrpc.BigtableImplBase rpcBase = setupRpcCall();
     BigtableGrpc.BigtableImplBase rpcSleepWrapper = setupRpcServerWithSleepHandler(rpcBase);
 
-    int portNum;
-    try (ServerSocket ss = new ServerSocket(0)) {
-      portNum = ss.getLocalPort();
-    }
-    Server fakeBigtableServer = ServerBuilder.forPort(portNum).addService(rpcSleepWrapper).build();
-    fakeBigtableServer.start();
+    Server fakeBigtableServer = TestServerBuilder.newInstance().addService(rpcSleepWrapper).buildAndStart();
     return fakeBigtableServer;
   }
 

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestRpcRetryBehavior.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestRpcRetryBehavior.java
@@ -221,7 +221,8 @@ public abstract class TestRpcRetryBehavior {
     final BigtableGrpc.BigtableImplBase rpcBase = setupRpcCall();
     BigtableGrpc.BigtableImplBase rpcSleepWrapper = setupRpcServerWithSleepHandler(rpcBase);
 
-    Server fakeBigtableServer = TestServerBuilder.newInstance().addService(rpcSleepWrapper).buildAndStart();
+    Server fakeBigtableServer =
+        TestServerBuilder.newInstance().addService(rpcSleepWrapper).buildAndStart();
     return fakeBigtableServer;
   }
 

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/pom.xml
@@ -149,6 +149,12 @@ limitations under the License.
 
     <!-- Test dependencies-->
     <dependency>
+      <groupId>com.google.cloud.bigtable</groupId>
+      <artifactId>bigtable-internal-test-helper</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
       <version>1.1.2</version>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase1_x/BigtableAdminTest.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase1_x/BigtableAdminTest.java
@@ -22,11 +22,11 @@ import com.google.bigtable.admin.v2.BigtableTableAdminGrpc;
 import com.google.bigtable.admin.v2.DropRowRangeRequest;
 import com.google.cloud.bigtable.hbase.BigtableConfiguration;
 import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
+import com.google.cloud.bigtable.test.helper.TestServerBuilder;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
 import io.grpc.*;
 import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.concurrent.ArrayBlockingQueue;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.ClusterStatus;
@@ -54,21 +54,14 @@ public class BigtableAdminTest {
 
   @Before
   public void setup() throws Exception {
-    final int port;
-
-    try (ServerSocket serverSocket = new ServerSocket(0)) {
-      port = serverSocket.getLocalPort();
-    }
-
     fakeBigtableServer =
-        ServerBuilder.forPort(port)
+        TestServerBuilder.newInstance()
             .intercept(new RequestInterceptor())
             .addService(new BigtableTableAdminGrpc.BigtableTableAdminImplBase() {})
-            .build();
-    fakeBigtableServer.start();
+            .buildAndStart();
 
     Configuration configuration = BigtableConfiguration.configure(PROJECT_ID, INSTANCE_ID);
-    configuration.set(BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + port);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + fakeBigtableServer.getPort());
     connection = new BigtableConnection(configuration);
     admin = (BigtableAdmin) connection.getAdmin();
   }

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase1_x/BigtableAdminTest.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase1_x/BigtableAdminTest.java
@@ -61,7 +61,9 @@ public class BigtableAdminTest {
             .buildAndStart();
 
     Configuration configuration = BigtableConfiguration.configure(PROJECT_ID, INSTANCE_ID);
-    configuration.set(BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + fakeBigtableServer.getPort());
+    configuration.set(
+        BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY,
+        "localhost:" + fakeBigtableServer.getPort());
     connection = new BigtableConnection(configuration);
     admin = (BigtableAdmin) connection.getAdmin();
   }

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase1_x/TestBigtableAdmin.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase1_x/TestBigtableAdmin.java
@@ -22,17 +22,16 @@ import com.google.bigtable.admin.v2.BigtableTableAdminGrpc;
 import com.google.bigtable.admin.v2.DropRowRangeRequest;
 import com.google.cloud.bigtable.hbase.BigtableConfiguration;
 import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
+import com.google.cloud.bigtable.test.helper.TestServerBuilder;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
 import io.grpc.Metadata;
 import io.grpc.Server;
-import io.grpc.ServerBuilder;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
 import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.concurrent.ArrayBlockingQueue;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.ClusterStatus;
@@ -61,21 +60,14 @@ public class TestBigtableAdmin {
 
   @Before
   public void setup() throws Exception {
-    final int port;
-
-    try (ServerSocket serverSocket = new ServerSocket(0)) {
-      port = serverSocket.getLocalPort();
-    }
-
     fakeBigtableServer =
-        ServerBuilder.forPort(port)
+        TestServerBuilder.newInstance()
             .intercept(new RequestInterceptor())
             .addService(new BigtableTableAdminGrpc.BigtableTableAdminImplBase() {})
-            .build();
-    fakeBigtableServer.start();
+            .buildAndStart();
 
     Configuration configuration = BigtableConfiguration.configure(PROJECT_ID, INSTANCE_ID);
-    configuration.set(BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + port);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + fakeBigtableServer.getPort());
     connection = new BigtableConnection(configuration);
     admin = (BigtableAdmin) connection.getAdmin();
   }

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase1_x/TestBigtableAdmin.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase1_x/TestBigtableAdmin.java
@@ -67,7 +67,9 @@ public class TestBigtableAdmin {
             .buildAndStart();
 
     Configuration configuration = BigtableConfiguration.configure(PROJECT_ID, INSTANCE_ID);
-    configuration.set(BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + fakeBigtableServer.getPort());
+    configuration.set(
+        BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY,
+        "localhost:" + fakeBigtableServer.getPort());
     connection = new BigtableConnection(configuration);
     admin = (BigtableAdmin) connection.getAdmin();
   }

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase1_x/TestBigtableConnection.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase1_x/TestBigtableConnection.java
@@ -80,7 +80,8 @@ public class TestBigtableConnection {
     configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, TEST_INSTANCE_ID);
     configuration.set(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, "true");
     configuration.set(BigtableOptionsFactory.BIGTABLE_DATA_CHANNEL_COUNT_KEY, "1");
-    configuration.set(BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + server.getPort());
+    configuration.set(
+        BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + server.getPort());
     connection = new BigtableConnection(configuration);
   }
 

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase1_x/TestBigtableConnection.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase1_x/TestBigtableConnection.java
@@ -24,13 +24,12 @@ import com.google.bigtable.v2.SampleRowKeysResponse;
 import com.google.cloud.bigtable.data.v2.internal.NameUtil;
 import com.google.cloud.bigtable.hbase.AbstractBigtableTable;
 import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
+import com.google.cloud.bigtable.test.helper.TestServerBuilder;
 import com.google.common.collect.Queues;
 import com.google.protobuf.ByteString;
 import io.grpc.Server;
-import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Executors;
@@ -56,7 +55,6 @@ public class TestBigtableConnection {
   private static final String FULL_TABLE_NAME =
       NameUtil.formatTableName(TEST_PROJECT_ID, TEST_INSTANCE_ID, TABLE_NAME.getNameAsString());
   private static Server server;
-  private static int dataPort;
 
   private static FakeDataService fakeDataService = new FakeDataService();
   private Configuration configuration;
@@ -64,11 +62,7 @@ public class TestBigtableConnection {
 
   @BeforeClass
   public static void setUpServer() throws IOException {
-    try (ServerSocket s = new ServerSocket(0)) {
-      dataPort = s.getLocalPort();
-    }
-    server = ServerBuilder.forPort(dataPort).addService(fakeDataService).build();
-    server.start();
+    server = TestServerBuilder.newInstance().addService(fakeDataService).buildAndStart();
   }
 
   @AfterClass
@@ -86,7 +80,7 @@ public class TestBigtableConnection {
     configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, TEST_INSTANCE_ID);
     configuration.set(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, "true");
     configuration.set(BigtableOptionsFactory.BIGTABLE_DATA_CHANNEL_COUNT_KEY, "1");
-    configuration.set(BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + dataPort);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + server.getPort());
     connection = new BigtableConnection(configuration);
   }
 

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase1_x/TestMetrics.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase1_x/TestMetrics.java
@@ -105,7 +105,8 @@ public class TestMetrics {
     configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, TEST_INSTANCE_ID);
     configuration.set(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, "true");
     configuration.set(BigtableOptionsFactory.BIGTABLE_DATA_CHANNEL_COUNT_KEY, "1");
-    configuration.set(BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + server.getPort());
+    configuration.set(
+        BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + server.getPort());
     configuration.set(BigtableOptionsFactory.BIGTABLE_USE_GCJ_CLIENT, "true");
 
     fakeMetricRegistry = new FakeMetricRegistry();

--- a/bigtable-test/bigtable-internal-test-helper/pom.xml
+++ b/bigtable-test/bigtable-internal-test-helper/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>bigtable-test</artifactId>
+        <groupId>com.google.cloud.bigtable</groupId>
+        <version>2.0.0-alpha-1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>bigtable-internal-test-helper</artifactId>
+    <description>
+        Module with helper code for Bigtable unit and integration tests.
+        Not intended to be shared with external users.
+    </description>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>google-cloud-bigtable-bom</artifactId>
+                <version>${bigtable.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>google-cloud-bigtable-deps-bom</artifactId>
+                <version>${bigtable.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-api</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <!-- Start Skip publishing -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>3.0.0-M1</version>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <configuration>
+                        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <configuration>
+                        <skipDeploy>true</skipDeploy>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <configuration>
+                        <skipSource>true</skipSource>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>clirr-maven-plugin</artifactId>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>
+                <!-- End Skip publishing -->
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/bigtable-test/bigtable-internal-test-helper/pom.xml
+++ b/bigtable-test/bigtable-internal-test-helper/pom.xml
@@ -15,11 +15,6 @@
         Not intended to be shared with external users.
     </description>
 
-    <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-    </properties>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/bigtable-test/bigtable-internal-test-helper/src/main/java/com/google/cloud/bigtable/test/helper/TestServerBuilder.java
+++ b/bigtable-test/bigtable-internal-test-helper/src/main/java/com/google/cloud/bigtable/test/helper/TestServerBuilder.java
@@ -20,7 +20,6 @@ import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerInterceptor;
 import io.grpc.ServerServiceDefinition;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.ServerSocket;
@@ -28,12 +27,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Wrapper around {@link ServerBuilder} that automatically finds a free port when starting the service.
+ * Wrapper around {@link ServerBuilder} that automatically finds a free port when starting the
+ * service.
  *
- * This wraps the call for getting a random free port (e.g. ServerSocket ss = new ServerSocket(0)) into a
- * retry, since it is possible for another process on the host to use the port before the caller of the
- * method can. Though it does not happen often, it happens enough to cause noticeable test flakes. Retrying
- * the call will minimize the flakes.
+ * <p>This wraps the call for getting a random free port (e.g. ServerSocket ss = new
+ * ServerSocket(0)) into a retry, since it is possible for another process on the host to use the
+ * port before the caller of the method can. Though it does not happen often, it happens enough to
+ * cause noticeable test flakes. Retrying the call will minimize the flakes.
  */
 public class TestServerBuilder {
   private List<BindableService> services = new ArrayList<>();
@@ -48,33 +48,25 @@ public class TestServerBuilder {
 
   private TestServerBuilder() {}
 
-  /**
-   * See {@link ServerBuilder#addService(BindableService)}.
-   */
+  /** See {@link ServerBuilder#addService(BindableService)}. */
   public TestServerBuilder addService(BindableService service) {
     services.add(service);
     return this;
   }
 
-  /**
-   * See {@link ServerBuilder#addService(ServerServiceDefinition)}.
-   */
+  /** See {@link ServerBuilder#addService(ServerServiceDefinition)}. */
   public TestServerBuilder addService(ServerServiceDefinition serverServiceDefinition) {
     serverServiceDefinitions.add(serverServiceDefinition);
     return this;
   }
 
-  /**
-   * See {@link ServerBuilder#intercept(ServerInterceptor)}.
-   */
+  /** See {@link ServerBuilder#intercept(ServerInterceptor)}. */
   public TestServerBuilder intercept(ServerInterceptor interceptor) {
     interceptors.add(interceptor);
     return this;
   }
 
-  /**
-   * See {@link ServerBuilder#useTransportSecurity(File, File)}.
-   */
+  /** See {@link ServerBuilder#useTransportSecurity(File, File)}. */
   public TestServerBuilder useTransportSecurity(File certChain, File privateKey) {
     this.certChain = certChain;
     this.privateKey = privateKey;
@@ -123,6 +115,7 @@ public class TestServerBuilder {
         lastError = e;
       }
     }
+
     throw lastError;
   }
 }

--- a/bigtable-test/bigtable-internal-test-helper/src/main/java/com/google/cloud/bigtable/test/helper/TestServerBuilder.java
+++ b/bigtable-test/bigtable-internal-test-helper/src/main/java/com/google/cloud/bigtable/test/helper/TestServerBuilder.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.test.helper;
+
+import io.grpc.BindableService;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.ServerInterceptor;
+import io.grpc.ServerServiceDefinition;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Wrapper around {@link ServerBuilder} that automatically finds a free port when starting the service.
+ *
+ * This wraps the call for getting a random free port (e.g. ServerSocket ss = new ServerSocket(0)) into a
+ * retry, since it is possible for another process on the host to use the port before the caller of the
+ * method can. Though it does not happen often, it happens enough to cause noticeable test flakes. Retrying
+ * the call will minimize the flakes.
+ */
+public class TestServerBuilder {
+  private List<BindableService> services = new ArrayList<>();
+  private List<ServerServiceDefinition> serverServiceDefinitions = new ArrayList<>();
+  private List<ServerInterceptor> interceptors = new ArrayList<>();
+  private File certChain = null;
+  private File privateKey = null;
+
+  public static TestServerBuilder newInstance() {
+    return new TestServerBuilder();
+  }
+
+  private TestServerBuilder() {}
+
+  /**
+   * See {@link ServerBuilder#addService(BindableService)}.
+   */
+  public TestServerBuilder addService(BindableService service) {
+    services.add(service);
+    return this;
+  }
+
+  /**
+   * See {@link ServerBuilder#addService(ServerServiceDefinition)}.
+   */
+  public TestServerBuilder addService(ServerServiceDefinition serverServiceDefinition) {
+    serverServiceDefinitions.add(serverServiceDefinition);
+    return this;
+  }
+
+  /**
+   * See {@link ServerBuilder#intercept(ServerInterceptor)}.
+   */
+  public TestServerBuilder intercept(ServerInterceptor interceptor) {
+    interceptors.add(interceptor);
+    return this;
+  }
+
+  /**
+   * See {@link ServerBuilder#useTransportSecurity(File, File)}.
+   */
+  public TestServerBuilder useTransportSecurity(File certChain, File privateKey) {
+    this.certChain = certChain;
+    this.privateKey = privateKey;
+    return this;
+  }
+
+  private Server buildServer(int port) {
+    ServerBuilder<?> builder = ServerBuilder.forPort(port);
+
+    for (BindableService service : services) {
+      builder.addService(service);
+    }
+    for (ServerServiceDefinition serverServiceDefinition : serverServiceDefinitions) {
+      builder.addService(serverServiceDefinition);
+    }
+    for (ServerInterceptor interceptor : interceptors) {
+      builder.intercept(interceptor);
+    }
+
+    if (certChain != null || privateKey != null) {
+      builder.useTransportSecurity(certChain, privateKey);
+    }
+    return builder.build();
+  }
+
+  /**
+   * Gets a free port on the host and starts the server, retrying in case the start fails (notably
+   * if the port is no longer available).
+   */
+  public Server buildAndStart() throws IOException {
+    IOException lastError = null;
+
+    int maxRetries = 3;
+    for (int retry = 0; retry < maxRetries; retry++) {
+      int port;
+      try (ServerSocket ss = new ServerSocket(0)) {
+        port = ss.getLocalPort();
+      }
+
+      Server server = buildServer(port);
+      try {
+        server.start();
+        return server;
+      } catch (IOException e) {
+        server.shutdown();
+        lastError = e;
+      }
+    }
+    throw lastError;
+  }
+}

--- a/bigtable-test/pom.xml
+++ b/bigtable-test/pom.xml
@@ -33,5 +33,6 @@ limitations under the License.
   <modules>
     <module>bigtable-emulator-maven-plugin</module>
     <module>bigtable-build-helper</module>
+    <module>bigtable-internal-test-helper</module>
   </modules>
 </project>


### PR DESCRIPTION
Code areas to review:

1) TestServerBuilder (though the final location (which module, test vs main) are TBD
2) All the test changes that remove the "new ServerSocket(0)" call and move to TestServerBuilder
3) One test calls "new ServerSocket(0)" unnecessarily (see TestBigtableHBaseVeneerSettings). I just specify a number there now.