### PR TITLE
feat: Add support for renaming tables in schema translator

### DIFF
--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/pom.xml
@@ -41,10 +41,6 @@
           <groupId>io.opencensus</groupId>
           <artifactId>*</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>io.grpc</groupId>
-          <artifactId>grpc-census</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -131,8 +127,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>8</source>
-          <target>8</target>
+          <source>${compileSource.1.8}</source>
+          <target>${compileSource.1.8}</target>
         </configuration>
       </plugin>
     </plugins>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/pom.xml
@@ -127,6 +127,14 @@
           <target>${compileSource.1.8}</target>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>8</source>
+          <target>8</target>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/pom.xml
@@ -41,6 +41,10 @@
           <groupId>io.opencensus</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-census</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -51,7 +55,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>30.0-jre</version>
+      <version>30.1.1-android</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/src/main/java/com/google/cloud/bigtable/hbase/tools/ClusterSchemaDefinition.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/src/main/java/com/google/cloud/bigtable/hbase/tools/ClusterSchemaDefinition.java
@@ -16,7 +16,6 @@
 package com.google.cloud.bigtable.hbase.tools;
 
 import com.google.bigtable.repackaged.com.google.api.core.InternalApi;
-import com.google.common.base.Objects;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/src/main/java/com/google/cloud/bigtable/hbase/tools/ClusterSchemaDefinition.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/src/main/java/com/google/cloud/bigtable/hbase/tools/ClusterSchemaDefinition.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.hbase.tools;
 
 import com.google.bigtable.repackaged.com.google.api.core.InternalApi;
