### PR TITLE
fix: fix compatibility of CloudBigtableIO with the emulator env var

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BigtableHBaseVeneerSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BigtableHBaseVeneerSettings.java
@@ -429,6 +429,9 @@ public class BigtableHBaseVeneerSettings extends BigtableHBaseSettings {
       endpointOverride =
           Optional.of(hostOverride.or(defaultHostname) + ":" + portOverride.or(defaultPort));
     } else if (endpointKey.equals(BIGTABLE_HOST_KEY)
+        // only apply batch endpoint when the default endpoint hasnt changed (ie. when
+        // BIGTABLE_EMULATOR_HOST is set)
+        && defaultEndpoint.equals("bigtable.googleapis.com:443")
         && configuration.getBoolean(BIGTABLE_USE_BATCH, false)) {
       endpointOverride = Optional.of(BIGTABLE_BATCH_DATA_HOST_DEFAULT + ":443");
     }

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableIO.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableIO.java
@@ -335,7 +335,7 @@ public class CloudBigtableIO {
     protected List<SourceWithKeys> split(
         long regionSize, long desiredBundleSizeBytes, byte[] startKey, byte[] stopKey)
         throws IOException {
-      Preconditions.checkState(desiredBundleSizeBytes > 0);
+      Preconditions.checkState(desiredBundleSizeBytes >= 0);
       int splitCount = (int) Math.ceil((double) (regionSize) / (double) (desiredBundleSizeBytes));
 
       if (splitCount < 2 || stopKey.length == 0 || Bytes.compareTo(startKey, stopKey) >= 0) {
@@ -477,7 +477,7 @@ public class CloudBigtableIO {
                   "Source keys not in order: [%s, %s]",
                   Bytes.toStringBinary(startRow), Bytes.toStringBinary(stopRow)));
         }
-        Preconditions.checkState(estimatedSize > 0, "Source size must be positive", estimatedSize);
+        Preconditions.checkState(estimatedSize >= 0, "Source size must be positive", estimatedSize);
       }
       this.estimatedSize = estimatedSize;
       SOURCE_LOG.debug("Source with split: {}.", this);

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableIO.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableIO.java
@@ -477,7 +477,8 @@ public class CloudBigtableIO {
                   "Source keys not in order: [%s, %s]",
                   Bytes.toStringBinary(startRow), Bytes.toStringBinary(stopRow)));
         }
-        Preconditions.checkState(estimatedSize >= 0, "Source size cannot be negative", estimatedSize);
+        Preconditions.checkState(
+            estimatedSize >= 0, "Source size cannot be negative", estimatedSize);
       }
       this.estimatedSize = estimatedSize;
       SOURCE_LOG.debug("Source with split: {}.", this);

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableIO.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableIO.java
@@ -477,7 +477,7 @@ public class CloudBigtableIO {
                   "Source keys not in order: [%s, %s]",
                   Bytes.toStringBinary(startRow), Bytes.toStringBinary(stopRow)));
         }
-        Preconditions.checkState(estimatedSize >= 0, "Source size must be positive", estimatedSize);
+        Preconditions.checkState(estimatedSize >= 0, "Source size cannot be negative", estimatedSize);
       }
       this.estimatedSize = estimatedSize;
       SOURCE_LOG.debug("Source with split: {}.", this);


### PR DESCRIPTION
There are 2 issues that prevented CloudBigtableIO from working with the emulator:
1. useBulk macro setting would override the endpoint to batch-bigtable.googleapis.com regardless if the BIGTABLE_EMULATOR_ENV was set
2. the emulator doesnt return sample row key sizes when when the data is tiny, so split calculations broke
