### PR TITLE
chore: remove deprecation notice for latency based throttling

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BulkOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BulkOptions.java
@@ -172,17 +172,17 @@ public class BulkOptions implements Serializable, Cloneable {
      * Enable an experimental feature that will throttle requests from {@link BulkMutation} if
      * request latency surpasses a latency threshold. The default is {@link
      * BulkOptions#BIGTABLE_BULK_THROTTLE_TARGET_MS_DEFAULT}.
-     *
-     * @deprecated This will be removed in the future
      */
-    @Deprecated
     public Builder enableBulkMutationThrottling() {
       options.enableBulkMutationThrottling = true;
       return this;
     }
 
-    /** @deprecated This will be removed in the future */
-    @Deprecated
+    /**
+     * Configure the threshold latency for enabling throttling. When enabled via {@link #enableBulkMutationThrottling},
+     * the client will reduce the amount of concurrency when average latency is higher than the
+     * configured target.
+     */
     public Builder setBulkMutationRpcTargetMs(int bulkMutationRpcTargetMs) {
       options.bulkMutationRpcTargetMs = bulkMutationRpcTargetMs;
       return this;


### PR DESCRIPTION
The alternative is not ready yet and the deprecation notice is causing confusion

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable-hbase/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
