### PR TITLE
chore: cleanup shading of provided deps

### DIFF
--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -49,6 +49,35 @@ limitations under the License.
         <scope>import</scope>
       </dependency>
 
+      <!-- Mark conscrypt as provided since it can't be relocated and is optional -->
+      <dependency>
+        <groupId>org.conscrypt</groupId>
+        <artifactId>conscrypt-openjdk-uber</artifactId>
+        <scope>provided</scope>
+      </dependency>
+
+      <!-- Annotation jars can be marked as provided -->
+      <dependency>
+        <groupId>org.checkerframework</groupId>
+        <artifactId>checker-qual</artifactId>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.errorprone</groupId>
+        <artifactId>error_prone_annotations</artifactId>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <scope>provided</scope>
+      </dependency>
+      
       <!-- Fix mismatched scopes: maven will pick the closest artifact version,
       but apply the highest scope to it -->
       <dependency>
@@ -93,14 +122,6 @@ limitations under the License.
       <groupId>${project.groupId}</groupId>
       <artifactId>bigtable-hbase-1.x</artifactId>
       <version>2.7.3-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-parent:current} -->
-      <exclusions>
-        <!-- api-common recently declared dependency on autovalue during migration to gradle. We don't
-            have a use of it so we're excluding it from the shaded jar. -->
-        <exclusion>
-          <groupId>com.google.auto.value</groupId>
-          <artifactId>auto-value</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <!-- Since opencensus-api is a transitive dep, we have to shade its impl as well.
     Otherwise the -api will be permanently severed from the impl and exporters -->
@@ -115,26 +136,10 @@ limitations under the License.
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-exporter-stats-stackdriver</artifactId>
-      <exclusions>
-        <!-- api-common recently declared dependency on autovalue during migration to gradle. We don't
-            have a use of it so we're excluding it from the shaded jar. -->
-        <exclusion>
-          <groupId>com.google.auto.value</groupId>
-          <artifactId>auto-value</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-exporter-trace-stackdriver</artifactId>
-      <exclusions>
-        <!-- api-common recently declared dependency on autovalue during migration to gradle. We don't
-            have a use of it so we're excluding it from the shaded jar. -->
-        <exclusion>
-          <groupId>com.google.auto.value</groupId>
-          <artifactId>auto-value</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.opencensus</groupId>
@@ -165,21 +170,6 @@ limitations under the License.
       <groupId>io.grpc</groupId>
       <artifactId>grpc-census</artifactId>
     </dependency>
-
-    <!-- Manually promote public dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
-    <dependency>
-      <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-core</artifactId>
-      <version>${hbase1-metrics.version}</version>
-    </dependency>
-
-    <!-- See notes in bigtable-client-core/bigtable-hbase/pom.xml#verify-conscrypt-version -->
-    <dependency>
-      <groupId>org.conscrypt</groupId>
-      <artifactId>conscrypt-openjdk-uber</artifactId>
-      <version>${grpc-conscrypt.version}</version>
-      <scope>runtime</scope>
-    </dependency>
   </dependencies>
 
   <build>
@@ -197,9 +187,6 @@ limitations under the License.
             </goals>
             <configuration>
               <excludedScopes>test,provided,system</excludedScopes>
-              <!-- Should mirror the shade plugin exclusions-->
-              <excludedArtifacts>metrics-core|commons-logging|hbase-shaded-client|slf4j-api|slf4j-log4j12|log4j|htrace-core|findbugs-annotations|conscrypt-openjdk-uber|htrace-core4|jsr305</excludedArtifacts>
-              <excludedGroups>org.bouncycastle|javax.annotation|org.checkerframework</excludedGroups>
               <generateBundle>true</generateBundle>
             </configuration>
           </execution>
@@ -217,12 +204,7 @@ limitations under the License.
             <configuration>
               <shadedArtifactAttached>false</shadedArtifactAttached>
               <createDependencyReducedPom>true</createDependencyReducedPom>
-              <!-- Need to manually promote to dependencies to keep the structure of hbase-shade-client.
-               Also, this is needed to workaround maven reactor not using dependency-reduced-pom.xml
-               files. See note in bigtable-1.x-hadoop .-->
-              <promoteTransitiveDependencies>
-                false
-              </promoteTransitiveDependencies>
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
               <filters>
                 <filter>
                   <artifact>*:*</artifact>
@@ -243,18 +225,6 @@ limitations under the License.
                     implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
               </transformers>
-              <artifactSet>
-                <excludes>
-                  <!-- exclude user visible deps -->
-                  <exclude>io.dropwizard.metrics:metrics-core</exclude>
-                  <!-- See notes in bigtable-client-core/bigtable-hbase/pom.xml#verify-conscrypt-version -->
-                  <exclude>org.conscrypt:conscrypt-openjdk-uber</exclude>
-                  <exclude>org.bouncycastle:*</exclude>
-                  <exclude>javax.annotation:*</exclude>
-                  <exclude>org.checkerframework:*</exclude>
-                  <exclude>com.google.code.findbugs:jsr305</exclude>
-                </excludes>
-              </artifactSet>
               <relocations>
                 <relocation>
                   <pattern>com.google</pattern>
@@ -395,6 +365,10 @@ limitations under the License.
                 <relocation>
                   <pattern>net.bytebuddy</pattern>
                   <shadedPattern>com.google.bigtable.repackaged.net.bytebuddy</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>autovalue</pattern>
+                  <shadedPattern>com.google.bigtable.repackaged.autovalue</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/pom.xml
@@ -93,12 +93,6 @@ limitations under the License.
       <version>2.7.3-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-parent:current} -->
     </dependency>
 
-    <dependency>
-      <groupId>net.bytebuddy</groupId>
-      <artifactId>byte-buddy</artifactId>
-      <version>${byte.buddy.version}</version>
-    </dependency>
-
     <!-- Test dependencies-->
     <dependency>
       <groupId>com.google.cloud.bigtable</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@ limitations under the License.
     <!-- core dependency versions -->
     <bigtable.version>2.20.0</bigtable.version>
     <google-cloud-bigtable-emulator.version>0.157.0</google-cloud-bigtable-emulator.version>
-    <bigtable-client-core.version>1.28.0</bigtable-client-core.version>
+    <bigtable-client-core.version>1.29.0</bigtable-client-core.version>
     <grpc-conscrypt.version>2.5.2</grpc-conscrypt.version>
     <!--  keeping at this version to align with hbase-->
     <slf4j.version>1.7.25</slf4j.version>


### PR DESCRIPTION
Upgrade to metrics-api and make dropwizard metrics provided. Cleanup 1x poms to ensure that everything is shaded and everything optional or provided by hbase is marked provided

Change-Id: I9e498f21ba465d7d2e05794f6c539a919e249c18

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable-hbase/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