+import com.google.common.base.Objects;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/src/main/java/com/google/cloud/bigtable/hbase/tools/HBaseSchemaTranslator.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/src/main/java/com/google/cloud/bigtable/hbase/tools/HBaseSchemaTranslator.java
@@ -123,8 +123,7 @@ public class HBaseSchemaTranslator {
     String schemaMappingFilePath;
 
     @VisibleForTesting
-    SchemaTranslationOptions() {
-    }
+    SchemaTranslationOptions() {}
 
     @VisibleForTesting
     void validateOptions() {
@@ -182,9 +181,7 @@ public class HBaseSchemaTranslator {
     }
   }
 
-  /**
-   * Interface for reading HBase schema.
-   */
+  /** Interface for reading HBase schema. */
   interface SchemaReader {
 
     ClusterSchemaDefinition readSchema() throws IOException;
@@ -209,9 +206,7 @@ public class HBaseSchemaTranslator {
     }
   }
 
-  /**
-   * Reads the HBase schema by connecting to an HBase cluster.
-   */
+  /** Reads the HBase schema by connecting to an HBase cluster. */
   static class HBaseSchemaReader implements SchemaReader {
 
     private final String tableFilterPattern;
@@ -285,8 +280,7 @@ public class HBaseSchemaTranslator {
   }
 
   /**
-   * Interface for writing the HBase schema represented by a {@link ClusterSchemaDefinition}
-   * object.
+   * Interface for writing the HBase schema represented by a {@link ClusterSchemaDefinition} object.
    */
   interface SchemaWriter {
 
@@ -391,9 +385,7 @@ public class HBaseSchemaTranslator {
         throws IOException, DeserializationException;
   }
 
-  /**
-   * No-op implementation of @{@link SchemaTransformer}. Returns the original schema definition.
-   */
+  /** No-op implementation of @{@link SchemaTransformer}. Returns the original schema definition. */
   static class NoopSchemaTransformer implements SchemaTransformer {
 
     @Override
@@ -416,11 +408,9 @@ public class HBaseSchemaTranslator {
     private final String mappingFilePath;
 
     // Map from old-tableName -> new-tableName
-    @VisibleForTesting
-    Map<String, String> tableNameMappings;
+    @VisibleForTesting Map<String, String> tableNameMappings;
     // Map of column families mapping scoped by a table. {tableName -> {old-family -> new-family}}
-    @VisibleForTesting
-    Map<String, Map<String, String>> tableScopedColumnFamilyMappings;
+    @VisibleForTesting Map<String, Map<String, String>> tableScopedColumnFamilyMappings;
 
     public JsonBasedSchemaTransformer(String mappingFilePath) {
       this.mappingFilePath = mappingFilePath;
@@ -489,10 +479,14 @@ public class HBaseSchemaTranslator {
           Map<String, String> cfMap =
               tableScopedColumnFamilyMappings.get(tableSchemaDefinition.name);
           for (Map.Entry<String, String> cfEntry : cfMap.entrySet()) {
-            HColumnDescriptor sourceFamily = newTableDescriptor.getFamily(cfEntry.getKey().getBytes());
+            HColumnDescriptor sourceFamily =
+                newTableDescriptor.getFamily(cfEntry.getKey().getBytes());
 
-            if(sourceFamily == null){
-              throw new IllegalStateException("Requested rename of a non existent column family: '"+ cfEntry.getKey() + "', please make sure that there are no typos." );
+            if (sourceFamily == null) {
+              throw new IllegalStateException(
+                  "Requested rename of a non existent column family: '"
+                      + cfEntry.getKey()
+                      + "', please make sure that there are no typos.");
             }
             // Its not possible to rename a columnFamily using the HColumnDescriptor interface
             // So create a new family with same config and replace it in the HTableDescriptor.
@@ -501,7 +495,7 @@ public class HBaseSchemaTranslator {
           }
         }
 
-       // finalize the transformed schema
+        // finalize the transformed schema
         transformedSchema.addTableSchemaDefinition(
             newTableDescriptor, tableSchemaDefinition.splits);
       }
@@ -550,12 +544,12 @@ public class HBaseSchemaTranslator {
     try {
       jarName =
           new File(
-              HBaseSchemaTranslator.class
-                  .getProtectionDomain()
-                  .getCodeSource()
-                  .getLocation()
-                  .toURI()
-                  .getPath())
+                  HBaseSchemaTranslator.class
+                      .getProtectionDomain()
+                      .getCodeSource()
+                      .getLocation()
+                      .toURI()
+                      .getPath())
               .getName();
     } catch (URISyntaxException e) {
       jarName = "<jar>";

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/src/main/java/com/google/cloud/bigtable/hbase/tools/HBaseSchemaTranslator.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/src/main/java/com/google/cloud/bigtable/hbase/tools/HBaseSchemaTranslator.java
@@ -111,14 +111,14 @@ public class HBaseSchemaTranslator {
   @VisibleForTesting
   static class SchemaTranslationOptions {
 
-    String projectId;
-    String instanceId;
-    String zookeeperQuorum;
-    Integer zookeeperPort;
-    String inputFilePath;
-    String outputFilePath;
-    String tableNameFilter;
-    String schemaMappingFilePath;
+    @Nullable String projectId;
+    @Nullable String instanceId;
+    @Nullable String zookeeperQuorum;
+    @Nullable Integer zookeeperPort;
+    @Nullable String inputFilePath;
+    @Nullable String outputFilePath;
+    @Nullable String tableNameFilter;
+    @Nullable String schemaMappingFilePath;
 
     @VisibleForTesting
     SchemaTranslationOptions() {}
@@ -180,8 +180,7 @@ public class HBaseSchemaTranslator {
   }
 
   /** Interface for reading HBase schema. */
-  interface SchemaReader {
-
+  private interface SchemaReader {
     ClusterSchemaDefinition readSchema() throws IOException;
   }
 
@@ -189,6 +188,7 @@ public class HBaseSchemaTranslator {
    * Reads HBase schema from a JSON file. JSON file should be representation of a {@link
    * ClusterSchemaDefinition} object.
    */
+  @VisibleForTesting
   static class FileBasedSchemaReader implements SchemaReader {
 
     private final String schemaFilePath;
@@ -205,6 +205,7 @@ public class HBaseSchemaTranslator {
   }
 
   /** Reads the HBase schema by connecting to an HBase cluster. */
+  @VisibleForTesting
   static class HBaseSchemaReader implements SchemaReader {
 
     private final String tableFilterPattern;
@@ -281,7 +282,7 @@ public class HBaseSchemaTranslator {
   /**
    * Interface for writing the HBase schema represented by a {@link ClusterSchemaDefinition} object.
    */
-  interface SchemaWriter {
+  private interface SchemaWriter {
 
     void writeSchema(ClusterSchemaDefinition schemaDefinition) throws IOException;
   }
@@ -290,6 +291,7 @@ public class HBaseSchemaTranslator {
    * Writes the HBase schema into a file. File contains the JSON representation of the {@link
    * ClusterSchemaDefinition} object.
    */
+  @VisibleForTesting
   static class FileBasedSchemaWriter implements SchemaWriter {
 
     private final String outputFilePath;
@@ -312,6 +314,7 @@ public class HBaseSchemaTranslator {
    * Creates tables in Cloud Bigtable based on the schema provided by the {@link
    * ClusterSchemaDefinition} object.
    */
+  @VisibleForTesting
   static class BigtableSchemaWriter implements SchemaWriter {
 
     private final Admin btAdmin;
@@ -381,14 +384,14 @@ public class HBaseSchemaTranslator {
    * Transforms the {@link ClusterSchemaDefinition} read by {@link SchemaReader} before writing it
    * to {@link SchemaWriter}.
    */
-  interface SchemaTransformer {
+  private interface SchemaTransformer {
 
     ClusterSchemaDefinition transform(ClusterSchemaDefinition originalSchema)
         throws IOException, DeserializationException;
   }
 
   /** No-op implementation of @{@link SchemaTransformer}. Returns the original schema definition. */
-  static class NoopSchemaTransformer implements SchemaTransformer {
+  private static class NoopSchemaTransformer implements SchemaTransformer {
 
     @Override
     public ClusterSchemaDefinition transform(ClusterSchemaDefinition originalSchema) {
@@ -403,6 +406,7 @@ public class HBaseSchemaTranslator {
    * <p>JSON map should look like { "SourceTable": "DestinationTable",
    * "sourceTable-2":"DestinationTable-2"}
    */
+  @VisibleForTesting
   static class JsonBasedSchemaTransformer implements SchemaTransformer {
 
     // Map from old-tableName -> new-tableName
@@ -527,8 +531,8 @@ public class HBaseSchemaTranslator {
         "  Additionally, you can filter tables to create when using HBase as source");
     System.err.println("   -D " + TABLE_NAME_FILTER_KEY + "=<table name regex>");
     System.err.println(
-        "  The tables can be renamed by providing a JSON map. Example JSON "
-            + "{\"source-table\": \"destination-table\", \"namespace:source-table2\": \"destination-table2\"}.");
+        "  Optionally, the tables can be renamed by providing a JSON map. Example JSON "
+            + "{\"source-table\": \"destination-table\", \"namespace:source-table2\": \"namespace-destination-table2\"}.");
     System.err.println("   -D " + SCHEMA_MAPPING_FILEPATH + "=/schema/mapping/file/path.json");
   }
 

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/src/main/java/com/google/cloud/bigtable/hbase/tools/HBaseSchemaTranslator.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/src/main/java/com/google/cloud/bigtable/hbase/tools/HBaseSchemaTranslator.java
@@ -173,7 +173,7 @@ public class HBaseSchemaTranslator {
       // readable. See if we can make it readable and validate before calling the constructor.
       try {
         options.validateOptions();
-      } catch (Exception e) {
+      } catch (RuntimeException e) {
         usage(e.getMessage());
         throw e;
       }

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/src/main/java/com/google/cloud/bigtable/hbase/tools/HBaseSchemaTranslator.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/src/main/java/com/google/cloud/bigtable/hbase/tools/HBaseSchemaTranslator.java
@@ -404,6 +404,7 @@ public class HBaseSchemaTranslator {
    */
   static class JsonBasedSchemaTransformer implements SchemaTransformer {
 
+    // ':' is a good choice since it can not be present in either tableName or column family name.
     public static final String COLUMN_FAMILY_SEPARATOR = ":";
     private final String mappingFilePath;
 
@@ -429,7 +430,7 @@ public class HBaseSchemaTranslator {
             "SchemaMapping file does not contain valid schema mappings");
       }
 
-      // Raed the mapping file and organize the transformations in a structured way.
+      // Read the mapping file and organize the transformations in a structured way.
       // Please note that we consciously chose a flat JSON file to make it easy for users to
       // configure the schema translator.
       for (Map.Entry<String, String> entry : schemaMapping.entrySet()) {

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/src/test/java/com/google/cloud/bigtable/hbase/tools/HBaseSchemaTransformerTest.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/src/test/java/com/google/cloud/bigtable/hbase/tools/HBaseSchemaTransformerTest.java
@@ -44,8 +44,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class HBaseSchemaTransformerTest {
 
-  @Rule
-  public TemporaryFolder tempFolder = new TemporaryFolder();
+  @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
 
   private String schemaFilePath;
   private JsonBasedSchemaTransformer schemaTransformer;
@@ -134,9 +133,15 @@ public class HBaseSchemaTransformerTest {
     ClusterSchemaDefinition transformedClusterSchema = transformer.transform(schemaDefinition);
 
     // Verify transformation
-    Assert.assertEquals(transformedClusterSchema.tableSchemaDefinitions.get(0).name, schemaDefinition.tableSchemaDefinitions.get(0).name);
-    Assert.assertEquals(transformedClusterSchema.tableSchemaDefinitions.get(0).getHbaseTableDescriptor(), schemaDefinition.tableSchemaDefinitions.get(0).getHbaseTableDescriptor());
-    Assert.assertEquals(transformedClusterSchema.tableSchemaDefinitions.get(0).splits, schemaDefinition.tableSchemaDefinitions.get(0).splits);
+    Assert.assertEquals(
+        transformedClusterSchema.tableSchemaDefinitions.get(0).name,
+        schemaDefinition.tableSchemaDefinitions.get(0).name);
+    Assert.assertEquals(
+        transformedClusterSchema.tableSchemaDefinitions.get(0).getHbaseTableDescriptor(),
+        schemaDefinition.tableSchemaDefinitions.get(0).getHbaseTableDescriptor());
+    Assert.assertEquals(
+        transformedClusterSchema.tableSchemaDefinitions.get(0).splits,
+        schemaDefinition.tableSchemaDefinitions.get(0).splits);
   }
 
   @Test
@@ -164,9 +169,15 @@ public class HBaseSchemaTransformerTest {
     ClusterSchemaDefinition transformedClusterSchema = transformer.transform(schemaDefinition);
 
     // Verify transformation
-    Assert.assertEquals(transformedClusterSchema.tableSchemaDefinitions.get(0).name, schemaDefinition.tableSchemaDefinitions.get(0).name);
-    Assert.assertEquals(transformedClusterSchema.tableSchemaDefinitions.get(0).getHbaseTableDescriptor(), schemaDefinition.tableSchemaDefinitions.get(0).getHbaseTableDescriptor());
-    Assert.assertEquals(transformedClusterSchema.tableSchemaDefinitions.get(0).splits, schemaDefinition.tableSchemaDefinitions.get(0).splits);
+    Assert.assertEquals(
+        transformedClusterSchema.tableSchemaDefinitions.get(0).name,
+        schemaDefinition.tableSchemaDefinitions.get(0).name);
+    Assert.assertEquals(
+        transformedClusterSchema.tableSchemaDefinitions.get(0).getHbaseTableDescriptor(),
+        schemaDefinition.tableSchemaDefinitions.get(0).getHbaseTableDescriptor());
+    Assert.assertEquals(
+        transformedClusterSchema.tableSchemaDefinitions.get(0).splits,
+        schemaDefinition.tableSchemaDefinitions.get(0).splits);
   }
 
   @Test
@@ -195,17 +206,26 @@ public class HBaseSchemaTransformerTest {
     JsonBasedSchemaTransformer transformer = new JsonBasedSchemaTransformer(schemaMapping);
 
     ClusterSchemaDefinition transformedClusterSchema = transformer.transform(schemaDefinition);
-    TableSchemaDefinition expectedTableSchema =new TableSchemaDefinition(new HTableDescriptor(TableName.valueOf("new-table1"), schemaDefinition.tableSchemaDefinitions.get(0).getHbaseTableDescriptor()),
-        tableSchemaDefinition.splits);
+    TableSchemaDefinition expectedTableSchema =
+        new TableSchemaDefinition(
+            new HTableDescriptor(
+                TableName.valueOf("new-table1"),
+                schemaDefinition.tableSchemaDefinitions.get(0).getHbaseTableDescriptor()),
+            tableSchemaDefinition.splits);
 
     // Verify transformation
     Assert.assertEquals("new-table1", transformedClusterSchema.tableSchemaDefinitions.get(0).name);
-    Assert.assertEquals(expectedTableSchema.getHbaseTableDescriptor(), transformedClusterSchema.tableSchemaDefinitions.get(0).getHbaseTableDescriptor());
-    Assert.assertEquals(transformedClusterSchema.tableSchemaDefinitions.get(0).splits, schemaDefinition.tableSchemaDefinitions.get(0).splits);
+    Assert.assertEquals(
+        expectedTableSchema.getHbaseTableDescriptor(),
+        transformedClusterSchema.tableSchemaDefinitions.get(0).getHbaseTableDescriptor());
+    Assert.assertEquals(
+        transformedClusterSchema.tableSchemaDefinitions.get(0).splits,
+        schemaDefinition.tableSchemaDefinitions.get(0).splits);
   }
 
   @Test
-  public void testTransformWithinCustomNamespaceTable() throws DeserializationException, IOException {
+  public void testTransformWithinCustomNamespaceTable()
+      throws DeserializationException, IOException {
 
     // Setup a cluster schema
     ClusterSchemaDefinition schemaDefinition = new ClusterSchemaDefinition();
@@ -229,14 +249,20 @@ public class HBaseSchemaTransformerTest {
     JsonBasedSchemaTransformer transformer = new JsonBasedSchemaTransformer(schemaMapping);
 
     ClusterSchemaDefinition transformedClusterSchema = transformer.transform(schemaDefinition);
-    TableSchemaDefinition expectedTableSchema =new TableSchemaDefinition(new HTableDescriptor(TableName.valueOf("new-table1"), schemaDefinition.tableSchemaDefinitions.get(0).getHbaseTableDescriptor()),
-        tableSchemaDefinition.splits);
+    TableSchemaDefinition expectedTableSchema =
+        new TableSchemaDefinition(
+            new HTableDescriptor(
+                TableName.valueOf("new-table1"),
+                schemaDefinition.tableSchemaDefinitions.get(0).getHbaseTableDescriptor()),
+            tableSchemaDefinition.splits);
 
     // Verify transformation
     Assert.assertEquals("new-table1", transformedClusterSchema.tableSchemaDefinitions.get(0).name);
-    Assert.assertEquals(expectedTableSchema.getHbaseTableDescriptor(), transformedClusterSchema.tableSchemaDefinitions.get(0).getHbaseTableDescriptor());
-    Assert.assertEquals(transformedClusterSchema.tableSchemaDefinitions.get(0).splits, schemaDefinition.tableSchemaDefinitions.get(0).splits);
-
+    Assert.assertEquals(
+        expectedTableSchema.getHbaseTableDescriptor(),
+        transformedClusterSchema.tableSchemaDefinitions.get(0).getHbaseTableDescriptor());
+    Assert.assertEquals(
+        transformedClusterSchema.tableSchemaDefinitions.get(0).splits,
+        schemaDefinition.tableSchemaDefinitions.get(0).splits);
   }
-
 }

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/src/test/java/com/google/cloud/bigtable/hbase/tools/HBaseSchemaTransformerTest.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/src/test/java/com/google/cloud/bigtable/hbase/tools/HBaseSchemaTransformerTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.tools;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import com.google.bigtable.repackaged.com.google.gson.Gson;
+import com.google.bigtable.repackaged.com.google.gson.JsonObject;
+import com.google.cloud.bigtable.hbase.tools.HBaseSchemaTranslator.JsonBasedSchemaTransformer;
+import com.google.common.collect.ImmutableMap;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class HBaseSchemaTransformerTest {
+
+  @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  private String schemaFilePath;
+  private JsonBasedSchemaTransformer schemaTransformer;
+
+  @Before
+  public void before() throws IOException {
+    schemaFilePath = tempFolder.newFile().getPath();
+    schemaTransformer = new JsonBasedSchemaTransformer(schemaFilePath);
+  }
+
+  ///////////////////////////////// Invalid cases //////////////////////////////////////
+  @Test
+  public void testBadJson() throws IOException {
+
+    // Setup bad JSON
+    FileWriter fw = new FileWriter(schemaFilePath);
+    fw.write("random JSON string");
+    // Execute the test method
+    try {
+      schemaTransformer.parseMappingFile();
+      fail("Expected IllegalStateException due to bad JSON.");
+    } catch (IllegalStateException e) {
+      e.printStackTrace();
+    } catch (Exception e) {
+      fail("Expected IllegalStateException due to bad JSON but found " + e.toString());
+    }
+  }
+
+  //////////////////////////////////////// Happy cases ////////////////////////////////////
+  @Test
+  public void testParseJsonOnlyTables() throws IOException {
+    // Setup the schema file
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("old-table", "new-table");
+    // Make sure that the whole table name is matched and not just prefix
+    jsonObject.addProperty("old-table-2", "random-table-2");
+    try (Writer writer = new FileWriter(schemaFilePath)) {
+      new Gson().toJson(jsonObject, writer);
+    }
+
+    // Parse schema file
+    schemaTransformer.parseMappingFile();
+
+    // Validate
+    Map<String, String> expectedTableMapping =
+        ImmutableMap.of("old-table", "new-table", "old-table-2", "random-table-2");
+    assertEquals(expectedTableMapping, schemaTransformer.tableNameMappings);
+    assertEquals(0, schemaTransformer.tableScopedColumnFamilyMappings.size());
+  }
+
+  @Test
+  public void testParseJsonOnlyColumnFamily() throws IOException {
+    // Setup the schema file
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("old-table:old-cf", "new-cf");
+    jsonObject.addProperty("old-table:old-cf2", "random-cf2");
+    jsonObject.addProperty("some-table:cf", "cf-new");
+    try (Writer writer = new FileWriter(schemaFilePath)) {
+      new Gson().toJson(jsonObject, writer);
+    }
+
+    // Parse schema file
+    schemaTransformer.parseMappingFile();
+
+    // Validate
+    assertEquals(0, schemaTransformer.tableNameMappings.size());
+    Map<String, Map<String, String>> expectedTableScopedCFMapping =
+        ImmutableMap.of(
+            "old-table", ImmutableMap.of("old-cf", "new-cf", "old-cf2", "random-cf2"),
+            "some-table", ImmutableMap.of("cf", "cf-new"));
+    assertEquals(expectedTableScopedCFMapping, schemaTransformer.tableScopedColumnFamilyMappings);
+  }
+
+  @Test
+  public void testParseJsonEmpty() throws IOException {
+    // Setup the schema file
+    JsonObject jsonObject = new JsonObject();
+    try (Writer writer = new FileWriter(schemaFilePath)) {
+      new Gson().toJson(jsonObject, writer);
+    }
+
+    // Parse schema file
+    schemaTransformer.parseMappingFile();
+    assertEquals(0, schemaTransformer.tableNameMappings.size());
+    assertEquals(0, schemaTransformer.tableScopedColumnFamilyMappings.size());
+  }
+
+  @Test
+  public void testParseJsonTableAndColumnFamily() throws IOException {
+    // Setup the schema file
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("old-table", "new-table");
+    jsonObject.addProperty("old-table:old-cf", "new-cf");
+    Gson gson = new Gson();
+    try (Writer writer = new FileWriter(schemaFilePath)) {
+      new Gson().toJson(jsonObject, writer);
+    }
+
+    schemaTransformer.parseMappingFile();
+    Map<String, String> expectedTableMapping = Collections.singletonMap("old-table", "new-table");
+    assertEquals(expectedTableMapping, schemaTransformer.tableNameMappings);
+    Map<String, Map<String, String>> expectedTableScopedCFMapping =
+        Collections.singletonMap("old-table", Collections.singletonMap("old-cf", "new-cf"));
+    assertEquals(expectedTableScopedCFMapping, schemaTransformer.tableScopedColumnFamilyMappings);
+  }
+}

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/src/test/java/com/google/cloud/bigtable/hbase/tools/HBaseSchemaTranslationOptionsTest.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/src/test/java/com/google/cloud/bigtable/hbase/tools/HBaseSchemaTranslationOptionsTest.java
@@ -106,12 +106,14 @@ public class HBaseSchemaTranslationOptionsTest {
     System.setProperty(HBaseSchemaTranslator.ZOOKEEPER_PORT_KEY, "1080");
     System.setProperty(HBaseSchemaTranslator.TABLE_NAME_FILTER_KEY, "hbase-.*");
     System.setProperty(HBaseSchemaTranslator.OUTPUT_FILE_KEY, "/tmp/output");
+    System.setProperty(HBaseSchemaTranslator.SCHEMA_MAPPING_FILEPATH, "/tmp/schema_mapping.json");
 
     SchemaTranslationOptions options = SchemaTranslationOptions.loadOptionsFromSystemProperties();
     Assert.assertEquals("localhost", options.zookeeperQuorum);
     Assert.assertEquals((Integer) 1080, options.zookeeperPort);
     Assert.assertEquals("/tmp/output", options.outputFilePath);
     Assert.assertEquals("hbase-.*", options.tableNameFilter);
+    Assert.assertEquals("/tmp/schema_mapping.json", options.schemaMappingFilePath);
   }
 
   @Test

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/src/test/java/com/google/cloud/bigtable/hbase/tools/HBaseSchemaTranslatorTest.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/src/test/java/com/google/cloud/bigtable/hbase/tools/HBaseSchemaTranslatorTest.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.hbase.tools;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.eq;
 
@@ -23,11 +24,17 @@ import com.google.cloud.bigtable.hbase.tools.HBaseSchemaTranslator.BigtableSchem
 import com.google.cloud.bigtable.hbase.tools.HBaseSchemaTranslator.FileBasedSchemaReader;
 import com.google.cloud.bigtable.hbase.tools.HBaseSchemaTranslator.FileBasedSchemaWriter;
 import com.google.cloud.bigtable.hbase.tools.HBaseSchemaTranslator.HBaseSchemaReader;
+import com.google.cloud.bigtable.hbase.tools.HBaseSchemaTranslator.JsonBasedSchemaTransformer;
+import com.google.cloud.bigtable.hbase.tools.HBaseSchemaTranslator.NoopSchemaTransformer;
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HRegionInfo;
@@ -41,6 +48,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
@@ -139,7 +147,9 @@ public class HBaseSchemaTranslatorTest {
 
     HBaseSchemaTranslator translator =
         new HBaseSchemaTranslator(
-            new HBaseSchemaReader(hbaseAdmin, ".*"), new BigtableSchemaWriter(btAdmin));
+            new HBaseSchemaReader(hbaseAdmin, ".*"),
+            new BigtableSchemaWriter(btAdmin),
+            new NoopSchemaTransformer());
 
     // Call
     translator.translate();
@@ -159,6 +169,60 @@ public class HBaseSchemaTranslatorTest {
   }
 
   @Test
+  public void testTranslateFromHBaseToBigtableWithTransformation()
+      throws IOException, DeserializationException {
+    // Setup
+    Mockito.when(hbaseAdmin.listTables(eq(".*"))).thenReturn(getTables());
+    Mockito.when(hbaseAdmin.getTableRegions(eq(TableName.valueOf("test-table1"))))
+        .thenReturn(getRegions(0));
+    Mockito.when(hbaseAdmin.getTableRegions(eq(TableName.valueOf("test-table2"))))
+        .thenReturn(getRegions(1));
+    ArgumentCaptor<HTableDescriptor> tableCaptor = ArgumentCaptor.forClass(HTableDescriptor.class);
+
+    Map<String, String> schemaMapping = new HashMap<>();
+    schemaMapping.put("test-table1", "new-test-table1");
+    schemaMapping.put("test-table1:cf", "new-cf");
+    // Not found in the schema, should get discarded.
+    schemaMapping.put("test", "new-test");
+    schemaMapping.put("test:family", "new-family");
+
+    File schemaFile = tempFolder.newFile("schema_mapping.json");
+    try (Writer writer = new FileWriter(schemaFile.getPath())) {
+      new com.google.bigtable.repackaged.com.google.gson.Gson().toJson(schemaMapping, writer);
+    }
+
+    HBaseSchemaTranslator translator =
+        new HBaseSchemaTranslator(
+            new HBaseSchemaReader(hbaseAdmin, ".*"),
+            new BigtableSchemaWriter(btAdmin),
+            new JsonBasedSchemaTransformer(schemaFile.getPath()));
+
+    // Call
+    translator.translate();
+
+    // Verify
+    Mockito.verify(btAdmin)
+        .createTable(
+            tableCaptor.capture(), eq(schemaDefinition.tableSchemaDefinitions.get(0).splits));
+    Mockito.verify(btAdmin)
+        .createTable(
+            tableCaptor.capture(), eq(schemaDefinition.tableSchemaDefinitions.get(1).splits));
+    HTableDescriptor transformedTable = tableCaptor.getAllValues().get(0);
+    assertEquals("new-test-table1", transformedTable.getNameAsString());
+    assertEquals("new-cf", transformedTable.getColumnFamilies()[0].getNameAsString());
+    // Cloud Bigtable only uses the GC policies from HColumnFamily object
+    assertEquals(2, transformedTable.getColumnFamilies()[0].getMaxVersions());
+    assertEquals(1000, transformedTable.getColumnFamilies()[0].getTimeToLive());
+    assertEquals(
+        schemaDefinition.tableSchemaDefinitions.get(1).getHbaseTableDescriptor(),
+        tableCaptor.getAllValues().get(1));
+
+    Mockito.verify(hbaseAdmin).listTables(".*");
+    Mockito.verify(hbaseAdmin).getTableRegions(TableName.valueOf("test-table1"));
+    Mockito.verify(hbaseAdmin).getTableRegions(TableName.valueOf("test-table2"));
+  }
+
+  @Test
   public void testTranslateHBaseToBigtableViaFile() throws IOException, DeserializationException {
     // Setup
     Mockito.when(hbaseAdmin.listTables(eq(".*"))).thenReturn(getTables());
@@ -171,14 +235,17 @@ public class HBaseSchemaTranslatorTest {
     HBaseSchemaTranslator translator1 =
         new HBaseSchemaTranslator(
             new HBaseSchemaReader(hbaseAdmin, ".*"),
-            new FileBasedSchemaWriter(schemaFile.getPath()));
+            new FileBasedSchemaWriter(schemaFile.getPath()),
+            new NoopSchemaTransformer());
 
     // call
     translator1.translate();
 
     HBaseSchemaTranslator translator2 =
         new HBaseSchemaTranslator(
-            new FileBasedSchemaReader(schemaFile.getPath()), new BigtableSchemaWriter(btAdmin));
+            new FileBasedSchemaReader(schemaFile.getPath()),
+            new BigtableSchemaWriter(btAdmin),
+            new NoopSchemaTransformer());
 
     translator2.translate();
 
@@ -205,7 +272,9 @@ public class HBaseSchemaTranslatorTest {
 
     HBaseSchemaTranslator translator =
         new HBaseSchemaTranslator(
-            new HBaseSchemaReader(hbaseAdmin, ".*"), new BigtableSchemaWriter(btAdmin));
+            new HBaseSchemaReader(hbaseAdmin, ".*"),
+            new BigtableSchemaWriter(btAdmin),
+            new NoopSchemaTransformer());
 
     // Call
     try {
@@ -232,7 +301,9 @@ public class HBaseSchemaTranslatorTest {
     // Create a translator;
     HBaseSchemaTranslator translator =
         new HBaseSchemaTranslator(
-            new HBaseSchemaReader(hbaseAdmin, ".*"), new BigtableSchemaWriter(btAdmin));
+            new HBaseSchemaReader(hbaseAdmin, ".*"),
+            new BigtableSchemaWriter(btAdmin),
+            new NoopSchemaTransformer());
     // Call
     try {
       translator.translate();
@@ -266,7 +337,9 @@ public class HBaseSchemaTranslatorTest {
 
     HBaseSchemaTranslator translator =
         new HBaseSchemaTranslator(
-            new HBaseSchemaReader(hbaseAdmin, ".*"), new BigtableSchemaWriter(btAdmin));
+            new HBaseSchemaReader(hbaseAdmin, ".*"),
+            new BigtableSchemaWriter(btAdmin),
+            new NoopSchemaTransformer());
 
     // Call
     try {
@@ -287,6 +360,44 @@ public class HBaseSchemaTranslatorTest {
           .createTable(
               eq(schemaDefinition.tableSchemaDefinitions.get(1).getHbaseTableDescriptor()),
               eq(schemaDefinition.tableSchemaDefinitions.get(1).splits));
+      Mockito.verify(hbaseAdmin).listTables(".*");
+      Mockito.verify(hbaseAdmin).getTableRegions(TableName.valueOf("test-table1"));
+      // Validate that translator calls createTable for  test-table-2 even after creation of
+      // test-table1 failed.
+      Mockito.verify(hbaseAdmin).getTableRegions(TableName.valueOf("test-table2"));
+    }
+  }
+
+  @Test
+  public void testHBaseSchemaTransformerFails() throws IOException, DeserializationException {
+    // Setup
+    Mockito.when(hbaseAdmin.listTables(eq(".*"))).thenReturn(getTables());
+    Mockito.when(hbaseAdmin.getTableRegions(eq(TableName.valueOf("test-table1"))))
+        .thenReturn(getRegions(0));
+    Mockito.when(hbaseAdmin.getTableRegions(eq(TableName.valueOf("test-table2"))))
+        .thenReturn(getRegions(1));
+
+    File schemaFile = tempFolder.newFile("schema.json");
+    FileWriter fileWriter = new FileWriter(schemaFile.getPath());
+    fileWriter.write("{This is invalid JSON}");
+
+    HBaseSchemaTranslator translator =
+        new HBaseSchemaTranslator(
+            new HBaseSchemaReader(hbaseAdmin, ".*"),
+            new BigtableSchemaWriter(btAdmin),
+            new JsonBasedSchemaTransformer(schemaFile.getPath()));
+
+    // Call
+    try {
+      translator.translate();
+      fail("Expected IOException here.");
+    } catch (IllegalStateException e) {
+      // Expected.
+      e.printStackTrace();
+    } catch (Exception e) {
+      fail("Expected DeserializationException but found: " + e.toString());
+    } finally {
+      // Verify
       Mockito.verify(hbaseAdmin).listTables(".*");
       Mockito.verify(hbaseAdmin).getTableRegions(TableName.valueOf("test-table1"));
       // Validate that translator calls createTable for  test-table-2 even after creation of

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/src/test/java/com/google/cloud/bigtable/hbase/tools/HBaseSchemaTranslatorTest.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/src/test/java/com/google/cloud/bigtable/hbase/tools/HBaseSchemaTranslatorTest.java
@@ -154,7 +154,9 @@ public class HBaseSchemaTranslatorTest {
     Mockito.verify(btAdmin)
         .createTable(
             eq(schemaDefinition.tableSchemaDefinitions.get(0).getHbaseTableDescriptor()),
-            eq(schemaDefinition.tableSchemaDefinitions.get(0).splits));
+            // First split is EMPTY_BYTE_ARRAY which gets filtered as CBT does not support empty
+            // splits.
+            eq(Arrays.copyOfRange(schemaDefinition.tableSchemaDefinitions.get(0).splits, 1, 3)));
     Mockito.verify(btAdmin)
         .createTable(
             eq(schemaDefinition.tableSchemaDefinitions.get(1).getHbaseTableDescriptor()),
@@ -194,7 +196,10 @@ public class HBaseSchemaTranslatorTest {
     // Verify
     Mockito.verify(btAdmin)
         .createTable(
-            tableCaptor.capture(), eq(schemaDefinition.tableSchemaDefinitions.get(0).splits));
+            tableCaptor.capture(),
+            // First split is EMPTY_BYTE_ARRAY which gets filtered as CBT does not support empty
+            // splits.
+            eq(Arrays.copyOfRange(schemaDefinition.tableSchemaDefinitions.get(0).splits, 1, 3)));
     Mockito.verify(btAdmin)
         .createTable(
             tableCaptor.capture(), eq(schemaDefinition.tableSchemaDefinitions.get(1).splits));
@@ -241,7 +246,9 @@ public class HBaseSchemaTranslatorTest {
     Mockito.verify(btAdmin)
         .createTable(
             eq(schemaDefinition.tableSchemaDefinitions.get(0).getHbaseTableDescriptor()),
-            eq(schemaDefinition.tableSchemaDefinitions.get(0).splits));
+            // First split is EMPTY_BYTE_ARRAY which gets filtered as CBT does not support empty
+            // splits.
+            eq(Arrays.copyOfRange(schemaDefinition.tableSchemaDefinitions.get(0).splits, 1, 3)));
     Mockito.verify(btAdmin)
         .createTable(
             eq(schemaDefinition.tableSchemaDefinitions.get(1).getHbaseTableDescriptor()),
@@ -317,7 +324,9 @@ public class HBaseSchemaTranslatorTest {
         .when(btAdmin)
         .createTable(
             eq(schemaDefinition.tableSchemaDefinitions.get(0).getHbaseTableDescriptor()),
-            eq(schemaDefinition.tableSchemaDefinitions.get(0).splits));
+            // First split is EMPTY_BYTE_ARRAY which gets filtered as CBT does not support empty
+            // splits.
+            eq(Arrays.copyOfRange(schemaDefinition.tableSchemaDefinitions.get(0).splits, 1, 3)));
 
     HBaseSchemaTranslator translator =
         new HBaseSchemaTranslator(
@@ -337,7 +346,9 @@ public class HBaseSchemaTranslatorTest {
       Mockito.verify(btAdmin)
           .createTable(
               eq(schemaDefinition.tableSchemaDefinitions.get(0).getHbaseTableDescriptor()),
-              eq(schemaDefinition.tableSchemaDefinitions.get(0).splits));
+              // First split is EMPTY_BYTE_ARRAY which gets filtered as CBT does not support empty
+              // splits.
+              eq(Arrays.copyOfRange(schemaDefinition.tableSchemaDefinitions.get(0).splits, 1, 3)));
       // Validate that translator calls createTable for  test-table-2 even after creation of
       // test-table1 failed.
       Mockito.verify(btAdmin)


### PR DESCRIPTION
This PR allows the users to rename tables while translating their schema from HBase to Bigtable. This is required to translate any tables with custom namespaces as Cloud Bigtable does not support namespaces. 

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable-hbase/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️
