### PR TITLE
deps(fix): bump log4j2 to 2.16.0 and ban all 2.x.x versions which are < 2.16.0

### DIFF
--- a/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
@@ -246,6 +246,11 @@ limitations under the License.
       <version>1.21</version>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j2.version}</version>
+    </dependency>
 
 
     <!-- Test Group -->
@@ -426,6 +431,17 @@ limitations under the License.
         <configuration>
           <!-- disable integration tests by default, opt-in via profile -->
           <skip>true</skip>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <!-- log4j-api dependency is added to enforce log4j versions with CVE fixes -->
+            <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-api</ignoredUnusedDeclaredDependency>
+          </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>
 

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/pom.xml
@@ -141,6 +141,12 @@ limitations under the License.
       <version>${beam-slf4j.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j2.version}</version>
+    </dependency>
+
     <!-- Test Group -->
     <dependency>
       <groupId>org.mockito</groupId>
@@ -318,6 +324,16 @@ limitations under the License.
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <!-- log4j-api dependency is added to enforce log4j versions with CVE fixes -->
+            <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-api</ignoredUnusedDeclaredDependency>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/pom.xml
@@ -11,7 +11,6 @@
 
   <properties>
     <mainclass>com.google.cloud.bigtable.hbase.tools.HBaseSchemaTranslator</mainclass>
-    <log4j2.version>2.15.0</log4j2.version>
   </properties>
   <artifactId>bigtable-hbase-1.x-tools</artifactId>
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@ limitations under the License.
     <slf4j.version>1.7.25</slf4j.version>
     <commons-logging.version>1.2</commons-logging.version>
     <jsr305.version>3.0.2</jsr305.version>
+    <log4j2.version>2.16.0</log4j2.version>
 
     <!-- hbase dependency versions -->
     <hbase1.version>1.7.1</hbase1.version>
@@ -337,6 +338,28 @@ limitations under the License.
                   <excludes>
                     <exclude>commons-codec:commons-codec:[,1.15)</exclude>
                     <exclude>org.apache.commons:commons-compress:[,1.20)</exclude>
+                  </excludes>
+                </bannedDependencies>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-banned-deps</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <!-- ban all log4j 2.x deps with CVEs -->
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>org.apache.logging.log4j:*:[2.0-alpha1,2.15.0]</exclude>
                   </excludes>
                 </bannedDependencies>
               </rules>


### PR DESCRIPTION
(port of #3380)
