### PR TITLE
deps: mark conscrypt as a provided dep

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/pom.xml
+++ b/bigtable-client-core-parent/bigtable-hbase/pom.xml
@@ -104,13 +104,6 @@ limitations under the License.
       <artifactId>grpc-api</artifactId>
     </dependency>
     <dependency>
-      <!-- See notes in verify-conscrypt-version execution below -->
-      <groupId>org.conscrypt</groupId>
-      <artifactId>conscrypt-openjdk-uber</artifactId>
-      <version>${grpc-conscrypt.version}</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
     </dependency>
@@ -255,21 +248,8 @@ limitations under the License.
         <version>2.12.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-parent:current} -->
 
         <executions>
-          <!-- TODO: Remove this once we can properly shade conscrypt:
-            https://github.com/google/conscrypt/issues/811 -->
-
-          <!-- This module doesn't actually need to declare a dependency on
-          conscrypt, it already has it transitively via bigtable-client-core.
-          However, the child -shaded artifacts need a version number to manually
-          promote it. So this module declares the dependency solely to verify
-          the version in grpc-conscrypt.version is correct.
-
-          Ideally we would just shade conscrypt in the -shaded artifacts, but
-          currently it impossible. So for now we just need to make sure that
-          after all of shading, we expose it properly.
-          -->
           <execution>
-            <id>verify-conscrypt-version</id>
+            <id>verify-mirror-deps-cbt</id>
             <phase>verify</phase>
             <goals>
               <goal>verify-mirror-deps</goal>

--- a/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
@@ -178,12 +178,6 @@ limitations under the License.
           <artifactId>hbase-shaded-client</artifactId>
         </exclusion>
 
-        <!-- google-cloud-bigtable pulls in a newer version of this, but we want to match beam's version-->
-        <exclusion>
-          <groupId>org.conscrypt</groupId>
-          <artifactId>conscrypt-openjdk-uber</artifactId>
-        </exclusion>
-
         <!-- Workaround MNG-5899 & MSHADE-206. Maven >= 3.3.0 doesn't use the dependency reduced
         pom.xml files when invoking the build from a parent project. So we have to manually exclude
         the dependencies. Note that this works in conjunction with the manually promoted dependencies

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/pom.xml
@@ -94,12 +94,6 @@ limitations under the License.
           <artifactId>slf4j-log4j12</artifactId>
         </exclusion>
 
