### PR TITLE
feat: make dropwizard metrics-core optional

### DIFF
--- a/bigtable-client-core-parent/bigtable-metrics-api/pom.xml
+++ b/bigtable-client-core-parent/bigtable-metrics-api/pom.xml
@@ -33,6 +33,7 @@
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
       <version>${hbase1-metrics.version}</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>

--- a/bigtable-client-core-parent/bigtable-metrics-api/src/main/java/com/google/cloud/bigtable/metrics/BigtableClientMetrics.java
+++ b/bigtable-client-core-parent/bigtable-metrics-api/src/main/java/com/google/cloud/bigtable/metrics/BigtableClientMetrics.java
@@ -63,7 +63,9 @@ public final class BigtableClientMetrics {
   static {
     Logger logger = LoggerFactory.getLogger(BigtableClientMetrics.class);
     if (logger.isDebugEnabled()) {
-      if (registry == MetricRegistry.NULL_METRICS_REGISTRY) {
+      if (!DropwizardMetricRegistry.isAvailable()) {
+        logger.info("Could not set up logging since metrics-core is not on the classpath");
+      } else if (registry == MetricRegistry.NULL_METRICS_REGISTRY) {
         DropwizardMetricRegistry dropwizardRegistry = new DropwizardMetricRegistry();
         DropwizardMetricRegistry.createSlf4jReporter(
             dropwizardRegistry, logger, 1, TimeUnit.MINUTES);

--- a/bigtable-client-core-parent/bigtable-metrics-api/src/main/java/com/google/cloud/bigtable/metrics/BigtableClientMetrics.java
+++ b/bigtable-client-core-parent/bigtable-metrics-api/src/main/java/com/google/cloud/bigtable/metrics/BigtableClientMetrics.java
@@ -64,7 +64,10 @@ public final class BigtableClientMetrics {
     Logger logger = LoggerFactory.getLogger(BigtableClientMetrics.class);
     if (logger.isDebugEnabled()) {
       if (!DropwizardMetricRegistry.isAvailable()) {
-        logger.info("Could not set up logging since metrics-core is not on the classpath");
+        logger.info(
+            "Could not set up logging since metrics-core is not on the classpath. "
+                + "To use dropwizard metrics plese include io.dropwizard.metrics:metrics-core as peer"
+                + "dependency");
       } else if (registry == MetricRegistry.NULL_METRICS_REGISTRY) {
         DropwizardMetricRegistry dropwizardRegistry = new DropwizardMetricRegistry();
         DropwizardMetricRegistry.createSlf4jReporter(

--- a/bigtable-client-core-parent/bigtable-metrics-api/src/main/java/com/google/cloud/bigtable/metrics/DropwizardMetricRegistry.java
+++ b/bigtable-client-core-parent/bigtable-metrics-api/src/main/java/com/google/cloud/bigtable/metrics/DropwizardMetricRegistry.java
@@ -63,6 +63,15 @@ public class DropwizardMetricRegistry implements MetricRegistry {
 
   private final com.codahale.metrics.MetricRegistry registry;
 
+  static boolean isAvailable() {
+    try {
+      Class.forName("com.codahale.metrics.MetricRegistry");
+      return true;
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
+  }
+
   public DropwizardMetricRegistry() {
     this(new com.codahale.metrics.MetricRegistry());
   }


### PR DESCRIPTION
In an effort to make java-bigtable-hbase a single drop in jar, make metrics-core an optional dependency

