### PR TITLE
chore(main): temporarily disable Clirr Binary Compatibility test for 2.1.x branch

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -61,7 +61,6 @@ branchProtectionRules:
   - pattern: 2.1.x
     isAdminEnforced: true
     requiredStatusCheckContexts:
-      - 'Kokoro - Test: Binary Compatibility'
       - 'Kokoro - Test: Code Format'
       - 'Kokoro - Test: Dependencies'
       - 'Kokoro - Test: Integration'


### PR DESCRIPTION
Disable Clirr Binary Compatibility test

Port of https://github.com/googleapis/java-bigtable-hbase/pull/3598/ for 2.1.x branch