-        <!-- google-cloud-bigtable pulls in a newer version of this, but we want to match beam's version-->
-        <exclusion>
-          <groupId>org.conscrypt</groupId>
-          <artifactId>conscrypt-openjdk-uber</artifactId>
-        </exclusion>
-
         <!-- Workaround MNG-5899 & MSHADE-206. Maven >= 3.3.0 doesn't use the dependency reduced
         pom.xml files when invoking the build from a parent project. So we have to manually exclude
         the dependencies. Note that this works in conjunction with the manually promoted dependencies

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
@@ -113,12 +113,6 @@ limitations under the License.
       <artifactId>slf4j-api</artifactId>
       <version>${hbase1-hadoop-slf4j.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.conscrypt</groupId>
-      <artifactId>conscrypt-openjdk-uber</artifactId>
-      <version>${grpc-conscrypt.version}</version>
-      <scope>runtime</scope>
-    </dependency>
 
     <!-- Test deps -->
     <dependency>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -48,6 +48,20 @@ limitations under the License.
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+
+      <!-- Conscrypt can't be shaded, and since we are trying to make this connector a single jar drop in, mark it as provided.
+      End users can always add it themselves
+      -->
+      <dependency>
+        <groupId>org.conscrypt</groupId>
+        <artifactId>conscrypt-openjdk-uber</artifactId>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.conscrypt</groupId>
+        <artifactId>conscrypt-openjdk</artifactId>
+        <scope>provided</scope>
+      </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
@@ -182,14 +196,6 @@ limitations under the License.
       <artifactId>metrics-core</artifactId>
       <version>${hbase1-metrics.version}</version>
     </dependency>
-
-    <!-- See notes in bigtable-client-core/bigtable-hbase/pom.xml#verify-conscrypt-version -->
-    <dependency>
-      <groupId>org.conscrypt</groupId>
-      <artifactId>conscrypt-openjdk-uber</artifactId>
-      <version>${grpc-conscrypt.version}</version>
-      <scope>runtime</scope>
-    </dependency>
     <!--needs to be declared as a dependency to be excluded from shading-->
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
@@ -214,8 +220,8 @@ limitations under the License.
             <configuration>
               <excludedScopes>test,provided,system</excludedScopes>
               <!-- Should mirror the shade plugin exclusions-->
-              <excludedArtifacts>metrics-core|commons-logging|hbase-shaded-client|slf4j-api|slf4j-log4j12|log4j|htrace-core|findbugs-annotations|conscrypt-openjdk-uber|htrace-core4|jsr305</excludedArtifacts>
-              <excludedGroups>org.bouncycastle|javax.annotation|org.checkerframework</excludedGroups>
+              <excludedArtifacts>metrics-core|commons-logging|hbase-shaded-client|slf4j-api|slf4j-log4j12|log4j|htrace-core|findbugs-annotations|htrace-core4|jsr305</excludedArtifacts>
+              <excludedGroups>javax.annotation|org.checkerframework</excludedGroups>
               <generateBundle>true</generateBundle>
             </configuration>
           </execution>
@@ -272,10 +278,7 @@ limitations under the License.
                   <exclude>log4j:log4j</exclude>
                   <exclude>org.apache.htrace:htrace-core</exclude>
                   <exclude>com.github.stephenc.findbugs:findbugs-annotations</exclude>
-                  <!-- See notes in bigtable-client-core/bigtable-hbase/pom.xml#verify-conscrypt-version -->
-                  <exclude>org.conscrypt:conscrypt-openjdk-uber</exclude>
                   <exclude>org.apache.htrace:htrace-core4</exclude>
-                  <exclude>org.bouncycastle:*</exclude>
                   <exclude>javax.annotation:*</exclude>
                   <exclude>org.checkerframework:*</exclude>
                   <exclude>com.google.code.findbugs:jsr305</exclude>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
@@ -106,12 +106,6 @@ limitations under the License.
       <artifactId>slf4j-api</artifactId>
       <version>${hbase2-hadoop-slf4j.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.conscrypt</groupId>
-      <artifactId>conscrypt-openjdk-uber</artifactId>
-      <version>${grpc-conscrypt.version}</version>
-      <scope>runtime</scope>
-    </dependency>
 
     <!-- Test deps -->
     <dependency>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
@@ -48,6 +48,20 @@ limitations under the License.
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+
+      <!-- Conscrypt can't be shaded, and since we are trying to make this connector a single jar drop in, mark it as provided.
+      End users can always add it themselves
+      -->
+      <dependency>
+        <groupId>org.conscrypt</groupId>
+        <artifactId>conscrypt-openjdk-uber</artifactId>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.conscrypt</groupId>
+        <artifactId>conscrypt-openjdk</artifactId>
+        <scope>provided</scope>
+      </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
@@ -166,13 +180,6 @@ limitations under the License.
       <version>${hbase2-metrics.version}</version>
     </dependency>
 
-    <!-- See notes in bigtable-client-core/bigtable-hbase/pom.xml#verify-conscrypt-version -->
-    <dependency>
-      <groupId>org.conscrypt</groupId>
-      <artifactId>conscrypt-openjdk-uber</artifactId>
-      <version>${grpc-conscrypt.version}</version>
-      <scope>runtime</scope>
-    </dependency>
     <!--    needs to be declared as a dependency to be excluded from shading-->
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
@@ -197,8 +204,8 @@ limitations under the License.
             <configuration>
               <excludedScopes>test,provided,system</excludedScopes>
               <!--Should match the exclusions of shade plugin-->
-              <excludedArtifacts>metrics-core|commons-logging|hbase-shaded-client|slf4j-api|slf4j-log4j12|log4j|htrace-core4|audience-annotations|findbugs-annotations|conscrypt-openjdk-uber|jsr305</excludedArtifacts>
-              <excludedGroups>org.bouncycastle|javax.annotation|org.checkerframework</excludedGroups>
+              <excludedArtifacts>metrics-core|commons-logging|hbase-shaded-client|slf4j-api|slf4j-log4j12|log4j|htrace-core4|audience-annotations|findbugs-annotations|jsr305</excludedArtifacts>
+              <excludedGroups>javax.annotation|org.checkerframework</excludedGroups>
               <generateBundle>true</generateBundle>
             </configuration>
           </execution>
@@ -258,9 +265,6 @@ limitations under the License.
                   <exclude>
                     com.github.stephenc.findbugs:findbugs-annotations
                   </exclude>
-                  <!-- See notes in bigtable-client-core/bigtable-hbase/pom.xml#verify-conscrypt-version -->
-                  <exclude>org.conscrypt:conscrypt-openjdk-uber</exclude>
-                  <exclude>org.bouncycastle:*</exclude>
                   <exclude>javax.annotation:*</exclude>
                   <exclude>org.checkerframework:*</exclude>
                   <exclude>com.google.code.findbugs:jsr305</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,6 @@ limitations under the License.
     <bigtable.version>2.28.0</bigtable.version>
     <google-cloud-bigtable-emulator.version>0.165.0</google-cloud-bigtable-emulator.version>
     <bigtable-client-core.version>1.29.2</bigtable-client-core.version>
-    <grpc-conscrypt.version>2.5.2</grpc-conscrypt.version>
     <!--  keeping at this version to align with hbase-->
     <slf4j.version>1.7.25</slf4j.version>
     <commons-logging.version>1.2</commons-logging.version>


### PR DESCRIPTION
Conscrypt can't be shaded, keeping it as a runtime dependency is too much effort (trying to keep it in sync with google-cloud-bigtable). Also the current goal is make bigtable-hbase a standalone jar that can be dropped into a classpath. With this in mind, this PR marks conscrypt as a provided dep, that end users can add themselves
