### PR TITLE
deps: upgrade guava to 31.1-jre and Bigtable to 2.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@ limitations under the License.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- core dependency versions -->
-    <bigtable.version>2.5.3</bigtable.version>
+    <bigtable.version>2.6.2</bigtable.version>
     <bigtable-client-core.version>1.26.3</bigtable-client-core.version>
     <grpc-conscrypt.version>2.5.1</grpc-conscrypt.version>
     <!--  keeping at this version to align with hbase-->

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@ limitations under the License.
     <!-- TODO: check if commons-codec was transitively updated to 1.13 and okhttp was updated to 2.7.5 when upgrading-->
     <beam.version>2.35.0</beam.version>
     <!-- referred from bigtable-beam-import and bigtable-emulator -->
-    <guava.version>31.0.1-jre</guava.version>
+    <guava.version>31.1-jre</guava.version>
     <gcs-guava.version>29.0-jre</gcs-guava.version>
     <beam-slf4j.version>1.7.30</beam-slf4j.version>
 


### PR DESCRIPTION
Updated guava to `31.1-jre` to avoid Maven's `RequireUpperBoundDeps` error
Updated Bigtable version to '2.6.2' (On behalf of https://github.com/googleapis/java-bigtable-hbase/pull/3541)