### PR TITLE
fix: use binary search in async region locator

### DIFF
--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTableRegionLocator.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTableRegionLocator.java
@@ -22,12 +22,14 @@ import com.google.cloud.bigtable.hbase.AbstractBigtableRegionLocator;
 import com.google.cloud.bigtable.hbase.adapters.SampledRowKeysAdapter;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import org.apache.hadoop.hbase.HRegionInfo;
 import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.AsyncTableRegionLocator;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.RegionInfoBuilder;
+import org.apache.hadoop.hbase.util.Bytes;
 
 /**
  * Bigtable implementation of {@link AsyncTableRegionLocator}
@@ -37,7 +39,6 @@ import org.apache.hadoop.hbase.client.RegionInfoBuilder;
 @InternalApi("For internal usage only")
 public class BigtableAsyncTableRegionLocator extends AbstractBigtableRegionLocator
     implements AsyncTableRegionLocator {
-  HRegionLocation hRegionLocation = null;
 
   public BigtableAsyncTableRegionLocator(
       TableName tableName, BigtableOptions options, IBigtableDataClient client) {
@@ -52,16 +53,30 @@ public class BigtableAsyncTableRegionLocator extends AbstractBigtableRegionLocat
   @Override
   public CompletableFuture<HRegionLocation> getRegionLocation(byte[] row, boolean reload) {
     return FutureUtils.toCompletableFuture(getRegionsAsync(reload))
-        .thenApplyAsync(
-            result -> {
-              for (HRegionLocation region : result) {
-                if (region.getRegion().containsRow(row)) {
-                  hRegionLocation = region;
-                  break;
-                }
-              }
-              return hRegionLocation;
-            });
+        .thenApplyAsync(result -> findRegion(result, row));
+  }
+
+  private HRegionLocation findRegion(List<HRegionLocation> regions, byte[] row) {
+    int low = 0;
+    int high = regions.size() - 1;
+
+    while (low <= high) {
+      int mid = (low + high) >>> 1;
+      HRegionLocation regionLocation = regions.get(mid);
+      HRegionInfo regionInfo = regionLocation.getRegionInfo();
+
+      // This isn't the last region (endKey != "") and row key is greater than the current bound
+      if (regionInfo.getEndKey().length > 0 && Bytes.compareTo(row, regionInfo.getEndKey()) >= 0) {
+        low = mid + 1;
+      } else if (Bytes.compareTo(row, regionInfo.getStartKey()) < 0) {
+        // no need to check empty key because it will compare naturally
+        high = mid - 1;
+      } else {
+        return regionLocation;
+      }
+    }
+    // Should never happen because the regions are contiguous
+    return null;
   }
 
   @Override

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTableRegionLocator.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTableRegionLocator.java
@@ -22,7 +22,6 @@ import com.google.cloud.bigtable.hbase.AbstractBigtableRegionLocator;
 import com.google.cloud.bigtable.hbase.adapters.SampledRowKeysAdapter;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import org.apache.hadoop.hbase.HRegionInfo;
 import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.TableName;
@@ -63,7 +62,10 @@ public class BigtableAsyncTableRegionLocator extends AbstractBigtableRegionLocat
     while (low <= high) {
       int mid = (low + high) >>> 1;
       HRegionLocation regionLocation = regions.get(mid);
-      HRegionInfo regionInfo = regionLocation.getRegionInfo();
+      // TODO 2.x deprecated getRegionInfo() and returns a RegionInfo class instead of HRegionInfo.
+      // We could move this
+      // method to AbstractBigtableRegionLocator after making sure there's no compatibility issues.
+      RegionInfo regionInfo = regionLocation.getRegion();
 
       // This isn't the last region (endKey != "") and row key is greater than the current bound
       if (regionInfo.getEndKey().length > 0 && Bytes.compareTo(row, regionInfo.getEndKey()) >= 0) {

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTableRegionLocator.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTableRegionLocator.java
@@ -63,8 +63,8 @@ public class BigtableAsyncTableRegionLocator extends AbstractBigtableRegionLocat
       int mid = (low + high) >>> 1;
       HRegionLocation regionLocation = regions.get(mid);
       // TODO 2.x deprecated getRegionInfo() and returns a RegionInfo class instead of HRegionInfo.
-      // We could move this
-      // method to AbstractBigtableRegionLocator after making sure there's no compatibility issues.
+      // We could move this method to AbstractBigtableRegionLocator after making sure there's no
+      // compatibility issues.
       RegionInfo regionInfo = regionLocation.getRegion();
 
       // This isn't the last region (endKey != "") and row key is greater than the current bound

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase2_x/TestBigtableAsyncTableRegionLocator.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase2_x/TestBigtableAsyncTableRegionLocator.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase2_x;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import com.google.api.core.ApiFutures;
+import com.google.cloud.bigtable.core.IBigtableDataClient;
+import com.google.cloud.bigtable.data.v2.models.KeyOffset;
+import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HRegionLocation;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@RunWith(JUnit4.class)
+public class TestBigtableAsyncTableRegionLocator {
+
+  @Rule public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  private static final TableName TABLE_NAME = TableName.valueOf("fake-table-name");
+
+  @Mock private IBigtableDataClient mockDataClient;
+
+  private BigtableAsyncTableRegionLocator regionLocator;
+
+  @Before
+  public void setUp() throws IOException {
+    Configuration configuration = new Configuration(false);
+    configuration.set(BigtableOptionsFactory.PROJECT_ID_KEY, "fake-project-id");
+    configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, "fake-instance-id");
+    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, "localhost");
+    configuration.set(BigtableOptionsFactory.BIGTABLE_ADMIN_HOST_KEY, "localhost");
+    configuration.set(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, "true");
+    configuration.set(BigtableOptionsFactory.BIGTABLE_DATA_CHANNEL_COUNT_KEY, "1");
+    regionLocator =
+        new BigtableAsyncTableRegionLocator(
+            TABLE_NAME, BigtableOptionsFactory.fromConfiguration(configuration), mockDataClient);
+  }
+
+  @Test
+  public void testGetRegionLocation() throws ExecutionException, InterruptedException {
+    List<KeyOffset> keyOffsets =
+        ImmutableList.of(
+            KeyOffset.create(ByteString.copyFromUtf8("a"), 100L),
+            KeyOffset.create(ByteString.copyFromUtf8("b"), 100L),
+            KeyOffset.create(ByteString.copyFromUtf8("y"), 100L),
+            KeyOffset.create(ByteString.copyFromUtf8("z"), 100L));
+    when(mockDataClient.sampleRowKeysAsync(TABLE_NAME.getNameAsString()))
+        .thenReturn(ApiFutures.immediateFuture(keyOffsets));
+
+    HRegionLocation regionLocationFuture =
+        regionLocator.getRegionLocation(Bytes.toBytes("rowKey"), 1, false).get();
+    assertEquals("b", Bytes.toString(regionLocationFuture.getRegion().getStartKey()));
+    assertEquals("y", Bytes.toString(regionLocationFuture.getRegion().getEndKey()));
+
+    assertEquals(TABLE_NAME, regionLocator.getName());
+
+    regionLocationFuture = regionLocator.getRegionLocation(Bytes.toBytes("1")).get();
+    assertEquals("", Bytes.toString(regionLocationFuture.getRegion().getStartKey()));
+    assertEquals("a", Bytes.toString(regionLocationFuture.getRegion().getEndKey()));
+
+    regionLocationFuture = regionLocator.getRegionLocation(Bytes.toBytes("a")).get();
+    assertEquals("a", Bytes.toString(regionLocationFuture.getRegion().getStartKey()));
+    assertEquals("b", Bytes.toString(regionLocationFuture.getRegion().getEndKey()));
+
+    regionLocationFuture = regionLocator.getRegionLocation(Bytes.toBytes("z")).get();
+    assertEquals("z", Bytes.toString(regionLocationFuture.getRegion().getStartKey()));
+    assertEquals("", Bytes.toString(regionLocationFuture.getRegion().getEndKey()));
+
+    regionLocationFuture = regionLocator.getRegionLocation(Bytes.toBytes("zzz")).get();
+    assertEquals("z", Bytes.toString(regionLocationFuture.getRegion().getStartKey()));
+    assertEquals("", Bytes.toString(regionLocationFuture.getRegion().getEndKey()));
+  }
+}


### PR DESCRIPTION
Use binary search in async region locator similar to https://github.com/googleapis/java-bigtable-hbase/pull/3040