### PR TITLE
Close Connection to prevent gRPC leak error messages

### DIFF
--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/AbstractCloudBigtableTableDoFn.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/AbstractCloudBigtableTableDoFn.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.beam;
 
 import com.google.cloud.bigtable.hbase.BigtableConfiguration;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -124,5 +125,18 @@ public abstract class AbstractCloudBigtableTableDoFn<In, Out> extends DoFn<In, O
 
   public CloudBigtableConfiguration getConfig() {
     return config;
+  }
+
+  @Teardown
+  public void tearDown() {
+    // Close connection when DoFn is aborted.
+    if (connection != null) {
+      try {
+        connection.close();
+      } catch (IOException e) {
+        DOFN_LOG.info("Ignore an exception encountered while closing the connection", e);
+      }
+      connection = null;
+    }
   }
 }

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableIO.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableIO.java
@@ -685,11 +685,20 @@ public class CloudBigtableIO {
 
     /** Closes the {@link ResultScanner}, {@link Table}, and {@link Connection}. */
     @Override
-    public void close() throws IOException {
+    public void close() {
       if (scanner != null) {
         scanner.close();
         scanner = null;
       }
+
+      if (connection != null) {
+        try {
+          connection.close();
+        } catch (IOException ignored) {
+        }
+        connection = null;
+      }
+
       long totalOps = getRowsReadCount();
       long elapsedTimeMs = System.currentTimeMillis() - workStart;
       long operationsPerSecond = elapsedTimeMs == 0 ? 0 : (totalOps * 1000 / elapsedTimeMs);
@@ -809,7 +818,7 @@ public class CloudBigtableIO {
       mutationsCounter.inc();
     }
 
-    /** Closes the {@link BufferedMutator} and {@link Connection}. */
+    /** Closes the {@link BufferedMutator}. */
     @FinishBundle
     public synchronized void finishBundle(@SuppressWarnings("unused") FinishBundleContext context)
         throws Exception {


### PR DESCRIPTION
I believe this change can reduce the gRPC connection leak error messages that look scary but no impact on the Bigtable operations.
```
*~*~*~ Channel ManagedChannelImpl{logId=288, target=bigtableadmin.googleapis.com:443} was not shutdown properly!!! ~*~*~* Make sure to call shutdown()/shutdownNow() and wait until awaitTermination() returns true.
```

`Reader.close()`: fixes #2658 where original fix #2782 was rolled back by #2871 and #2873. As we don’t use “session” here anymore, I believe we should close “connection” here.

`AbstractCloudBigtableTableDoFn.tearDown()`: If an exception happened in ProcessElement, FinishBundle is not executed. We should clean up resources in TearDown. You can see the similar code with BigQueryIO https://github.com/apache/beam/pull/14949.

---

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable-hbase/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #2658

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
