### PR TITLE
ci: removing linkage-monitor from the required checks

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -11,7 +11,6 @@ branchProtectionRules:
       - 'Kokoro - Test: Integration'
       - 'Kokoro - Test: Java 11'
       - 'Kokoro - Test: Java 8'
-      - 'Kokoro - Test: Linkage Monitor'
       - 'Kokoro - Test: Beam Integration'
       - cla/google
     requiredApprovingReviewCount: 1
@@ -25,7 +24,6 @@ branchProtectionRules:
       - 'Kokoro - Test: Integration'
       - 'Kokoro - Test: Java 11'
       - 'Kokoro - Test: Java 8'
-      - 'Kokoro - Test: Linkage Monitor'
       - 'Kokoro - Test: Beam Integration'
       - cla/google
     requiredApprovingReviewCount: 1
@@ -39,7 +37,6 @@ branchProtectionRules:
       - 'Kokoro - Test: Integration'
       - 'Kokoro - Test: Java 11'
       - 'Kokoro - Test: Java 8'
-      - 'Kokoro - Test: Linkage Monitor'
       - 'Kokoro - Test: Beam Integration'
       - cla/google
     requiredApprovingReviewCount: 1


### PR DESCRIPTION
Linkage Monitor is no longer needed, because the Libraries BOM synchronizes with Google Cloud BOM and the shared dependencies BOM https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/2137