### PR TITLE
deps: bigtable 2.23.3 and beam 2.49.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,8 @@ limitations under the License.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- core dependency versions -->
-    <bigtable.version>2.22.0</bigtable.version>
-    <google-cloud-bigtable-emulator.version>0.157.3</google-cloud-bigtable-emulator.version>
+    <bigtable.version>2.23.3</bigtable.version>
+    <google-cloud-bigtable-emulator.version>0.160.3</google-cloud-bigtable-emulator.version>
     <bigtable-client-core.version>1.28.0</bigtable-client-core.version>
     <grpc-conscrypt.version>2.5.2</grpc-conscrypt.version>
     <!--  keeping at this version to align with hbase-->
@@ -81,9 +81,9 @@ limitations under the License.
     <junit-vintage-engine.version>5.9.2</junit-vintage-engine.version>
     <hamcrest.version>1.3</hamcrest.version>
     <mockito.version>4.11.0</mockito.version>
-    <beam.version>2.43.0</beam.version>
+    <beam.version>2.49.0</beam.version>
     <!-- referred from bigtable-beam-import and bigtable-emulator -->
-    <guava.version>31.1-jre</guava.version>
+    <guava.version>32.1.1-jre</guava.version>
     <gcs-guava.version>29.0-jre</gcs-guava.version>
     <beam-slf4j.version>1.7.30</beam-slf4j.version>
     <opencensus.version>0.31.1</opencensus.version>


### PR DESCRIPTION
Version updates targeting the (new) 2.9.x LTS branch.

Update to versions associated with libraries-bom 26.17.0:
* java-bigtable 2.23.3
* guava 32.1.1-jre

Update to Apache Beam 2.49.0