### PR TITLE
deps: update bigtable version to 2.17.1, shared config to 1.5.5

### DIFF
--- a/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
@@ -256,7 +256,6 @@ limitations under the License.
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigtable-emulator-core</artifactId>
-      <version>0.153.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
@@ -36,7 +36,7 @@ limitations under the License.
 
   <properties>
     <mrunit.version>1.1.0</mrunit.version>
-    <google-cloud-bigtable-emulator.version>0.154.0</google-cloud-bigtable-emulator.version>
+    <google-cloud-bigtable-emulator.version>0.154.1</google-cloud-bigtable-emulator.version>
   </properties>
 
   <!-- NOTE: this artifact is designed to be used alongside hbase-server via

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
@@ -36,7 +36,7 @@ limitations under the License.
 
   <properties>
     <mrunit.version>1.1.0</mrunit.version>
-    <google-cloud-bigtable-emulator.version>0.153.0</google-cloud-bigtable-emulator.version>
+    <google-cloud-bigtable-emulator.version>0.154.0</google-cloud-bigtable-emulator.version>
   </properties>
 
   <!-- NOTE: this artifact is designed to be used alongside hbase-server via

--- a/hbase-migration-tools/bigtable-hbase-replication/bigtable-hbase-1.x-replication/pom.xml
+++ b/hbase-migration-tools/bigtable-hbase-replication/bigtable-hbase-1.x-replication/pom.xml
@@ -177,7 +177,7 @@ limitations under the License.
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigtable-emulator-core</artifactId>
-      <version>0.153.0</version>
+      <version>${bigtable-emulator.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/hbase-migration-tools/bigtable-hbase-replication/bigtable-hbase-1.x-replication/pom.xml
+++ b/hbase-migration-tools/bigtable-hbase-replication/bigtable-hbase-1.x-replication/pom.xml
@@ -177,7 +177,7 @@ limitations under the License.
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigtable-emulator-core</artifactId>
-      <version>${bigtable-emulator.version}</version>
+      <version>${google-cloud-bigtable-emulator.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/hbase-migration-tools/bigtable-hbase-replication/bigtable-hbase-2.x-replication/pom.xml
+++ b/hbase-migration-tools/bigtable-hbase-replication/bigtable-hbase-2.x-replication/pom.xml
@@ -208,7 +208,7 @@ limitations under the License.
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-bigtable-emulator-core</artifactId>
-            <version>${bigtable-emulator.version}</version>
+            <version>${google-cloud-bigtable-emulator.version}</version>
             <scope>test</scope>
         </dependency>
         <!--Test dependencies-->

--- a/hbase-migration-tools/bigtable-hbase-replication/bigtable-hbase-2.x-replication/pom.xml
+++ b/hbase-migration-tools/bigtable-hbase-replication/bigtable-hbase-2.x-replication/pom.xml
@@ -208,7 +208,7 @@ limitations under the License.
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-bigtable-emulator-core</artifactId>
-            <version>0.153.0</version>
+            <version>${bigtable-emulator.version}</version>
             <scope>test</scope>
         </dependency>
         <!--Test dependencies-->

--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,8 @@ limitations under the License.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- core dependency versions -->
-    <bigtable.version>2.17.0</bigtable.version>
-    <bigtable-emulator.version>0.154.0</bigtable-emulator.version>
+    <bigtable.version>2.17.1</bigtable.version>
+    <bigtable-emulator.version>0.154.1</bigtable-emulator.version>
     <bigtable-client-core.version>1.28.0</bigtable-client-core.version>
     <grpc-conscrypt.version>2.5.2</grpc-conscrypt.version>
     <!--  keeping at this version to align with hbase-->

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@ limitations under the License.
 
     <!-- core dependency versions -->
     <bigtable.version>2.17.1</bigtable.version>
-    <bigtable-emulator.version>0.154.1</bigtable-emulator.version>
+    <google-cloud-bigtable-emulator.version>0.154.1</google-cloud-bigtable-emulator.version>
     <bigtable-client-core.version>1.28.0</bigtable-client-core.version>
     <grpc-conscrypt.version>2.5.2</grpc-conscrypt.version>
     <!--  keeping at this version to align with hbase-->

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.5.4</version>
+    <version>1.5.5</version>
   </parent>
 
   <licenses>
@@ -56,7 +56,8 @@ limitations under the License.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- core dependency versions -->
-    <bigtable.version>2.16.0</bigtable.version>
+    <bigtable.version>2.17.0</bigtable.version>
+    <bigtable-emulator.version>0.154.0</bigtable-emulator.version>
     <bigtable-client-core.version>1.28.0</bigtable-client-core.version>
     <grpc-conscrypt.version>2.5.2</grpc-conscrypt.version>
     <!--  keeping at this version to align with hbase-->

--- a/renovate.json5
+++ b/renovate.json5
@@ -101,6 +101,14 @@
       ],
       // Exclude version 3.3.0 due to https://issues.apache.org/jira/projects/MSHADE/issues/MSHADE-419
       "allowedVersions": "(,3.3.0),(3.3.0,)"
+    },
+    {
+      "packagePatterns": [
+        "^com.google.cloud:google-cloud-bigtable",
+        "^com.google.cloud:google-cloud-bigtable-emulator-core",
+        "^com.google.cloud:google-cloud-bigtable-emulator",
+      ],
+      "groupName": "google-cloud-bigtable dependencies"
     }
   ],
   "semanticCommits": true,


### PR DESCRIPTION
Also updates the renovate config to group bigtable and emulator updates in the same PR going forward

Opening in favor of #3884, #3883, #3882, #3873