### PR TITLE
test: run hbase 2.x integration tests in parallel

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestSnapshot.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestSnapshot.java
@@ -19,6 +19,7 @@ import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
 import org.apache.hadoop.hbase.HTableDescriptor;
@@ -74,22 +75,23 @@ public abstract class AbstractTestSnapshot extends AbstractTest {
 
   @Test
   public void testSnapshot() throws IOException, InterruptedException, ExecutionException {
-    String snapshotName = generateId("test-snapshot");
+    String snapshotId = newSnapshotId();
     try {
-      snapshot(snapshotName, tableName);
-      Assert.assertEquals(1, listSnapshotsSize(snapshotName));
+      snapshot(snapshotId, tableName);
+      Assert.assertEquals(1, listSnapshotsSize(snapshotId));
     } finally {
-      deleteSnapshot(snapshotName);
-      Assert.assertEquals(0, listSnapshotsSize(snapshotName));
+      deleteSnapshot(snapshotId);
+      Assert.assertEquals(0, listSnapshotsSize(snapshotId));
     }
   }
 
   @Test
   public void testListAndDeleteSnapshots()
       throws IOException, InterruptedException, ExecutionException {
-    String snapshotName = generateId("list-1");
-    String snapshotName2 = generateId("list-2");
-    Pattern allSnapshots = Pattern.compile(prefix + ".*" + "list" + ".*");
+    String prefix = newSnapshotId();
+    String snapshotName = prefix + "-1";
+    String snapshotName2 = prefix + "-2";
+    Pattern allSnapshots = Pattern.compile(prefix + ".*");
 
     try {
       snapshot(snapshotName, tableName);
@@ -108,7 +110,7 @@ public abstract class AbstractTestSnapshot extends AbstractTest {
 
   @Test
   public void testCloneSnapshot() throws IOException, InterruptedException {
-    String cloneSnapshotName = generateId("clone-test");
+    String cloneSnapshotName = newSnapshotId();
     snapshot(cloneSnapshotName, tableName);
 
     // Wait 2 minutes so that the RestoreTable API will trigger an optimize restored
@@ -186,5 +188,9 @@ public abstract class AbstractTestSnapshot extends AbstractTest {
 
   protected static String generateId(String name) {
     return prefix + "-" + name + "-" + TEST_BACKUP_SUFFIX;
+  }
+
+  protected static String newSnapshotId() {
+    return UUID.randomUUID().toString();
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/BigtableEnv.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/BigtableEnv.java
@@ -80,6 +80,11 @@ class BigtableEnv extends SharedTestEnv {
       }
     }
 
+    // Auto expire orphaned snapshots. Minimum ttl is 6h
+    configuration.setIfUnset(
+        "google.bigtable.snapshot.default.ttl.secs",
+        String.valueOf(TimeUnit.HOURS.toSeconds(6) + 1));
+
     // Configure DirectPath settings:
     // - when a required mode is specified, ensure that ip address match the mode
     // - specify a user agent that will trigger deny/allow lists on the serverside

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
@@ -65,10 +65,6 @@ limitations under the License.
                 <phase>integration-test</phase>
                 <configuration>
                   <forkCount>1</forkCount>
-                  <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                  <!-- Run tests in parallel -->
-                  <parallel>classes</parallel>
-                  <threadCount>4</threadCount>
                   <includes>
                     <include>**/IntegrationTestsNoKnownGap.java</include>
                   </includes>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/pom.xml
@@ -65,6 +65,10 @@ limitations under the License.
                 <phase>integration-test</phase>
                 <configuration>
                   <forkCount>1</forkCount>
+                  <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                  <!-- Run tests in parallel -->
+                  <parallel>classes</parallel>
+                  <threadCount>4</threadCount>
                   <includes>
                     <include>**/IntegrationTestsNoKnownGap.java</include>
                   </includes>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSnapshots.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSnapshots.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
@@ -45,31 +44,16 @@ public class TestSnapshots extends AbstractTestSnapshot {
   @Before
   public void setUp() throws IOException {
     try (Admin admin = getConnection().getAdmin()) {
-      // Setup a prefix to avoid collisions between concurrent test runs
-      prefix = String.format("020%d", System.currentTimeMillis());
-
-      // clean up stale backups
-      String stalePrefix =
-          String.format("020%d", System.currentTimeMillis() - TimeUnit.HOURS.toMillis(2));
-
-      for (SnapshotDescription snapshotDescription : admin.listSnapshots()) {
-        int i = snapshotDescription.getName().lastIndexOf("/");
-        String backupId = snapshotDescription.getName().substring(i + 1);
-        if (backupId.endsWith(TEST_BACKUP_SUFFIX) && stalePrefix.compareTo(backupId) > 0) {
-          LOG.info("Deleting old snapshot: " + backupId);
-          admin.deleteSnapshot(backupId);
-        }
-      }
       values = createAndPopulateTable(tableName);
     }
   }
 
   @Test
   public void listSnapshots() throws IOException, InterruptedException {
-    String snapshot1 = generateId("snapshot-1");
+    String snapshot1 = newSnapshotId();
     snapshot(snapshot1, tableName);
 
-    String snapshot2 = generateId("snapshot-2");
+    String snapshot2 = newSnapshotId();
     snapshot(snapshot2, tableName);
 
     try (Admin admin = getConnection().getAdmin()) {

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/pom.xml
@@ -69,6 +69,10 @@ limitations under the License.
                 <phase>integration-test</phase>
                 <configuration>
                   <forkCount>1</forkCount>
+                  <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                  <!-- Run tests in parallel -->
+                  <parallel>classes</parallel>
+                  <threadCount>4</threadCount>
                   <includes>
                     <include>**/IntegrationTestsNoKnownGap.java</include>
                   </includes>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSnapshots.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSnapshots.java
@@ -82,10 +82,10 @@ public class TestSnapshots extends AbstractTestSnapshot {
 
   @Test
   public void listSnapshots() throws IOException, InterruptedException {
-    String snapshot1 = generateId("snapshot-1");
+    String snapshot1 = newSnapshotId();
     snapshot(snapshot1, tableName);
 
-    String snapshot2 = generateId("snapshot-2");
+    String snapshot2 = newSnapshotId();
     snapshot(snapshot2, tableName);
 
     try (Admin admin = getConnection().getAdmin()) {

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncSnapshots.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncSnapshots.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import org.apache.hadoop.hbase.TableExistsException;
 import org.apache.hadoop.hbase.TableName;
@@ -55,22 +54,6 @@ public class TestAsyncSnapshots extends AbstractTestSnapshot {
 
   @Before
   public void setUp() throws ExecutionException, InterruptedException, IOException {
-    // Setup a prefix to avoid collisions between concurrent test runs
-    prefix = String.format("020%d", System.currentTimeMillis());
-
-    // clean up stale backups
-    String stalePrefix =
-        String.format("020%d", System.currentTimeMillis() - TimeUnit.HOURS.toMillis(2));
-
-    for (SnapshotDescription snapshotDescription : getAsyncAdmin().listSnapshots().get()) {
-      int i = snapshotDescription.getName().lastIndexOf("/");
-      String backupId = snapshotDescription.getName().substring(i + 1);
-      if (backupId.endsWith(TEST_BACKUP_SUFFIX) && stalePrefix.compareTo(backupId) > 0) {
-        LOG.info("Deleting old snapshot: " + backupId);
-        getAsyncAdmin().deleteSnapshot(backupId);
-      }
-    }
-
     values = createAndPopulateTable(tableName);
   }
 
@@ -103,10 +86,10 @@ public class TestAsyncSnapshots extends AbstractTestSnapshot {
 
   @Test
   public void listSnapshots() throws IOException, InterruptedException, ExecutionException {
-    String snapshot1 = generateId("snapshot-1");
+    String snapshot1 = newSnapshotId();
     snapshot(snapshot1, tableName);
 
-    String snapshot2 = generateId("snapshot-2");
+    String snapshot2 = newSnapshotId();
     snapshot(snapshot2, tableName);
     try {
       List<SnapshotDescription> snapshotDescriptions = getAsyncAdmin().listSnapshots().get();


### PR DESCRIPTION
Porting part of the change in #2991 and #2992 in 2.x-integration-tests