### PR TITLE
chore: make dropwizard metrics an optional dependency

### DIFF
--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
@@ -55,14 +55,7 @@ limitations under the License.
 
   <dependencyManagement>
     <dependencies>
-      <!-- Fix mismatched scopes: maven will pick the closest artifact version,
-      but apply the highest scope to it -->
-      <!-- TODO: remove this when metrics-core is an optional dep -->
-      <dependency>
-        <groupId>io.dropwizard.metrics</groupId>
-        <artifactId>metrics-core</artifactId>
-        <scope>provided</scope>
-      </dependency>
+      <!-- Mark annotation jars are provided -->
       <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
@@ -72,7 +65,7 @@ limitations under the License.
   </dependencyManagement>
 
   <dependencies>
-    <!-- Primary Group -->
+    <!-- Provided deps first -->
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-server</artifactId>
@@ -93,6 +86,7 @@ limitations under the License.
       <scope>provided</scope>
     </dependency>
 
+    <!-- Implementation jars -->
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>bigtable-hbase-1.x-shaded</artifactId>
@@ -106,10 +100,6 @@ limitations under the License.
         <exclusion>
           <groupId>${project.groupId}</groupId>
           <artifactId>bigtable-hbase-1.x</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.cloud.bigtable</groupId>
-          <artifactId>bigtable-metrics-api</artifactId>
         </exclusion>
         <exclusion>
           <groupId>io.opencensus</groupId>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -102,17 +102,6 @@ limitations under the License.
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>com.google.cloud.bigtable</groupId>
-      <artifactId>bigtable-metrics-api</artifactId>
-      <version>${bigtable-client-core.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.api</groupId>
-          <artifactId>api-common</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
     <!-- Since opencensus-api is a transitive dep, we have to shade its impl as well.
     Otherwise the -api will be permanently severed from the impl and exporters -->
     <dependency>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/pom.xml
@@ -19,17 +19,6 @@
     This project contains tools for migrating to Cloud Bigtable from HBase 1.x.
   </description>
 
-  <dependencyManagement>
-    <dependencies>
-      <!-- TODO: remove this when metrics-core is dropped as a compile time dep -->
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <scope>provided</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <!-- Provided deps first -->
     <dependency>
@@ -71,10 +60,6 @@
         <exclusion>
           <groupId>${project.groupId}</groupId>
           <artifactId>bigtable-hbase-1.x</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.cloud.bigtable</groupId>
-          <artifactId>bigtable-metrics-api</artifactId>
         </exclusion>
         <exclusion>
           <groupId>io.opencensus</groupId>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
@@ -88,17 +88,6 @@ limitations under the License.
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>com.google.cloud.bigtable</groupId>
-      <artifactId>bigtable-metrics-api</artifactId>
-      <version>${bigtable-client-core.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.api</groupId>
-          <artifactId>api-common</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
     <!-- Since opencensus-api is a transitive dep, we have to shade its impl as well.
     Otherwise the -api will be permanently severed from the impl and exporters -->
     <dependency>
@@ -162,14 +151,6 @@ limitations under the License.
       <groupId>io.grpc</groupId>
       <artifactId>grpc-census</artifactId>
     </dependency>
-
-    <!-- Manually promote dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
-    <dependency>
-      <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-core</artifactId>
-      <version>${hbase2-metrics.version}</version>
-    </dependency>
-
     <!-- See notes in bigtable-client-core/bigtable-hbase/pom.xml#verify-conscrypt-version -->
     <dependency>
       <groupId>org.conscrypt</groupId>
@@ -263,8 +244,6 @@ limitations under the License.
               </filters>
               <artifactSet>
                 <excludes>
-                  <!-- exclude user visible deps -->
-                  <exclude>io.dropwizard.metrics:metrics-core</exclude>
                   <!-- See notes in bigtable-client-core/bigtable-hbase/pom.xml#verify-conscrypt-version -->
                   <exclude>org.conscrypt:conscrypt-openjdk-uber</exclude>
                   <exclude>org.bouncycastle:*</exclude>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/pom.xml
@@ -84,20 +84,6 @@ limitations under the License.
     </dependency>
 
     <dependency>
-      <groupId>com.google.cloud.bigtable</groupId>
-      <artifactId>bigtable-metrics-api</artifactId>
-      <version>${bigtable-client-core.version}</version>
-      <exclusions>
-        <!-- use version from google-cloud-bigtable -->
-        <exclusion>
-          <groupId>com.google.api</groupId>
-          <artifactId>api-common</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-
-    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
     </dependency>

--- a/hbase-migration-tools/bigtable-hbase-replication/bigtable-hbase-1.x-replication/pom.xml
+++ b/hbase-migration-tools/bigtable-hbase-replication/bigtable-hbase-1.x-replication/pom.xml
@@ -140,17 +140,6 @@ limitations under the License.
     </plugins>
   </build>
 
-  <dependencyManagement>
-    <dependencies>
-      <!-- TODO: remove this when bigtable metrics api makes metrics-core optional -->
-      <dependency>
-        <groupId>io.dropwizard.metrics</groupId>
-        <artifactId>metrics-core</artifactId>
-        <scope>provided</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <!-- Provided deps first -->
     <dependency>

--- a/hbase-migration-tools/bigtable-hbase-replication/bigtable-hbase-2.x-replication/pom.xml
+++ b/hbase-migration-tools/bigtable-hbase-replication/bigtable-hbase-2.x-replication/pom.xml
@@ -150,16 +150,6 @@ limitations under the License.
         </plugins>
     </build>
 
-    <dependencyManagement>
-        <dependencies>
-            <!-- TODO: remove this when bigtable metrics api makes metrics-core optional -->
-            <dependency>
-                <groupId>io.dropwizard.metrics</groupId>
-                <artifactId>metrics-core</artifactId>
-                <scope>provided</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.apache.hbase</groupId>

--- a/hbase-migration-tools/bigtable-hbase-replication/bigtable-hbase-replication-core/pom.xml
+++ b/hbase-migration-tools/bigtable-hbase-replication/bigtable-hbase-replication-core/pom.xml
@@ -42,12 +42,6 @@ limitations under the License.
         <artifactId>slf4j-api</artifactId>
         <scope>provided</scope>
       </dependency>
-      <!-- TODO: remove this when bigtable metrics api makes metrics-core optional -->
-      <dependency>
-        <groupId>io.dropwizard.metrics</groupId>
-        <artifactId>metrics-core</artifactId>
-        <scope>provided</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   <build>

--- a/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-1.x-2.x-integration-tests/pom.xml
+++ b/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-1.x-2.x-integration-tests/pom.xml
@@ -332,14 +332,6 @@ limitations under the License.
       <version>1.7.30</version>
       <scope>test</scope>
     </dependency>
-
-    <!-- Pinned to prevent Enforcer errors -->
-    <dependency>
-      <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-core</artifactId>
-      <version>3.2.6</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x-integration-tests/pom.xml
+++ b/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x-integration-tests/pom.xml
@@ -344,14 +344,6 @@ limitations under the License.
       <version>1.7.30</version>
       <scope>test</scope>
     </dependency>
-
-    <!-- Pinned to prevent Enforcer errors -->
-    <dependency>
-      <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-core</artifactId>
-      <version>3.2.6</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
bigtable-metrics-api 1.9.2 makes dropwizard metrics-core an optional transitive. This brings us 1 step closer to bigtable-hbase being a single drop in jar.