### PR TITLE
Skeleton for the mirroring client

### DIFF
--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/pom.xml
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/pom.xml
@@ -62,5 +62,11 @@ limitations under the License.
       <version>1.10.4</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.8.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/pom.xml
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2021 Google LCC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.google.cloud.bigtable</groupId>
+    <artifactId>bigtable-hbase-mirroring-client-1.x-parent</artifactId>
+    <version>0.0.1-alpha1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>bigtable-hbase-mirroring-client-1.x</artifactId>
+  <packaging>jar</packaging>
+  <name>${project.groupId}:${project.artifactId}</name>
+  <version>0.0.1-alpha1-SNAPSHOT</version>
+  <description>
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-shaded-client</artifactId>
+      <version>${hbase1.version}</version>
+    </dependency>
+
+    <!-- Test dependencies-->
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-graphite</artifactId>
+      <version>${hbase1-metrics.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>1.1.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>api-common</artifactId>
+      <version>1.10.4</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/AsyncTableWrapper.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/AsyncTableWrapper.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.mirroring.hbase1_x;
+
+import com.google.api.core.InternalApi;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import java.util.List;
+import java.util.concurrent.Callable;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Table;
+
+/**
+ * MirroringClient verifies consistency between two databases asynchronously - after the results are
+ * delivered to the user. HBase Table object does not have an synchronous API, so we simulate it by
+ * wrapping the regular Table into AsyncTableWrapper.
+ *
+ * <p>Table instances are not thread-safe, every operation is synchronized to prevent concurrent
+ * accesses to the table from different threads in the executor.
+ */
+@InternalApi("For internal usage only")
+public class AsyncTableWrapper {
+  private final Table table;
+  private final ListeningExecutorService executorService;
+
+  public AsyncTableWrapper(Table table, ListeningExecutorService executorService) {
+    this.table = table;
+    this.executorService = executorService;
+  }
+
+  public ListenableFuture<Result> get(final Get gets) {
+    return this.executorService.submit(
+        new Callable<Result>() {
+          @Override
+          public Result call() throws Exception {
+            synchronized (table) {
+              return table.get(gets);
+            }
+          }
+        });
+  }
+
+  public ListenableFuture<Result[]> get(final List<Get> gets) {
+    return this.executorService.submit(
+        new Callable<Result[]>() {
+          @Override
+          public Result[] call() throws Exception {
+            synchronized (table) {
+              return table.get(gets);
+            }
+          }
+        });
+  }
+
+  public ListenableFuture<Boolean> exists(final Get get) {
+    return this.executorService.submit(
+        new Callable<Boolean>() {
+          @Override
+          public Boolean call() throws Exception {
+            synchronized (table) {
+              return table.exists(get);
+            }
+          }
+        });
+  }
+
+  public ListenableFuture<boolean[]> existsAll(final List<Get> gets) {
+    return this.executorService.submit(
+        new Callable<boolean[]>() {
+          @Override
+          public boolean[] call() throws Exception {
+            synchronized (table) {
+              return table.existsAll(gets);
+            }
+          }
+        });
+  }
+}

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringConfiguration.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringConfiguration.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.mirroring.hbase1_x;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import org.apache.hadoop.conf.Configuration;
+
+public class MirroringConfiguration extends Configuration {
+  Configuration primaryConfiguration;
+  Configuration secondaryConfiguration;
+  MirroringOptions mirroringOptions;
+
+  /**
+   * Key to set to a name of Connection class that should be used to connect to primary database. It
+   * is used as hbase.client.connection.impl when creating connection to primary database.
+   */
+  public static final String MIRRORING_PRIMARY_CONNECTION_CLASS_KEY =
+      "google.bigtable.mirroring.primary-client.connection.impl";
+
+  /**
+   * Key to set to a name of Connection class that should be used to connect to secondary database.
+   * It is used as hbase.client.connection.impl when creating connection to secondary database.
+   */
+  public static final String MIRRORING_SECONDARY_CONNECTION_CLASS_KEY =
+      "google.bigtable.mirroring.secondary-client.connection.impl";
+
+  /**
+   * By default all parameters from the Configuration object passed to
+   * ConnectionFactory#createConnection are passed to Connection instances. If this key is set, then
+   * only parameters that start with given prefix are passed to primary Connection. Use it if
+   * primary and secondary connections' configurations share a key that should have different value
+   * passed to each of connections, e.g. zookeeper url.
+   *
+   * <p>Prefixes should not contain dot at the end.
+   */
+  public static final String MIRRORING_PRIMARY_CONFIG_PREFIX_KEY =
+      "google.bigtable.mirroring.primary-client.prefix";
+
+  /**
+   * If this key is set, then only parameters that start with given prefix are passed to secondary
+   * Connection.
+   */
+  public static final String MIRRORING_SECONDARY_CONFIG_PREFIX_KEY =
+      "google.bigtable.mirroring.secondary-client.prefix";
+
+  public MirroringConfiguration(
+      Configuration primaryConfiguration,
+      Configuration secondaryConfiguration,
+      Configuration mirroringConfiguration) {
+    super.set("hbase.client.connection.impl", MirroringConnection.class.getCanonicalName());
+    this.primaryConfiguration = primaryConfiguration;
+    this.secondaryConfiguration = secondaryConfiguration;
+    this.mirroringOptions = new MirroringOptions(mirroringConfiguration);
+  }
+
+  public MirroringConfiguration(Configuration conf) {
+    super(conf); // Copy-constructor
+    // In case the user constructed MirroringConfiguration by hand.
+    if (conf instanceof MirroringConfiguration) {
+      MirroringConfiguration mirroringConfiguration = (MirroringConfiguration) conf;
+      this.primaryConfiguration = new Configuration(mirroringConfiguration.primaryConfiguration);
+      this.secondaryConfiguration =
+          new Configuration(mirroringConfiguration.secondaryConfiguration);
+      this.mirroringOptions = mirroringConfiguration.mirroringOptions;
+    } else {
+      checkParameters(conf);
+      this.primaryConfiguration = constructPrimaryConfiguration(conf);
+      this.secondaryConfiguration = constructSecondaryConfiguration(conf);
+      this.mirroringOptions = new MirroringOptions(conf);
+    }
+  }
+
+  private Configuration constructPrimaryConfiguration(Configuration conf) {
+    return constructConnectionConfiguration(
+        conf, MIRRORING_PRIMARY_CONNECTION_CLASS_KEY, MIRRORING_PRIMARY_CONFIG_PREFIX_KEY);
+  }
+
+  private Configuration constructSecondaryConfiguration(Configuration conf) {
+    return constructConnectionConfiguration(
+        conf, MIRRORING_SECONDARY_CONNECTION_CLASS_KEY, MIRRORING_SECONDARY_CONFIG_PREFIX_KEY);
+  }
+
+  private Configuration constructConnectionConfiguration(
+      Configuration conf, String connectionClassKey, String prefixKey) {
+    String connectionClassName = conf.get(connectionClassKey);
+    String prefix = conf.get(prefixKey, "");
+    Configuration connectionConfig = extractPrefixedConfig(prefix, conf);
+    connectionConfig.set("hbase.client.connection.impl", connectionClassName);
+    return connectionConfig;
+  }
+
+  private static void checkParameters(Configuration conf) {
+    String primaryConnectionClassName = conf.get(MIRRORING_PRIMARY_CONNECTION_CLASS_KEY);
+    String secondaryConnectionClassName = conf.get(MIRRORING_SECONDARY_CONNECTION_CLASS_KEY);
+    String primaryConnectionConfigPrefix = conf.get(MIRRORING_PRIMARY_CONFIG_PREFIX_KEY, "");
+    String secondaryConnectionConfigPrefix = conf.get(MIRRORING_SECONDARY_CONFIG_PREFIX_KEY, "");
+
+    checkArgument(
+        primaryConnectionClassName != null,
+        String.format("Specify %s.", MIRRORING_PRIMARY_CONNECTION_CLASS_KEY));
+    checkArgument(
+        secondaryConnectionClassName != null,
+        String.format("Specify %s.", MIRRORING_SECONDARY_CONNECTION_CLASS_KEY));
+
+    if (Objects.equals(primaryConnectionClassName, secondaryConnectionClassName)
+        && Objects.equals(primaryConnectionConfigPrefix, secondaryConnectionConfigPrefix)) {
+      if (primaryConnectionConfigPrefix.isEmpty()) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Mirroring connections using the same client class requires a separate "
+                    + "configuration for one of them. Specify either %s or %s and use its value "
+                    + "as a prefix for configuration options.",
+                MIRRORING_PRIMARY_CONFIG_PREFIX_KEY, MIRRORING_SECONDARY_CONFIG_PREFIX_KEY));
+      } else {
+        throw new IllegalArgumentException(
+            String.format(
+                "Values of %s and %s should be different.",
+                MIRRORING_PRIMARY_CONFIG_PREFIX_KEY, MIRRORING_SECONDARY_CONFIG_PREFIX_KEY));
+      }
+    }
+  }
+
+  private static Configuration extractPrefixedConfig(String prefix, Configuration conf) {
+    if (prefix.isEmpty()) {
+      return new Configuration(conf);
+    }
+
+    return stripPrefixFromConfiguration(prefix, conf);
+  }
+
+  private static Configuration stripPrefixFromConfiguration(String prefix, Configuration config) {
+    Map<String, String> matchingConfigs =
+        config.getValByRegex("^" + Pattern.quote(prefix) + "\\..*");
+    Configuration newConfig = new Configuration(false);
+    for (Map.Entry<String, String> entry : matchingConfigs.entrySet()) {
+      newConfig.set(entry.getKey().substring(prefix.length() + 1), entry.getValue());
+    }
+    return newConfig;
+  }
+}

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringConnection.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringConnection.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.mirroring.hbase1_x;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.BufferedMutator;
+import org.apache.hadoop.hbase.client.BufferedMutatorParams;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.RegionLocator;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.security.User;
+
+public class MirroringConnection implements Connection {
+  private MirroringConfiguration configuration;
+  private Connection primaryConnection;
+  private Connection secondaryConnection;
+
+  /**
+   * The constructor called from {@link
+   * org.apache.hadoop.hbase.client.ConnectionFactory#createConnection(Configuration)} and in its
+   * many forms via reflection with this specific signature.
+   *
+   * <p>Parameters are passed down to ConnectionFactory#createConnection method, connection errors
+   * are passed back to the user.
+   */
+  public MirroringConnection(Configuration conf, boolean managed, ExecutorService pool, User user)
+      throws IOException {
+    assert !managed; // This is always-false legacy hbase parameter.
+    this.configuration = new MirroringConfiguration(conf);
+    this.primaryConnection =
+        ConnectionFactory.createConnection(this.configuration.primaryConfiguration, pool, user);
+    this.secondaryConnection =
+        ConnectionFactory.createConnection(this.configuration.secondaryConfiguration, pool, user);
+  }
+
+  @Override
+  public Configuration getConfiguration() {
+    return this.configuration;
+  }
+
+  @Override
+  public Table getTable(TableName tableName) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Table getTable(TableName tableName, ExecutorService executorService) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public BufferedMutator getBufferedMutator(TableName tableName) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public BufferedMutator getBufferedMutator(BufferedMutatorParams bufferedMutatorParams)
+      throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public RegionLocator getRegionLocator(TableName tableName) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Admin getAdmin() throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void close() throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isClosed() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void abort(String s, Throwable throwable) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isAborted() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringOptions.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringOptions.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.mirroring.hbase1_x;
+
+import com.google.api.core.InternalApi;
+import org.apache.hadoop.conf.Configuration;
+
+@InternalApi("For internal use only")
+class MirroringOptions {
+  static final String MIRRORING_SYNCHRONOUS_KEY = "google.bigtable.mirroring.synchronous";
+
+  private boolean synchronous;
+
+  public boolean getSynchronous() {
+    return synchronous;
+  }
+
+  MirroringOptions(Configuration configuration) {
+    this.synchronous = configuration.getBoolean(MIRRORING_SYNCHRONOUS_KEY, false);
+  }
+}

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringTable.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringTable.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.mirroring.hbase1_x;
+
+import com.google.api.core.InternalApi;
+import com.google.cloud.bigtable.mirroring.hbase1_x.verification.MismatchDetector;
+import com.google.cloud.bigtable.mirroring.hbase1_x.verification.VerificationContinuationFactory;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Append;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Durability;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Increment;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Row;
+import org.apache.hadoop.hbase.client.RowMutations;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.client.coprocessor.Batch.Call;
+import org.apache.hadoop.hbase.client.coprocessor.Batch.Callback;
+import org.apache.hadoop.hbase.filter.CompareFilter.CompareOp;
+import org.apache.hadoop.hbase.ipc.CoprocessorRpcChannel;
+import org.apache.hadoop.hbase.shaded.com.google.protobuf.Descriptors.MethodDescriptor;
+import org.apache.hadoop.hbase.shaded.com.google.protobuf.Message;
+import org.apache.hadoop.hbase.shaded.com.google.protobuf.Service;
+
+/**
+ * Table which mirrors every two mutations to two underlying tables.
+ *
+ * <p>Objects of this class present themselves as HBase 1.x `Table` objects. Every operation is
+ * first performed on primary table and if it succeeded it is replayed on the secondary table
+ * asynchronously. Read operations are mirrored to verify that content of both databases matches.
+ */
+@InternalApi("For internal usage only")
+public class MirroringTable implements Table {
+  Table primaryTable;
+  Table secondaryTable;
+  AsyncTableWrapper secondaryAsyncWrapper;
+  VerificationContinuationFactory verificationContinuationFactory;
+
+  /**
+   * @param executorService ExecutorService is used to perform operations on secondaryTable and
+   *     verification tasks.
+   * @param mismatchDetector Detects mismatches in results from operations preformed on both
+   *     databases.
+   */
+  public MirroringTable(
+      Table primaryTable,
+      Table secondaryTable,
+      ExecutorService executorService,
+      MismatchDetector mismatchDetector) {
+    this.primaryTable = primaryTable;
+    this.secondaryTable = secondaryTable;
+    this.verificationContinuationFactory = new VerificationContinuationFactory(mismatchDetector);
+    this.secondaryAsyncWrapper =
+        new AsyncTableWrapper(
+            this.secondaryTable, MoreExecutors.listeningDecorator(executorService));
+  }
+
+  @Override
+  public TableName getName() {
+    return this.primaryTable.getName();
+  }
+
+  @Override
+  public Configuration getConfiguration() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public HTableDescriptor getTableDescriptor() throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean exists(Get get) throws IOException {
+    boolean result = this.primaryTable.exists(get);
+    Futures.addCallback(
+        this.secondaryAsyncWrapper.exists(get),
+        this.verificationContinuationFactory.exists(get, result),
+        MoreExecutors.directExecutor());
+    return result;
+  }
+
+  @Override
+  public boolean[] existsAll(List<Get> list) throws IOException {
+    boolean[] result = this.primaryTable.existsAll(list);
+    Futures.addCallback(
+        this.secondaryAsyncWrapper.existsAll(list),
+        this.verificationContinuationFactory.existsAll(list, result),
+        MoreExecutors.directExecutor());
+    return result;
+  }
+
+  @Override
+  public void batch(List<? extends Row> list, Object[] objects)
+      throws IOException, InterruptedException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Object[] batch(List<? extends Row> list) throws IOException, InterruptedException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <R> void batchCallback(List<? extends Row> list, Object[] objects, Callback<R> callback)
+      throws IOException, InterruptedException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <R> Object[] batchCallback(List<? extends Row> list, Callback<R> callback)
+      throws IOException, InterruptedException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Result get(Get get) throws IOException {
+    Result result = this.primaryTable.get(get);
+    Futures.addCallback(
+        this.secondaryAsyncWrapper.get(get),
+        this.verificationContinuationFactory.get(get, result),
+        MoreExecutors.directExecutor());
+    return result;
+  }
+
+  @Override
+  public Result[] get(List<Get> list) throws IOException {
+    Result[] result = this.primaryTable.get(list);
+    Futures.addCallback(
+        this.secondaryAsyncWrapper.get(list),
+        this.verificationContinuationFactory.get(list, result),
+        MoreExecutors.directExecutor());
+    return result;
+  }
+
+  @Override
+  public ResultScanner getScanner(Scan scan) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ResultScanner getScanner(byte[] bytes) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ResultScanner getScanner(byte[] bytes, byte[] bytes1) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void put(Put put) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void put(List<Put> list) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean checkAndPut(byte[] bytes, byte[] bytes1, byte[] bytes2, byte[] bytes3, Put put)
+      throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean checkAndPut(
+      byte[] bytes, byte[] bytes1, byte[] bytes2, CompareOp compareOp, byte[] bytes3, Put put)
+      throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void delete(Delete delete) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void delete(List<Delete> list) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean checkAndDelete(
+      byte[] bytes, byte[] bytes1, byte[] bytes2, byte[] bytes3, Delete delete) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean checkAndDelete(
+      byte[] bytes, byte[] bytes1, byte[] bytes2, CompareOp compareOp, byte[] bytes3, Delete delete)
+      throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void mutateRow(RowMutations rowMutations) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Result append(Append append) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Result increment(Increment increment) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long incrementColumnValue(byte[] bytes, byte[] bytes1, byte[] bytes2, long l)
+      throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long incrementColumnValue(
+      byte[] bytes, byte[] bytes1, byte[] bytes2, long l, Durability durability)
+      throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void close() throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public CoprocessorRpcChannel coprocessorService(byte[] bytes) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <T extends Service, R> Map<byte[], R> coprocessorService(
+      Class<T> aClass, byte[] bytes, byte[] bytes1, Call<T, R> call) throws Throwable {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <T extends Service, R> void coprocessorService(
+      Class<T> aClass, byte[] bytes, byte[] bytes1, Call<T, R> call, Callback<R> callback)
+      throws Throwable {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long getWriteBufferSize() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void setWriteBufferSize(long l) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <R extends Message> Map<byte[], R> batchCoprocessorService(
+      MethodDescriptor methodDescriptor, Message message, byte[] bytes, byte[] bytes1, R r)
+      throws Throwable {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <R extends Message> void batchCoprocessorService(
+      MethodDescriptor methodDescriptor,
+      Message message,
+      byte[] bytes,
+      byte[] bytes1,
+      R r,
+      Callback<R> callback)
+      throws Throwable {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean checkAndMutate(
+      byte[] bytes,
+      byte[] bytes1,
+      byte[] bytes2,
+      CompareOp compareOp,
+      byte[] bytes3,
+      RowMutations rowMutations)
+      throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void setOperationTimeout(int i) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int getOperationTimeout() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int getRpcTimeout() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void setRpcTimeout(int i) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int getReadRpcTimeout() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void setReadRpcTimeout(int i) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int getWriteRpcTimeout() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void setWriteRpcTimeout(int i) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/Comparators.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/Comparators.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.mirroring.hbase1_x.utils;
+
+import com.google.api.core.InternalApi;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellComparator;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.client.Result;
+
+@InternalApi("For internal usage only")
+public class Comparators {
+  public static boolean resultsEqual(Result result1, Result result2) {
+    if (result1 == null && result2 == null) {
+      return true;
+    }
+    if (result1 == null || result2 == null) {
+      return false;
+    }
+    int rowsComparisionResult =
+        CellComparator.compareRows(result1.getRow(), 0, 0, result2.getRow(), 0, 0);
+    if (rowsComparisionResult != 0) {
+      return false;
+    }
+    Cell[] cells1 = result1.rawCells();
+    Cell[] cells2 = result2.rawCells();
+    if (cells1.length != cells2.length) {
+      return false;
+    }
+    for (int i = 0; i < cells1.length; i++) {
+      int cellResult = CellComparator.compare(cells1[i], cells2[i], true);
+      if (cellResult != 0) {
+        return false;
+      }
+      if (!CellUtil.matchingValue(cells1[i], cells2[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/verification/DefaultMismatchDetector.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/verification/DefaultMismatchDetector.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.mirroring.hbase1_x.verification;
+
+import com.google.api.core.InternalApi;
+import com.google.cloud.bigtable.mirroring.hbase1_x.utils.Comparators;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Result;
+
+@InternalApi("For internal usage only")
+public class DefaultMismatchDetector implements MismatchDetector {
+  public void exists(Get request, boolean primary, boolean secondary) {
+    if (primary != secondary) {
+      System.out.println("exists mismatch");
+    }
+  }
+
+  @Override
+  public void exists(Get request, Throwable throwable) {
+    System.out.println("exists failed");
+  }
+
+  @Override
+  public void existsAll(List<Get> request, boolean[] primary, boolean[] secondary) {
+    if (!Arrays.equals(primary, secondary)) {
+      System.out.println("existsAll mismatch");
+    }
+  }
+
+  @Override
+  public void existsAll(List<Get> request, Throwable throwable) {
+    System.out.println("existsAll failed");
+  }
+
+  public void get(Get request, Result primary, Result secondary) {
+    if (!Comparators.resultsEqual(primary, secondary)) {
+      System.out.println("get mismatch");
+    }
+  }
+
+  @Override
+  public void get(Get request, Throwable throwable) {
+    System.out.println("get failed");
+  }
+
+  @Override
+  public void get(List<Get> request, Result[] primary, Result[] secondary) {
+    if (primary.length != secondary.length) {
+      System.out.println("getAll length mismatch");
+      return;
+    }
+
+    for (int i = 0; i < primary.length; i++) {
+      if (Comparators.resultsEqual(primary[i], secondary[i])) {
+        System.out.println("getAll mismatch");
+      }
+    }
+  }
+
+  @Override
+  public void get(List<Get> request, Throwable throwable) {
+    System.out.println("getAll failed");
+  }
+}

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/verification/MismatchDetector.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/verification/MismatchDetector.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.mirroring.hbase1_x.verification;
+
+import java.util.List;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Result;
+
+/**
+ * Detects mismatches between primary and secondary databases. User can provide own implementation
+ * (might be deriving from {@link DefaultMismatchDetector}) to handle only specific cases, such as
+ * ignoring timestamp mismatches or disabling verification of scan results.
+ */
+public interface MismatchDetector {
+  void exists(Get request, boolean primary, boolean secondary);
+
+  void exists(Get request, Throwable throwable);
+
+  void existsAll(List<Get> request, boolean[] primary, boolean[] secondary);
+
+  void existsAll(List<Get> request, Throwable throwable);
+
+  void get(Get request, Result primary, Result secondary);
+
+  void get(Get request, Throwable throwable);
+
+  void get(List<Get> request, Result[] primary, Result[] secondary);
+
+  void get(List<Get> request, Throwable throwable);
+}

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/verification/VerificationContinuationFactory.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/verification/VerificationContinuationFactory.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.mirroring.hbase1_x.verification;
+
+import com.google.api.core.InternalApi;
+import com.google.common.util.concurrent.FutureCallback;
+import java.util.List;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Result;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
+
+@InternalApi("For internal usage only")
+public class VerificationContinuationFactory {
+  private MismatchDetector mismatchDetector;
+
+  public VerificationContinuationFactory(MismatchDetector mismatchDetector) {
+    this.mismatchDetector = mismatchDetector;
+  }
+
+  public FutureCallback<Boolean> exists(final Get request, final boolean expectation) {
+    return new FutureCallback<Boolean>() {
+      @Override
+      public void onSuccess(@NullableDecl Boolean secondary) {
+        VerificationContinuationFactory.this.mismatchDetector.exists(
+            request, expectation, secondary);
+      }
+
+      @Override
+      public void onFailure(Throwable throwable) {
+        VerificationContinuationFactory.this.mismatchDetector.exists(request, throwable);
+      }
+    };
+  }
+
+  public FutureCallback<boolean[]> existsAll(final List<Get> request, final boolean[] expectation) {
+    return new FutureCallback<boolean[]>() {
+      @Override
+      public void onSuccess(@NullableDecl boolean[] secondary) {
+        VerificationContinuationFactory.this.mismatchDetector.existsAll(
+            request, expectation, secondary);
+      }
+
+      @Override
+      public void onFailure(Throwable throwable) {
+        VerificationContinuationFactory.this.mismatchDetector.existsAll(request, throwable);
+      }
+    };
+  }
+
+  public FutureCallback<Result> get(final Get request, final Result expectation) {
+    return new FutureCallback<Result>() {
+      @Override
+      public void onSuccess(@NullableDecl Result secondary) {
+        VerificationContinuationFactory.this.mismatchDetector.get(request, expectation, secondary);
+      }
+
+      @Override
+      public void onFailure(Throwable throwable) {
+        VerificationContinuationFactory.this.mismatchDetector.get(request, throwable);
+      }
+    };
+  }
+
+  public FutureCallback<Result[]> get(final List<Get> request, final Result[] expectation) {
+    return new FutureCallback<Result[]>() {
+      @Override
+      public void onSuccess(@NullableDecl Result[] secondary) {
+        VerificationContinuationFactory.this.mismatchDetector.get(request, expectation, secondary);
+      }
+
+      @Override
+      public void onFailure(Throwable throwable) {
+        VerificationContinuationFactory.this.mismatchDetector.get(request, throwable);
+      }
+    };
+  }
+}

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/TestMirroringConfiguration.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/TestMirroringConfiguration.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.mirroring.hbase1_x;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TestMirroringConfiguration {
+
+  private Exception assertInvalidConfiguration(final Configuration test) {
+    return assertThrows(
+        IllegalArgumentException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() throws Throwable {
+            new MirroringConfiguration(test);
+          }
+        });
+  }
+
+  @Test
+  public void testRequiresConfiguringImplClasses() {
+    Configuration testConfiguration = new Configuration(false);
+    Exception exc = assertInvalidConfiguration(testConfiguration);
+    assertThat(exc)
+        .hasMessageThat()
+        .contains("Specify google.bigtable.mirroring.primary-client.connection.impl");
+
+    testConfiguration = new Configuration(false);
+    testConfiguration.set(
+        MirroringConfiguration.MIRRORING_PRIMARY_CONNECTION_CLASS_KEY,
+        TestConnection.class.getCanonicalName());
+    exc = assertInvalidConfiguration(testConfiguration);
+    assertThat(exc)
+        .hasMessageThat()
+        .contains("Specify google.bigtable.mirroring.secondary-client.connection.impl");
+
+    testConfiguration = new Configuration(false);
+    testConfiguration.set(
+        MirroringConfiguration.MIRRORING_SECONDARY_CONNECTION_CLASS_KEY,
+        TestConnection.class.getCanonicalName());
+    exc = assertInvalidConfiguration(testConfiguration);
+    assertThat(exc)
+        .hasMessageThat()
+        .contains("Specify google.bigtable.mirroring.primary-client.connection.impl");
+  }
+
+  @Test
+  public void testSameConnectionClassesRequireOneOfPrefixes() {
+    Configuration testConfiguration = new Configuration(false);
+    testConfiguration.set(
+        MirroringConfiguration.MIRRORING_PRIMARY_CONNECTION_CLASS_KEY,
+        TestConnection.class.getCanonicalName());
+    testConfiguration.set(
+        MirroringConfiguration.MIRRORING_SECONDARY_CONNECTION_CLASS_KEY,
+        TestConnection.class.getCanonicalName());
+
+    Exception exc = assertInvalidConfiguration(testConfiguration);
+    assertThat(exc).hasMessageThat().contains("prefix");
+
+    testConfiguration.set(MirroringConfiguration.MIRRORING_PRIMARY_CONFIG_PREFIX_KEY, "test");
+    new MirroringConfiguration(testConfiguration);
+  }
+
+  @Test
+  public void testDifferentConnectionClassesDoNotRequirePrefix() {
+    Configuration testConfiguration = new Configuration(false);
+    testConfiguration.set(
+        MirroringConfiguration.MIRRORING_PRIMARY_CONNECTION_CLASS_KEY,
+        TestConnection.class.getCanonicalName());
+    testConfiguration.set(MirroringConfiguration.MIRRORING_SECONDARY_CONNECTION_CLASS_KEY, "test");
+
+    new MirroringConfiguration(testConfiguration);
+  }
+
+  @Test
+  public void testSamePrefixForPrimaryAndSecondaryIsNotAllowedIfConnectionClassesAreTheSame() {
+    Configuration testConfiguration = new Configuration(false);
+    testConfiguration.set(
+        MirroringConfiguration.MIRRORING_PRIMARY_CONNECTION_CLASS_KEY,
+        TestConnection.class.getCanonicalName());
+    testConfiguration.set(
+        MirroringConfiguration.MIRRORING_SECONDARY_CONNECTION_CLASS_KEY,
+        TestConnection.class.getCanonicalName());
+    testConfiguration.set(MirroringConfiguration.MIRRORING_PRIMARY_CONFIG_PREFIX_KEY, "test");
+    testConfiguration.set(MirroringConfiguration.MIRRORING_SECONDARY_CONFIG_PREFIX_KEY, "test");
+
+    assertInvalidConfiguration(testConfiguration);
+  }
+
+  @Test
+  public void testConfigurationPrefixesAreStrippedAndPassedAsConfigurations() {
+    Configuration testConfiguration = new Configuration(false);
+    testConfiguration.set(
+        MirroringConfiguration.MIRRORING_PRIMARY_CONNECTION_CLASS_KEY,
+        TestConnection.class.getCanonicalName());
+    testConfiguration.set(
+        MirroringConfiguration.MIRRORING_SECONDARY_CONNECTION_CLASS_KEY,
+        TestConnection.class.getCanonicalName());
+    testConfiguration.set(
+        MirroringConfiguration.MIRRORING_PRIMARY_CONFIG_PREFIX_KEY, "connection-1");
+    testConfiguration.set(
+        MirroringConfiguration.MIRRORING_SECONDARY_CONFIG_PREFIX_KEY, "connection-2");
+    testConfiguration.set("connection-2.test1", "21");
+    testConfiguration.set("connection-2.test2", "22");
+
+    testConfiguration.set("connection-1.test1", "11");
+    testConfiguration.set("connection-1.test2", "12");
+
+    MirroringConfiguration configuration = new MirroringConfiguration(testConfiguration);
+
+    assertThat(configuration.primaryConfiguration.get("test1")).isEqualTo("11");
+    assertThat(configuration.primaryConfiguration.get("test2")).isEqualTo("12");
+    assertThat(configuration.secondaryConfiguration.get("test1")).isEqualTo("21");
+    assertThat(configuration.secondaryConfiguration.get("test2")).isEqualTo("22");
+  }
+
+  @Test
+  public void testConfigWithoutPrefixReceivesAllProperties() {
+    Configuration testConfiguration = new Configuration(false);
+    testConfiguration.set(
+        MirroringConfiguration.MIRRORING_PRIMARY_CONNECTION_CLASS_KEY,
+        TestConnection.class.getCanonicalName());
+    testConfiguration.set(
+        MirroringConfiguration.MIRRORING_SECONDARY_CONNECTION_CLASS_KEY,
+        TestConnection.class.getCanonicalName());
+    testConfiguration.set(
+        MirroringConfiguration.MIRRORING_PRIMARY_CONFIG_PREFIX_KEY, "connection-1");
+    testConfiguration.set("connection-1.test1", "11");
+    testConfiguration.set("connection-1.test2", "12");
+    testConfiguration.set("not-a-connection-1.test3", "13");
+
+    testConfiguration.set("test1", "1");
+    testConfiguration.set("test2", "2");
+
+    MirroringConfiguration configuration = new MirroringConfiguration(testConfiguration);
+
+    assertThat(configuration.primaryConfiguration.get("test1")).isEqualTo("11");
+    assertThat(configuration.primaryConfiguration.get("test2")).isEqualTo("12");
+    // expected test1, test2, hbase.client.connection.impl
+    assertThat(configuration.primaryConfiguration.getValByRegex(".*")).hasSize(3);
+
+    assertThat(configuration.secondaryConfiguration.get("test1")).isEqualTo("1");
+    assertThat(configuration.secondaryConfiguration.get("test2")).isEqualTo("2");
+    assertThat(configuration.secondaryConfiguration.get("connection-1.test1")).isEqualTo("11");
+    assertThat(configuration.secondaryConfiguration.get("connection-1.test2")).isEqualTo("12");
+  }
+
+  @Test
+  public void testMirroringOptionsAreRead() {
+    Configuration testConfiguration = new Configuration(false);
+    testConfiguration.set(
+        MirroringConfiguration.MIRRORING_PRIMARY_CONNECTION_CLASS_KEY,
+        TestConnection.class.getCanonicalName());
+    testConfiguration.set(MirroringConfiguration.MIRRORING_SECONDARY_CONNECTION_CLASS_KEY, "test");
+    testConfiguration.set(MirroringOptions.MIRRORING_SYNCHRONOUS_KEY, "true");
+
+    MirroringConfiguration configuration = new MirroringConfiguration(testConfiguration);
+
+    assertThat(configuration.mirroringOptions.getSynchronous()).isTrue();
+  }
+
+  @Test
+  public void testConnectionClassesArePassedAsHbaseConfig() {
+    Configuration testConfiguration = new Configuration(false);
+    testConfiguration.set(MirroringConfiguration.MIRRORING_PRIMARY_CONNECTION_CLASS_KEY, "test1");
+    testConfiguration.set(MirroringConfiguration.MIRRORING_SECONDARY_CONNECTION_CLASS_KEY, "test2");
+    testConfiguration.set(
+        MirroringConfiguration.MIRRORING_PRIMARY_CONFIG_PREFIX_KEY, "connection-1");
+    MirroringConfiguration configuration = new MirroringConfiguration(testConfiguration);
+
+    assertThat(configuration.primaryConfiguration.get("hbase.client.connection.impl"))
+        .isEqualTo("test1");
+    assertThat(configuration.secondaryConfiguration.get("hbase.client.connection.impl"))
+        .isEqualTo("test2");
+  }
+}

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/TestMirroringConnection.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/TestMirroringConnection.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.mirroring.hbase1_x;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.BufferedMutator;
+import org.apache.hadoop.hbase.client.BufferedMutatorParams;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.RegionLocator;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.security.User;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+class TestConnection implements Connection {
+  public TestConnection(Configuration conf, boolean managed, ExecutorService pool, User user) {}
+
+  @Override
+  public Configuration getConfiguration() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Table getTable(TableName tableName) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Table getTable(TableName tableName, ExecutorService executorService) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public BufferedMutator getBufferedMutator(TableName tableName) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public BufferedMutator getBufferedMutator(BufferedMutatorParams bufferedMutatorParams)
+      throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public RegionLocator getRegionLocator(TableName tableName) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Admin getAdmin() throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void close() throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isClosed() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void abort(String s, Throwable throwable) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isAborted() {
+    throw new UnsupportedOperationException();
+  }
+}
+
+@RunWith(JUnit4.class)
+public class TestMirroringConnection {
+
+  @Test
+  public void testConnectionFactoryCreatesMirroringConnection() throws IOException {
+    Configuration testConfiguration = new Configuration();
+    testConfiguration.set("hbase.client.connection.impl", TestConnection.class.getCanonicalName());
+    MirroringConfiguration configuration =
+        new MirroringConfiguration(testConfiguration, testConfiguration, testConfiguration);
+    Connection connection = ConnectionFactory.createConnection(configuration);
+    assertTrue(connection instanceof MirroringConnection);
+  }
+}

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/TestMirroringTable.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/TestMirroringTable.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.mirroring.hbase1_x;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.bigtable.mirroring.hbase1_x.verification.MismatchDetector;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Table;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@RunWith(JUnit4.class)
+public class TestMirroringTable {
+  @Rule public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Mock Table primaryTable;
+  @Mock Table secondaryTable;
+  @Mock MismatchDetector mismatchDetector;
+
+  ExecutorService executorService;
+  MirroringTable mirroringTable;
+
+  @Before
+  public void setUp() {
+    this.executorService = Executors.newSingleThreadExecutor();
+    this.mirroringTable =
+        new MirroringTable(primaryTable, secondaryTable, this.executorService, mismatchDetector);
+  }
+
+  private Result createResult(String key, String... values) {
+    ArrayList<Cell> cells = new ArrayList<>();
+    for (int i = 0; i < values.length; i++) {
+      cells.add(CellUtil.createCell(key.getBytes(), values[i].getBytes()));
+    }
+    return Result.create(cells);
+  }
+
+  private Get createGet(String key) {
+    return new Get(key.getBytes());
+  }
+
+  private List<Get> createGets(String... keys) {
+    List<Get> result = new ArrayList<>();
+    for (String key : keys) {
+      result.add(createGet(key));
+    }
+    return result;
+  }
+
+  private void waitForExecutor() {
+    executorService.shutdown();
+    try {
+      executorService.awaitTermination(3, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  public void testMismatchDetectorIsCalledOnGetSingle() throws IOException {
+    Get get = createGets("test").get(0);
+    Result expectedResult = createResult("test", "value");
+
+    when(primaryTable.get(get)).thenReturn(expectedResult);
+    when(secondaryTable.get(get)).thenReturn(expectedResult);
+
+    Result result = mirroringTable.get(get);
+    waitForExecutor();
+
+    assertThat(result).isEqualTo(expectedResult);
+
+    verify(mismatchDetector, times(1)).get(get, expectedResult, expectedResult);
+    verify(mismatchDetector, never()).get((Get) any(), (Throwable) any());
+    verify(mismatchDetector, never())
+        .get(ArgumentMatchers.<Get>anyList(), any(Result[].class), any(Result[].class));
+  }
+
+  @Test
+  public void testSecondaryReadExceptionCallsVerificationErrorHandlerOnSingleGet()
+      throws IOException {
+    Get request = createGet("test");
+    Result expectedResult = createResult("test", "value");
+
+    when(primaryTable.get(request)).thenReturn(expectedResult);
+    IOException expectedException = new IOException("expected");
+    when(secondaryTable.get(request)).thenThrow(expectedException);
+
+    Result result = mirroringTable.get(request);
+    waitForExecutor();
+
+    assertThat(result).isEqualTo(expectedResult);
+
+    verify(mismatchDetector, times(1)).get(request, expectedException);
+  }
+
+  @Test
+  public void testMismatchDetectorIsCalledOnGetMultiple() throws IOException {
+    List<Get> get = Arrays.asList(createGets("test").get(0));
+    Result[] expectedResult = new Result[] {createResult("test", "value")};
+
+    when(primaryTable.get(get)).thenReturn(expectedResult);
+    when(secondaryTable.get(get)).thenReturn(expectedResult);
+
+    Result[] result = mirroringTable.get(get);
+    waitForExecutor();
+
+    assertThat(result).isEqualTo(expectedResult);
+
+    verify(mismatchDetector, times(1)).get(get, expectedResult, expectedResult);
+    verify(mismatchDetector, never()).get((Get) any(), (Throwable) any());
+    verify(mismatchDetector, never()).get((Get) any(), (Result) any(), (Result) any());
+  }
+
+  @Test
+  public void testSecondaryReadExceptionCallsVerificationErrorHandlerOnGetMultiple()
+      throws IOException {
+    List<Get> request = createGets("test1", "test2");
+    Result[] expectedResult =
+        new Result[] {createResult("test1", "value1"), createResult("test2", "value2")};
+
+    when(primaryTable.get(request)).thenReturn(expectedResult);
+    IOException expectedException = new IOException("expected");
+    when(secondaryTable.get(request)).thenThrow(expectedException);
+
+    Result[] result = mirroringTable.get(request);
+    waitForExecutor();
+
+    assertThat(result).isEqualTo(expectedResult);
+
+    verify(mismatchDetector, times(1)).get(request, expectedException);
+  }
+
+  @Test
+  public void testMismatchDetectorIsCalledOnExists() throws IOException {
+    Get get = createGet("test");
+    boolean expectedResult = true;
+
+    when(primaryTable.exists(get)).thenReturn(expectedResult);
+    when(secondaryTable.exists(get)).thenReturn(expectedResult);
+
+    boolean result = mirroringTable.exists(get);
+    waitForExecutor();
+
+    assertThat(result).isEqualTo(expectedResult);
+
+    verify(mismatchDetector, times(1)).exists(get, expectedResult, expectedResult);
+    verify(mismatchDetector, never()).exists((Get) any(), (Throwable) any());
+  }
+
+  @Test
+  public void testSecondaryReadExceptionCallsVerificationErrorHandlerOnExists() throws IOException {
+    Get request = createGet("test");
+    boolean expectedResult = true;
+
+    when(primaryTable.exists(request)).thenReturn(expectedResult);
+    IOException expectedException = new IOException("expected");
+    when(secondaryTable.exists(request)).thenThrow(expectedException);
+
+    boolean result = mirroringTable.exists(request);
+    waitForExecutor();
+
+    assertThat(result).isEqualTo(expectedResult);
+
+    verify(mismatchDetector, times(1)).exists(request, expectedException);
+  }
+
+  @Test
+  public void testMismatchDetectorIsCalledOnExistsAll() throws IOException {
+    List<Get> get = Arrays.asList(createGets("test").get(0));
+    boolean[] expectedResult = new boolean[] {true, false};
+
+    when(primaryTable.existsAll(get)).thenReturn(expectedResult);
+    when(secondaryTable.existsAll(get)).thenReturn(expectedResult);
+
+    boolean[] result = mirroringTable.existsAll(get);
+    waitForExecutor();
+
+    assertThat(result).isEqualTo(expectedResult);
+
+    verify(mismatchDetector, times(1)).existsAll(get, expectedResult, expectedResult);
+    verify(mismatchDetector, never()).existsAll(ArgumentMatchers.<Get>anyList(), (Throwable) any());
+  }
+
+  @Test
+  public void testSecondaryReadExceptionCallsVerificationErrorHandlerOnExistsAll()
+      throws IOException {
+    List<Get> request = createGets("test1", "test2");
+    boolean[] expectedResult = new boolean[] {true, false};
+
+    when(primaryTable.existsAll(request)).thenReturn(expectedResult);
+    IOException expectedException = new IOException("expected");
+    when(secondaryTable.existsAll(request)).thenThrow(expectedException);
+
+    boolean[] result = mirroringTable.existsAll(request);
+    waitForExecutor();
+
+    assertThat(result).isEqualTo(expectedResult);
+
+    verify(mismatchDetector, times(1)).existsAll(request, expectedException);
+  }
+}

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/TestResultComparator.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/TestResultComparator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.cloud.bigtable.mirroring.hbase1_x.utils;
 
 import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.Comparators.resultsEqual;

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/TestResultComparator.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/TestResultComparator.java
@@ -1,0 +1,111 @@
+package com.google.cloud.bigtable.mirroring.hbase1_x.utils;
+
+import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.Comparators.resultsEqual;
+import static com.google.common.truth.Truth.assertThat;
+
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.KeyValue.Type;
+import org.apache.hadoop.hbase.client.Result;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TestResultComparator {
+  private Cell createCell(
+      String row, String family, String qualifier, int timestamp, Type type, String value) {
+    return CellUtil.createCell(
+        row.getBytes(),
+        family.getBytes(),
+        qualifier.getBytes(),
+        timestamp,
+        type.getCode(),
+        value.getBytes());
+  }
+
+  private Result createResult(Cell... cells) {
+    return Result.create(cells);
+  }
+
+  @Test
+  public void testEqualResults() {
+    assertThat(
+            resultsEqual(
+                createResult(
+                    createCell("r1", "f1", "q1", 1, Type.Put, "v1"),
+                    createCell("r2", "f2", "q2", 2, Type.Put, "v2")),
+                createResult(
+                    createCell("r1", "f1", "q1", 1, Type.Put, "v1"),
+                    createCell("r2", "f2", "q2", 2, Type.Put, "v2"))))
+        .isTrue();
+
+    assertThat(
+            resultsEqual(
+                createResult(createCell("r1", "f1", "q1", 1, Type.Put, "v1")),
+                createResult(createCell("r1", "f1", "q1", 1, Type.Put, "v1"))))
+        .isTrue();
+  }
+
+  @Test
+  public void testNotMatchingLengths() {
+    assertThat(
+            resultsEqual(
+                createResult(
+                    createCell("r1", "f1", "q1", 1, Type.Put, "v1"),
+                    createCell("r2", "f2", "q2", 2, Type.Put, "v2"),
+                    createCell("r3", "", "", 0, Type.Put, "")),
+                createResult(
+                    createCell("r1", "f1", "q1", 1, Type.Put, "v1"),
+                    createCell("r2", "f2", "q2", 2, Type.Put, "v2"))))
+        .isFalse();
+
+    assertThat(
+            resultsEqual(
+                createResult(
+                    createCell("r1", "f1", "q1", 1, Type.Put, "v1"),
+                    createCell("r2", "f2", "q2", 2, Type.Put, "v2")),
+                createResult(
+                    createCell("r1", "f1", "q1", 1, Type.Put, "v1"),
+                    createCell("r2", "f2", "q2", 2, Type.Put, "v2"),
+                    createCell("r3", "", "", 0, Type.Put, ""))))
+        .isFalse();
+  }
+
+  @Test
+  public void testNotMatchingCellContents() {
+
+    assertThat(
+            resultsEqual(
+                createResult(createCell("r3", "f1", "q1", 1, Type.Put, "v1")),
+                createResult(createCell("r1", "f1", "q1", 1, Type.Put, "v1"))))
+        .isFalse();
+    assertThat(
+            resultsEqual(
+                createResult(createCell("r1", "f3", "q1", 1, Type.Put, "v1")),
+                createResult(createCell("r1", "f1", "q1", 1, Type.Put, "v1"))))
+        .isFalse();
+    assertThat(
+            resultsEqual(
+                createResult(createCell("r1", "f1", "q3", 1, Type.Put, "v1")),
+                createResult(createCell("r1", "f1", "q1", 1, Type.Put, "v1"))))
+        .isFalse();
+
+    assertThat(
+            resultsEqual(
+                createResult(createCell("r1", "f1", "q1", 3, Type.Put, "v1")),
+                createResult(createCell("r1", "f1", "q1", 1, Type.Put, "v1"))))
+        .isFalse();
+
+    assertThat(
+            resultsEqual(
+                createResult(createCell("r1", "f1", "q1", 1, Type.Delete, "v1")),
+                createResult(createCell("r1", "f1", "q1", 1, Type.Put, "v1"))))
+        .isFalse();
+    assertThat(
+            resultsEqual(
+                createResult(createCell("r1", "f1", "q1", 1, Type.Put, "v3")),
+                createResult(createCell("r1", "f1", "q1", 1, Type.Put, "v1"))))
+        .isFalse();
+  }
+}

--- a/bigtable-hbase-mirroring-client-1.x-parent/pom.xml
+++ b/bigtable-hbase-mirroring-client-1.x-parent/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2021 Google LCC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.google.cloud.bigtable</groupId>
+    <artifactId>bigtable-client-parent</artifactId>
+    <version>2.0.0-alpha2-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-parent:current} -->
+  </parent>
+
+  <artifactId>bigtable-hbase-mirroring-client-1.x-parent</artifactId>
+  <packaging>pom</packaging>
+  <name>${project.groupId}:${project.artifactId}</name>
+  <version>0.0.1-alpha1-SNAPSHOT</version>
+  <description>
+    This project is a parent project for the hbase 1.x mirroring client projects.
+  </description>
+
+  <modules>
+    <module>bigtable-hbase-mirroring-client-1.x</module>
+  </modules>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <configuration>
+            <windowtitle>
+              HBase / Bigtable mirroring Client
+            </windowtitle>
+            <doctitle>
+              HBase / Bigtable mirroring Client
+            </doctitle>
+            <overview>../overview.html</overview>
+            <bottom><![CDATA[<br>]]></bottom>
+
+            <detectLinks />
+            <links>
+              <link>https://hbase.apache.org/apidocs/</link>
+              <link>http://www.grpc.io/grpc-java/javadoc/</link>
+            </links>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@ limitations under the License.
     <module>bigtable-hbase-2.x-parent</module>
     <module>bigtable-dataflow-parent</module>
     <module>bigtable-test</module>
+    <module>bigtable-hbase-mirroring-client-1.x-parent</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
This PR introduces configuration, a `MirroringTable` with a simplistic implementation of some requests and an `AsyncTableWrapper`, which enables that implementation.