### PR TITLE
fix: update syntax in readme for dataflow max workers

### DIFF
--- a/bigtable-dataflow-parent/bigtable-beam-import/README.md
+++ b/bigtable-dataflow-parent/bigtable-beam-import/README.md
@@ -152,7 +152,7 @@ Please pay attention to the Cluster CPU usage and adjust the number of Dataflow 
         --snapshotName=$SNAPSHOT_NAME \
         --stagingLocation=$SNAPSHOT_GCS_PATH/staging \
         --gcpTempLocation=$SNAPSHOT_GCS_PATH/temp \
-        --maxWorkerNodes=$(expr 3 \* $CLUSTER_NUM_NODES) \
+        --maxNumWorkers=$(expr 3 \* $CLUSTER_NUM_NODES) \
         --region=$REGION
     ```
 
@@ -180,7 +180,7 @@ Please pay attention to the Cluster CPU usage and adjust the number of Dataflow 
         --snapshotName=$SNAPSHOT_NAME \
         --stagingLocation=$SNAPSHOT_GCS_PATH/staging \
         --gcpTempLocation=$SNAPSHOT_GCS_PATH/temp \
-        --maxWorkerNodes=$(expr 3 \* $CLUSTER_NUM_NODES) \
+        --maxNumWorkers=$(expr 3 \* $CLUSTER_NUM_NODES) \
         --region=$REGION \
         --enableSnappy=true
     ```


### PR DESCRIPTION
update to syntax, ref dataflow config for [horizontal-autoscaling](https://cloud.google.com/dataflow/docs/guides/deploying-a-pipeline#horizontal-autoscaling).