### PR TITLE
deps: use errorprone from shared deps

### DIFF
--- a/bigtable-dataflow-parent/bigtable-hbase-beam/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/pom.xml
@@ -27,17 +27,6 @@ limitations under the License.
     and writers in Google Cloud Dataflow.
   </description>
 
-  <dependencyManagement>
-    <dependencies>
-      <!-- fix conflict beam internal between beam-sdks-java-core & beam-model-pipeline -->
-      <dependency>
-        <groupId>com.google.errorprone</groupId>
-        <artifactId>error_prone_annotations</artifactId>
-        <version>2.13.1</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <!-- Beam Group: should come first since we will be running in the beam ecosystem -->
     <dependency>


### PR DESCRIPTION
The shared dependencies BOM provides the latest error_prone_annotations version. No need to specify in individual repositories.

The version was last updated by RenovateBot https://github.com/googleapis/java-bigtable-hbase/pull/3580 to the latest.
