### PR TITLE
deps: overriding protobuf version to 3.18.2

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -32,6 +32,12 @@ limitations under the License.
 
   <dependencyManagement>
     <dependencies>
+      <!-- override protobuf-java version -->
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${protobuf-java-test.version}</version>
+      </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigtable-bom</artifactId>
@@ -142,15 +148,14 @@ limitations under the License.
       <groupId>com.google.api</groupId>
       <artifactId>api-common</artifactId>
     </dependency>
-    <dependency>
+   <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
     </dependency>
-    <dependency>
+   <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
     </dependency>
-
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/pom.xml
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/pom.xml
@@ -30,12 +30,6 @@ limitations under the License.
   </description>
 
   <dependencies>
-    <!-- override protobuf-java version -->
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-      <version>${protobuf-java-test.version}</version>
-    </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-shaded-testing-util</artifactId>

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/pom.xml
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/pom.xml
@@ -30,6 +30,12 @@ limitations under the License.
   </description>
 
   <dependencies>
+    <!-- override protobuf-java version -->
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf-java-test.version}</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-shaded-testing-util</artifactId>

--- a/bigtable-client-core-parent/bigtable-hbase/pom.xml
+++ b/bigtable-client-core-parent/bigtable-hbase/pom.xml
@@ -33,6 +33,12 @@ limitations under the License.
 
   <dependencyManagement>
     <dependencies>
+      <!-- override protobuf-java version -->
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${protobuf-java-test.version}</version>
+      </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigtable-bom</artifactId>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
@@ -313,6 +313,12 @@ limitations under the License.
 
   <dependencyManagement>
     <dependencies>
+      <!-- override protobuf-java version -->
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${protobuf-java-test.version}</version>
+      </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigtable-bom</artifactId>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -34,6 +34,12 @@ limitations under the License.
 
   <dependencyManagement>
     <dependencies>
+      <!-- override protobuf-java version -->
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${protobuf-java-test.version}</version>
+      </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigtable-bom</artifactId>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/pom.xml
@@ -35,6 +35,12 @@ limitations under the License.
 
   <dependencyManagement>
     <dependencies>
+      <!-- override protobuf-java version -->
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${protobuf-java-test.version}</version>
+      </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigtable-bom</artifactId>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
@@ -308,6 +308,12 @@ limitations under the License.
 
   <dependencyManagement>
     <dependencies>
+      <!-- override protobuf-java version -->
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${protobuf-java-test.version}</version>
+      </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigtable-bom</artifactId>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
@@ -328,6 +328,12 @@ limitations under the License.
 
   <dependencies>
     <!-- Project Modules -->
+    <!-- override protobuf-java version -->
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf-java-test.version}</version>
+    </dependency>
     <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
       <artifactId>bigtable-hbase</artifactId>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
@@ -328,12 +328,6 @@ limitations under the License.
 
   <dependencies>
     <!-- Project Modules -->
-    <!-- override protobuf-java version -->
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-      <version>${protobuf-java-test.version}</version>
-    </dependency>
     <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
       <artifactId>bigtable-hbase</artifactId>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
@@ -38,6 +38,12 @@ limitations under the License.
 
   <dependencyManagement>
     <dependencies>
+      <!-- overriding protobuf-java version -->
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${protobuf-java-test.version}</version>
+      </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigtable-bom</artifactId>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/pom.xml
@@ -39,6 +39,12 @@ limitations under the License.
 
   <dependencyManagement>
     <dependencies>
+      <!-- override protobuf-java version -->
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${protobuf-java-test.version}</version>
+      </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigtable-bom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@ limitations under the License.
     <commons-logging.version>1.2</commons-logging.version>
     <jsr305.version>3.0.2</jsr305.version>
     <log4j2.version>2.16.0</log4j2.version>
+    <protobuf-java-test.version>3.16.1</protobuf-java-test.version>
 
     <!-- hbase dependency versions -->
     <hbase.version.1>1.4.12</hbase.version.1>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@ limitations under the License.
     <commons-logging.version>1.2</commons-logging.version>
     <jsr305.version>3.0.2</jsr305.version>
     <log4j2.version>2.17.1</log4j2.version>
+    <protobuf-java-test.version>3.18.2</protobuf-java-test.version>
 
     <!-- hbase dependency versions -->
     <hbase.version.1>1.4.12</hbase.version.1>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@ limitations under the License.
     <commons-logging.version>1.2</commons-logging.version>
     <jsr305.version>3.0.2</jsr305.version>
     <log4j2.version>2.16.0</log4j2.version>
-    <protobuf-java-test.version>3.16.1</protobuf-java-test.version>
+    <protobuf-java-test.version>3.18.2</protobuf-java-test.version>
 
     <!-- hbase dependency versions -->
     <hbase.version.1>1.4.12</hbase.version.1>


### PR DESCRIPTION
Testing protobuf dependency version 3.18.2 . Not to be merged.