### PR TITLE
fix: do not use system class loader

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncRegistry.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncRegistry.java
@@ -22,7 +22,6 @@ import java.util.concurrent.CompletableFuture;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
-import net.bytebuddy.dynamic.loading.InjectionClassLoader;
 import net.bytebuddy.implementation.FixedValue;
 import net.bytebuddy.implementation.InvocationHandlerAdapter;
 import net.bytebuddy.implementation.MethodCall;

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncRegistry.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncRegistry.java
@@ -89,7 +89,7 @@ public class BigtableAsyncRegistry {
         .method(ElementMatchers.named("getClusterId"))
         .intercept(FixedValue.value((CompletableFuture.completedFuture("NoopClusterId"))))
         .make()
-        .load(InjectionClassLoader.getSystemClassLoader(), ClassLoadingStrategy.Default.INJECTION)
+        .load(BigtableAsyncRegistry.class.getClassLoader(), ClassLoadingStrategy.Default.INJECTION)
         .getLoaded();
   }
 


### PR DESCRIPTION
System classloader seems to cause problem when using with spark and a different hbase version. Use BigtableAsyncRegistry classloader instead.
