### PR TITLE
fix: published dependencies of bigtable-beam-import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,8 @@ limitations under the License.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.3.0</version>
+          <!-- MSHADE-419: 3.3.0 Shade plugin causes pom to be created without compile dependencies -->
+          <version>3.2.4</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/renovate.json5
+++ b/renovate.json5
@@ -88,6 +88,13 @@
       // pin to bigtable version
       "packagePatterns": ["^grpc-conscrypt.version"],
       "enabled": false
+    },
+    {
+      "packagePatterns": [
+        "^org.apache.maven.plugins:maven-shade-plugin"
+      ],
+      // Exclude version 3.3.0 due to https://issues.apache.org/jira/projects/MSHADE/issues/MSHADE-419
+      "allowedVersions": "(,3.3.0),(3.3.0,)"
     }
   ],
   "semanticCommits": true,


### PR DESCRIPTION
Due to a bug in maven shade plugin 3.3.0,  compile dependencies got stripped from bigtable-beam-import. This bug only affects artifacts where shadedArtifactAttached=true.

Reference: https://issues.apache.org/jira/projects/MSHADE/issues/MSHADE-419

