### PR TITLE
chore: remove license plugin from -hadoop artifacts

### DIFF
--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
@@ -157,26 +157,7 @@ limitations under the License.
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>license-maven-plugin</artifactId>
-        <version>2.0.0</version>
-        <executions>
-          <execution>
-            <id>default-cli</id>
-            <phase>generate-resources</phase>
-            <goals>
-              <goal>add-third-party</goal>
-            </goals>
-            <configuration>
-              <excludedScopes>test,provided,system</excludedScopes>
-              <!--Should mirror shade plugin artifactset-->
-              <includedArtifacts>bigtable-hbase-1.x-shaded</includedArtifacts>
-              <generateBundle>true</generateBundle>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
@@ -158,27 +158,6 @@ limitations under the License.
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>license-maven-plugin</artifactId>
-        <version>2.0.0</version>
-        <executions>
-          <execution>
-            <id>default-cli</id>
-            <phase>generate-resources</phase>
-            <goals>
-              <goal>add-third-party</goal>
-<!--              <goal>download-licenses</goal>-->
-            </goals>
-            <configuration>
-              <excludedScopes>test,provided,system</excludedScopes>
-              <!--Should match the artifactset for shade plugin-->
-              <includedArtifacts>com.google.cloud.bigtable:bigtable-hbase-2.x-shaded</includedArtifacts>
-              <generateBundle>true</generateBundle>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <executions>


### PR DESCRIPTION
-hadoop simply repackages the -shaded artifacts which already runs the license plugin
