### PR TITLE
chore: fix published dependencies of bigtable-beam-import

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -5,7 +5,6 @@ branchProtectionRules:
   - pattern: main
     isAdminEnforced: true
     requiredStatusCheckContexts:
-      - 'Kokoro - Test: Binary Compatibility'
       - 'Kokoro - Test: Code Format'
       - 'Kokoro - Test: Dependencies'
       - 'Kokoro - Test: Integration'
@@ -58,6 +57,19 @@ branchProtectionRules:
       - OwlBot Post Processor
     requiredApprovingReviewCount: 1
     requiresCodeOwnerReviews: true
+- pattern: 2.1.x
+  isAdminEnforced: true
+  requiredStatusCheckContexts:
+      - 'Kokoro - Test: Code Format'
+      - 'Kokoro - Test: Dependencies'
+      - 'Kokoro - Test: Integration'
+      - 'Kokoro - Test: Java 11'
+      - 'Kokoro - Test: Java 8'
+      - 'Kokoro - Test: Beam Integration'
+      - cla/google
+      - OwlBot Post Processor
+  requiredApprovingReviewCount: 1
+  requiresCodeOwnerReviews: true
 permissionRules:
   - team: yoshi-java-admins
     permission: admin

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -57,19 +57,19 @@ branchProtectionRules:
       - OwlBot Post Processor
     requiredApprovingReviewCount: 1
     requiresCodeOwnerReviews: true
-- pattern: 2.1.x
-  isAdminEnforced: true
-  requiredStatusCheckContexts:
-      - 'Kokoro - Test: Code Format'
-      - 'Kokoro - Test: Dependencies'
-      - 'Kokoro - Test: Integration'
-      - 'Kokoro - Test: Java 11'
-      - 'Kokoro - Test: Java 8'
-      - 'Kokoro - Test: Beam Integration'
-      - cla/google
-      - OwlBot Post Processor
-  requiredApprovingReviewCount: 1
-  requiresCodeOwnerReviews: true
+  - pattern: 2.1.x
+    isAdminEnforced: true
+    requiredStatusCheckContexts:
+    - 'Kokoro - Test: Code Format'
+    - 'Kokoro - Test: Dependencies'
+    - 'Kokoro - Test: Integration'
+    - 'Kokoro - Test: Java 11'
+    - 'Kokoro - Test: Java 8'
+    - 'Kokoro - Test: Beam Integration'
+    - cla/google
+    - OwlBot Post Processor
+    requiredApprovingReviewCount: 1
+    requiresCodeOwnerReviews: true
 permissionRules:
   - team: yoshi-java-admins
     permission: admin

--- a/.kokoro/dependencies.sh
+++ b/.kokoro/dependencies.sh
@@ -23,4 +23,4 @@ echo $JOB_TYPE
 
 export MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m"
 
-mvn -B -V clean install -DskipTests=true dependency:analyze -DfailOnWarning=true
+mvn -B -V clean install -DskipTests=true dependency:analyze -DfailOnWarning=true -Dclirr.skip=true

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,8 @@ limitations under the License.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.3.0</version>
+          <!-- MSHADE-419: 3.3.0 Shade plugin causes pom to be created without compile dependencies -->
+          <version>3.2.4</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/renovate.json5
+++ b/renovate.json5
@@ -88,7 +88,13 @@
       // pin to bigtable version
       "packagePatterns": ["^grpc-conscrypt.version"],
       "enabled": false
-    }
+    },
+    {
+      "packagePatterns": [
+        "^org.apache.maven.plugins:maven-shade-plugin"
+      ],
+      // Exclude version 3.3.0 due to https://issues.apache.org/jira/projects/MSHADE/issues/MSHADE-419
+      "allowedVersions": "(,3.3.0),(3.3.0,)",
   ],
   "semanticCommits": true,
   "dependencyDashboard": true,


### PR DESCRIPTION
Applying fix from https://github.com/googleapis/java-bigtable-hbase/pull/3600 and https://github.com/googleapis/java-bigtable-hbase/pull/3598 on 2.1.x branch