### PR TITLE
fix: Close mutator when writing to Bigtable to avoid flooding logs

### DIFF
--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableIO.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableIO.java
@@ -22,12 +22,7 @@ import com.google.bigtable.repackaged.com.google.common.annotations.VisibleForTe
 import com.google.bigtable.repackaged.com.google.common.base.Preconditions;
 import com.google.cloud.bigtable.batch.common.CloudBigtableServiceImpl;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
@@ -867,10 +862,11 @@ public class CloudBigtableIO {
     @ProcessElement
     public void processElement(ProcessContext context) throws Exception {
       KV<String, Iterable<Mutation>> element = context.element();
-      BufferedMutator mutator = getMutator(context, element.getKey());
+      BufferedMutator mutator = getMutator(context, Objects.requireNonNull(element).getKey());
       try {
-        for (Mutation mutation : element.getValue()) {
+        for (Mutation mutation : Objects.requireNonNull(element.getValue())) {
           mutator.mutate(mutation);
+          mutator.close();
           mutationsCounter.inc();
         }
       } catch (RetriesExhaustedWithDetailsException exception) {

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableIO.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableIO.java
@@ -22,7 +22,12 @@ import com.google.bigtable.repackaged.com.google.common.annotations.VisibleForTe
 import com.google.bigtable.repackaged.com.google.common.base.Preconditions;
 import com.google.cloud.bigtable.batch.common.CloudBigtableServiceImpl;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
@@ -862,11 +867,9 @@ public class CloudBigtableIO {
     @ProcessElement
     public void processElement(ProcessContext context) throws Exception {
       KV<String, Iterable<Mutation>> element = context.element();
-      BufferedMutator mutator = getMutator(context, Objects.requireNonNull(element).getKey());
-      try {
-        for (Mutation mutation : Objects.requireNonNull(element.getValue())) {
+      try (BufferedMutator mutator = getMutator(context, element.getKey())) {
+        for (Mutation mutation : element.getValue()) {
           mutator.mutate(mutation);
-          mutator.close();
           mutationsCounter.inc();
         }
       } catch (RetriesExhaustedWithDetailsException exception) {


### PR DESCRIPTION
Fixes #3859 ☕️

The mutator should be closed after successful mutation when we are writing. That will close all the resources underneath. For the reader, we don't have to do this.