### PR TITLE
fix: fixing the memory leak in Mirroring connection

### DIFF
--- a/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-core-parent/bigtable-hbase-mirroring-client-core/src/main/java/com/google/cloud/bigtable/mirroring/core/MirroringConnection.java
+++ b/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-core-parent/bigtable-hbase-mirroring-client-core/src/main/java/com/google/cloud/bigtable/mirroring/core/MirroringConnection.java
@@ -315,6 +315,14 @@ public class MirroringConnection implements Connection {
         exceptions.add(e);
       }
 
+      // Close the failed mutation logger, which will close all the
+      // contained resources (file streams and buffers).
+      try {
+        failedMutationLogger.close();
+      } catch (Exception e) {
+        Log.error("Failed to close failedMutationLogger.", e);
+      }
+      
       exceptions.rethrowIfCaptured();
     }
   }


### PR DESCRIPTION
Close the FailedMutationLogger while closing MirroringConnection.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable-hbase/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
