### PR TITLE
build: skip clirr for release build of 2.1.x

### DIFF
--- a/.kokoro/release/stage.sh
+++ b/.kokoro/release/stage.sh
@@ -32,6 +32,7 @@ retry_with_backoff 3 10 \
   mvn clean deploy -B \
     --settings ${MAVEN_SETTINGS_FILE} \
     -DskipTests=true \
+    -Dclirr.skip=true \
     -DperformRelease=true \
     -Dgpg.executable=gpg \
     -Dgpg.passphrase=${GPG_PASSPHRASE} \

--- a/owlbot.py
+++ b/owlbot.py
@@ -35,6 +35,7 @@ java.common_templates(excludes=[
   '.kokoro/dependencies.sh',
   '.kokoro/build.sh',
   '.kokoro/build.bat',
+  '.kokoro/release/stage.sh',
   'samples/*',
   'renovate.json'
 ])


### PR DESCRIPTION
temporarily skipping clirr for release build, to be reverted back after 2.1.x release