### PR TITLE
build: update renovate config to ignore pinned slf4j versions

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -72,21 +72,8 @@
       "groupName": "jackson dependencies"
     },
     {
-      // pin to beam deps
-      "packagePatterns": ["^beam-slf4j.version"],
-      "enabled": false
-    },
-    {
-      // pin to hbase deps
-      "packagePatterns": [
-        "^hbase.-hadoop-slf4j.version",
-        "^hbase.-mapreduce-slfj.version"
-      ],
-      "enabled": false
-    },
-    {
-      // pin to bigtable version
-      "packagePatterns": ["^grpc-conscrypt.version"],
+      // pin to hbase, hadoop, or beam deps (depending on module)
+      "packagePatterns": ["^slf4j"],
       "enabled": false
     },
     {


### PR DESCRIPTION
The defined properties we have don't seem to be working - changing the config to ignore any slf4j packages, as they all are pinned to different versions.