### PR TITLE
fix: javadoc fix

### DIFF
--- a/.kokoro/release/publish_javadoc11.sh
+++ b/.kokoro/release/publish_javadoc11.sh
@@ -37,7 +37,20 @@ export NAME=bigtable-client-parent
 export VERSION=$(grep ${NAME}: versions.txt | cut -d: -f3)
 
 # cloud RAD generation
+# use javadoc:aggregate for the following modules
+cd bigtable-client-core-parent/
 mvn clean javadoc:aggregate -B -q -P docFX
+cd ../bigtable-dataflow-parent/
+mvn clean javadoc:aggregate -B -q -P docFX
+cd ../bigtable-hbase-2.x-parent/
+mvn clean javadoc:aggregate -B -q -P docFX
+
+# use javadoc:javadoc for the following modules for Standalone doc generation as javadoc:aggregate breaks due to compilation issues
+cd ../hbase-migration-tools/
+mvn clean javadoc:javadoc
+cd ../bigtable-hbase-1.x-parent/
+mvn clean javadoc:javadoc
+
 # include CHANGELOG
 cp CHANGELOG.md target/docfx-yml/history.md
 


### PR DESCRIPTION
Using `javadoc:aggregate` and `javadoc:javadoc` commands on individual modules as a workaround for javadoc generation. 