### PR TITLE
build: skip clirr for release build

### DIFF
--- a/.kokoro/release/stage.sh
+++ b/.kokoro/release/stage.sh
@@ -33,7 +33,6 @@ retry_with_backoff 3 10 \
   mvn clean deploy -B \
     --settings ${MAVEN_SETTINGS_FILE} \
     -DskipTests=true \
-    -Dclirr.skip=true \
     -DperformRelease=true \
     -Dgpg.executable=gpg \
     -Dgpg.passphrase=${GPG_PASSPHRASE} \

--- a/owlbot.py
+++ b/owlbot.py
@@ -37,6 +37,7 @@ java.common_templates(excludes=[
   '.kokoro/dependencies.sh',
   '.kokoro/build.sh',
   '.kokoro/build.bat',
+  '.kokoro/release/stage.sh',
   'samples/*',
   'renovate.json'
 ])


### PR DESCRIPTION
temporarily skipping clirr for release build, to be reverted back after 2.1.x release