### PR TITLE
chore(test): bypass maven-emulator-plugin and use the emulator directly

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/pom.xml
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/pom.xml
@@ -29,6 +29,18 @@ limitations under the License.
     This project contains common test infrastructure
   </description>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bigtable-bom</artifactId>
+        <version>${bigtable.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
@@ -39,6 +51,17 @@ limitations under the License.
         <exclusion>
           <groupId>org.apache.hbase</groupId>
           <artifactId>hbase-shaded-client</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-bigtable-emulator</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestCreateTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestCreateTable.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 
 public abstract class AbstractTestCreateTable extends AbstractTest {
@@ -168,6 +169,7 @@ public abstract class AbstractTestCreateTable extends AbstractTest {
   }
 
   @Test
+  @Category(KnownEmulatorGap.class)
   public void testSplitKeys() throws Exception {
     byte[][] splits =
         new byte[][] {
@@ -231,6 +233,7 @@ public abstract class AbstractTestCreateTable extends AbstractTest {
   }
 
   @Test
+  @Category(KnownEmulatorGap.class)
   public void testThreeRegionSplit() throws Exception {
 
     TableName tableName = sharedTestEnv.newTestTableName();
@@ -266,6 +269,7 @@ public abstract class AbstractTestCreateTable extends AbstractTest {
   }
 
   @Test
+  @Category(KnownEmulatorGap.class)
   public void testFiveRegionSplit() throws Exception {
     TableName tableName = sharedTestEnv.newTestTableName();
     byte[] startKey = Bytes.toBytes("AAA");

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestTruncateTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestTruncateTable.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -67,6 +68,7 @@ public abstract class AbstractTestTruncateTable extends AbstractTest {
   }
 
   @Test
+  @Category(KnownEmulatorGap.class)
   public void testTruncateWithSplits() throws IOException {
     byte[][] splits =
         new byte[][] {

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/CloudEnv.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/CloudEnv.java
@@ -37,7 +37,7 @@ import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
 
-class BigtableEnv extends SharedTestEnv {
+class CloudEnv extends SharedTestEnv {
   private final Logger LOG = new Logger(getClass());
 
   private static final Set<String> KEYS =

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/EmulatorEnv.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/EmulatorEnv.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.test_env;
+
+import com.google.cloud.bigtable.emulator.v2.Emulator;
+import com.google.cloud.bigtable.hbase.BigtableConfiguration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+
+public class EmulatorEnv extends SharedTestEnv {
+  private Emulator emulator;
+
+  @Override
+  protected void setup() throws Exception {
+    emulator = Emulator.createBundled();
+    emulator.start();
+
+    configuration = HBaseConfiguration.create();
+    configuration = BigtableConfiguration.configure(configuration, "fake-project", "fake-instance");
+    configuration.set("google.bigtable.emulator.endpoint.host", "localhost:" + emulator.getPort());
+  }
+
+  @Override
+  protected void teardown() {
+    emulator.stop();
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnv.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnv.java
@@ -49,8 +49,10 @@ abstract class SharedTestEnv {
     switch (testEnv) {
       case "minicluster":
         return new MiniClusterEnv();
-      case "bigtable":
-        return new BigtableEnv();
+      case "cloud":
+        return new CloudEnv();
+      case "emulator":
+        return new EmulatorEnv();
       default:
         throw new IllegalStateException("unsupported test environment");
     }

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnvRule.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnvRule.java
@@ -139,7 +139,7 @@ public class SharedTestEnvRule extends ExternalResource {
 
   public boolean isBigtable() {
     // TODO(igorbernstein2): clean this up
-    return sharedTestEnv instanceof BigtableEnv;
+    return sharedTestEnv instanceof CloudEnv;
   }
 
   public TableName getDefaultTableName() {

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
@@ -67,7 +67,7 @@ limitations under the License.
                   <!-- Fork & set system properties -->
                   <forkCount>1</forkCount>
                   <systemPropertyVariables>
-                    <google.bigtable.test_env>bigtable</google.bigtable.test_env>
+                    <google.bigtable.test_env>cloud</google.bigtable.test_env>
                   </systemPropertyVariables>
                   <forkedProcessTimeoutInSeconds>${test.timeout}</forkedProcessTimeoutInSeconds>
 
@@ -127,23 +127,6 @@ limitations under the License.
       <build>
         <plugins>
           <plugin>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>bigtable-emulator-maven-plugin</artifactId>
-            <version>2.2.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-parent:current} -->
-            <executions>
-              <execution>
-                <goals>
-                  <goal>start</goal>
-                  <goal>stop</goal>
-                </goals>
-                <configuration>
-                  <propertyName>bigtable.emulator.endpoint</propertyName>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-
-          <plugin>
             <artifactId>maven-failsafe-plugin</artifactId>
             <executions>
               <execution>
@@ -158,13 +141,8 @@ limitations under the License.
                   </includes>
                   <excludedGroups>KnownEmulatorGap,KnownGap</excludedGroups>
                   <systemPropertyVariables>
-                    <google.bigtable.test_env>bigtable</google.bigtable.test_env>
-                    <google.bigtable.project.id>fake-project</google.bigtable.project.id>
-                    <google.bigtable.instance.id>fake-instance</google.bigtable.instance.id>
+                    <google.bigtable.test_env>emulator</google.bigtable.test_env>
                   </systemPropertyVariables>
-                  <environmentVariables>
-                    <BIGTABLE_EMULATOR_HOST>${bigtable.emulator.endpoint}</BIGTABLE_EMULATOR_HOST>
-                  </environmentVariables>
                   <forkedProcessTimeoutInSeconds>${test.timeout}</forkedProcessTimeoutInSeconds>
                   <!-- Make sure to fail the build when the suite fails to initialize -->
                   <failIfNoTests>true</failIfNoTests>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestGet.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestGet.java
@@ -466,6 +466,7 @@ public class TestGet extends AbstractTest {
 
   /** Requirement 3.16 - When submitting an array of Get operations, if one fails, they all fail. */
   @Test
+  @Category(KnownEmulatorGap.class)
   public void testOneBadApple() throws IOException {
     // Initialize data
     Table table = getDefaultTable();

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSnapshots.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSnapshots.java
@@ -38,7 +38,12 @@ import org.apache.hadoop.hbase.snapshot.RestoreSnapshotException;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
+@Category(KnownEmulatorGap.class)
 public class TestSnapshots extends AbstractTestSnapshot {
 
   @Before

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
@@ -68,7 +68,7 @@ limitations under the License.
                   <!-- Fork & set system properties -->
                   <forkCount>1</forkCount>
                   <systemPropertyVariables>
-                    <google.bigtable.test_env>bigtable</google.bigtable.test_env>
+                    <google.bigtable.test_env>cloud</google.bigtable.test_env>
                   </systemPropertyVariables>
                   <forkedProcessTimeoutInSeconds>${test.timeout}</forkedProcessTimeoutInSeconds>
 
@@ -128,23 +128,6 @@ limitations under the License.
       <build>
         <plugins>
           <plugin>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>bigtable-emulator-maven-plugin</artifactId>
-            <version>2.2.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-parent:current} -->
-            <executions>
-              <execution>
-                <goals>
-                  <goal>start</goal>
-                  <goal>stop</goal>
-                </goals>
-                <configuration>
-                  <propertyName>bigtable.emulator.endpoint</propertyName>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-
-          <plugin>
             <artifactId>maven-failsafe-plugin</artifactId>
             <executions>
               <execution>
@@ -159,13 +142,8 @@ limitations under the License.
                   </includes>
                   <excludedGroups>KnownEmulatorGap,KnownGap</excludedGroups>
                   <systemPropertyVariables>
-                    <google.bigtable.project.id>fake-project</google.bigtable.project.id>
-                    <google.bigtable.instance.id>fake-instance</google.bigtable.instance.id>
-                    <google.bigtable.test_env>bigtable</google.bigtable.test_env>
+                    <google.bigtable.test_env>emulator</google.bigtable.test_env>
                   </systemPropertyVariables>
-                  <environmentVariables>
-                    <BIGTABLE_EMULATOR_HOST>${bigtable.emulator.endpoint}</BIGTABLE_EMULATOR_HOST>
-                  </environmentVariables>
                   <forkedProcessTimeoutInSeconds>${test.timeout}</forkedProcessTimeoutInSeconds>
                   <!-- Make sure to fail the build when the suite fails to initialize -->
                   <failIfNoTests>true</failIfNoTests>


### PR DESCRIPTION
This will improve usability by allowing each failsafe execution to be run with it own emulator instance and remove the need for using a separate test script in https://github.com/googleapis/java-bigtable-hbase/pull/3626

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable-hbase/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
