### PR TITLE
fix: retry idle timeout

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.hbase;
 
 import com.google.api.core.BetaApi;
 import com.google.api.core.InternalExtensionOnly;
+import com.google.common.annotations.VisibleForTesting;
 
 /**
  * Define {@link org.apache.hadoop.conf.Configuration} names for setting {@link
@@ -332,4 +333,8 @@ public class BigtableOptionsFactory {
    */
   public static final String BIGTABLE_ENABLE_BULK_MUTATION_FLOW_CONTROL =
       "google.bigtable.enable.bulk.mutation.flow.control";
+
+  /** Override idle timeout, for testing only. */
+  @VisibleForTesting
+  public static final String BIGTABLE_TEST_IDLE_TIMEOUT_MS = "google.bigtable.idle.timeout.ms";
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BigtableHBaseVeneerSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BigtableHBaseVeneerSettings.java
@@ -43,6 +43,7 @@ import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_SE
 import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_SERVICE_ACCOUNT_JSON_KEYFILE_LOCATION_KEY;
 import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_SERVICE_ACCOUNT_JSON_VALUE_KEY;
 import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_SERVICE_ACCOUNT_P12_KEYFILE_LOCATION_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_TEST_IDLE_TIMEOUT_MS;
 import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_BATCH;
 import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_CACHED_DATA_CHANNEL_POOL;
 import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_PLAINTEXT_NEGOTIATION;
@@ -727,6 +728,11 @@ public class BigtableHBaseVeneerSettings extends BigtableHBaseSettings {
       readRowsSettings
           .retrySettings()
           .setTotalTimeout(operationTimeouts.getOperationTimeout().get());
+    }
+
+    String idleTimeout = configuration.get(BIGTABLE_TEST_IDLE_TIMEOUT_MS);
+    if (idleTimeout != null) {
+      readRowsSettings.setIdleTimeout(Duration.ofMillis(Long.parseLong(idleTimeout)));
     }
   }
 

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/TemplateUtils.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/TemplateUtils.java
@@ -88,7 +88,7 @@ public class TemplateUtils {
             .withConfiguration(
                 BigtableOptionsFactory.CUSTOM_USER_AGENT_KEY, "SequenceFileExportJob")
             .withConfiguration(
-                "google.cloud.bigtable.retry.idle.timeout",
+                CloudBigtableIO.Reader.RETRY_IDLE_TIMEOUT,
                 String.valueOf(options.getRetryIdleTimeout()))
             .withScan(
                 new ScanValueProvider(

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/TemplateUtils.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/TemplateUtils.java
@@ -87,13 +87,15 @@ public class TemplateUtils {
             .withAppProfileId(options.getBigtableAppProfileId())
             .withConfiguration(
                 BigtableOptionsFactory.CUSTOM_USER_AGENT_KEY, "SequenceFileExportJob")
+            .withConfiguration(
+                "google.cloud.bigtable.retry.idle.timeout",
+                String.valueOf(options.getRetryIdleTimeout()))
             .withScan(
                 new ScanValueProvider(
                     options.getBigtableStartRow(),
                     options.getBigtableStopRow(),
                     options.getBigtableMaxVersions(),
                     options.getBigtableFilter()));
-
     return configBuilder.build();
   }
 }

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/sequencefiles/ExportJob.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/sequencefiles/ExportJob.java
@@ -173,6 +173,7 @@ public class ExportJob {
     @Default.Boolean(true)
     boolean getRetryIdleTimeout();
 
+    @SuppressWarnings("unused")
     void setRetryIdleTimeout(boolean retryIdleTimeout);
   }
 

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/sequencefiles/ExportJob.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/sequencefiles/ExportJob.java
@@ -168,6 +168,12 @@ public class ExportJob {
 
     @SuppressWarnings("unused")
     void setWait(boolean wait);
+
+    @Description("Get if idle timeout is retried.")
+    @Default.Boolean(true)
+    boolean getRetryIdleTimeout();
+
+    void setRetryIdleTimeout(boolean retryIdleTimeout);
   }
 
   public static void main(String[] args) {

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/sequencefiles/SequenceFileSink.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/sequencefiles/SequenceFileSink.java
@@ -178,7 +178,6 @@ class SequenceFileSink<K, V> extends FileBasedSink<KV<K, V>, Void, KV<K, V>> {
     @Override
     public void write(KV<K, V> value) throws Exception {
       counter.incrementAndGet();
-      Thread.sleep(5 * 60 * 1000 + 1000);
       sequenceFile.append(value.getKey(), value.getValue());
     }
   }

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/sequencefiles/SequenceFileSink.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/sequencefiles/SequenceFileSink.java
@@ -178,6 +178,7 @@ class SequenceFileSink<K, V> extends FileBasedSink<KV<K, V>, Void, KV<K, V>> {
     @Override
     public void write(KV<K, V> value) throws Exception {
       counter.incrementAndGet();
+      Thread.sleep(5 * 60 * 1000 + 1000);
       sequenceFile.append(value.getKey(), value.getValue());
     }
   }

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableIO.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableIO.java
@@ -770,7 +770,7 @@ public class CloudBigtableIO {
 
     static Throwable findCause(Throwable e, Class<? extends Throwable> cls) {
       Throwable throwable = e;
-      while (throwable != null && throwable.getClass() != cls) {
+      while (throwable != null && !cls.isAssignableFrom(e.getClass())) {
         throwable = throwable.getCause();
       }
       return throwable;

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/test/java/com/google/cloud/bigtable/beam/CloudBigtableIOReaderTest.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/test/java/com/google/cloud/bigtable/beam/CloudBigtableIOReaderTest.java
@@ -17,10 +17,26 @@ package com.google.cloud.bigtable.beam;
 
 import static org.mockito.Mockito.when;
 
+import com.google.bigtable.repackaged.com.google.bigtable.v2.BigtableGrpc;
 import com.google.bigtable.repackaged.com.google.bigtable.v2.ReadRowsRequest;
+import com.google.bigtable.repackaged.com.google.bigtable.v2.ReadRowsResponse;
+import com.google.bigtable.repackaged.com.google.bigtable.v2.RowRange;
+import com.google.bigtable.repackaged.com.google.bigtable.v2.RowSet;
+import com.google.bigtable.repackaged.com.google.cloud.bigtable.data.v2.internal.ByteStringComparator;
 import com.google.bigtable.repackaged.com.google.common.collect.ImmutableList;
 import com.google.bigtable.repackaged.com.google.protobuf.ByteString;
+import com.google.bigtable.repackaged.com.google.protobuf.BytesValue;
+import com.google.bigtable.repackaged.com.google.protobuf.StringValue;
+import com.google.bigtable.repackaged.io.grpc.Server;
+import com.google.bigtable.repackaged.io.grpc.ServerBuilder;
+import com.google.bigtable.repackaged.io.grpc.stub.StreamObserver;
+import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
 import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import org.apache.beam.sdk.io.BoundedSource;
 import org.apache.beam.sdk.io.range.ByteKey;
 import org.apache.beam.sdk.io.range.ByteKeyRange;
@@ -29,8 +45,11 @@ import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -50,6 +69,28 @@ public class CloudBigtableIOReaderTest {
   @Mock ResultScanner mockScanner;
 
   @Mock CloudBigtableIO.AbstractSource mockSource;
+
+  private Server server;
+
+  private FakeService fakeService;
+
+  int port;
+
+  @Before
+  public void setup() throws IOException {
+    try (ServerSocket ss = new ServerSocket(0)) {
+      port = ss.getLocalPort();
+    }
+    fakeService = new FakeService();
+    server = ServerBuilder.forPort(port).addService(fakeService).build().start();
+  }
+
+  @After
+  public void close() {
+    if (server != null) {
+      server.shutdown();
+    }
+  }
 
   private CloudBigtableScanConfiguration.Builder createDefaultConfig() {
     return new CloudBigtableScanConfiguration.Builder()
@@ -162,6 +203,167 @@ public class CloudBigtableIOReaderTest {
     }
   }
 
+  @Test
+  public void testRetryIdleTimeoutWithScan() throws Exception {
+    byte[] startKey = "A".getBytes();
+    byte[] endKey = "B".getBytes();
+
+    List<ReadRowsResponse> responses = generateResponses(fakeService, "A", "B", true, 10);
+
+    responses.remove(responses.size() - 1);
+
+    Scan scan = new Scan().withStartRow(startKey).withStopRow(endKey);
+
+    CloudBigtableScanConfiguration config =
+        new CloudBigtableScanConfiguration.Builder()
+            .withProjectId("project")
+            .withInstanceId("instsance")
+            .withTableId("table")
+            .withScan(scan)
+            .withConfiguration(
+                BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + port)
+            .withConfiguration(BigtableOptionsFactory.BIGTABLE_TEST_IDLE_TIMEOUT_MS, "15000")
+            .build();
+
+    CloudBigtableIO.Source source = (CloudBigtableIO.Source) CloudBigtableIO.read(config);
+    CloudBigtableIO.Reader reader = (CloudBigtableIO.Reader) source.createReader(null);
+
+    List<Result> actual = new ArrayList<>();
+
+    // Reader.start() will read the first row
+    reader.start();
+    actual.add(reader.getCurrent());
+    int count = 1;
+
+    boolean sleep = false;
+    while (reader.advance()) {
+      count++;
+      actual.add(reader.getCurrent());
+      if (!sleep) {
+        Thread.sleep(20 * 1000);
+        sleep = true;
+      }
+    }
+
+    // Make sure idle timeout is retried
+    Assert.assertTrue(fakeService.count.get() > 1);
+    Assert.assertEquals(responses.size(), count);
+    Assert.assertEquals(
+        responses.stream()
+            .map(response -> response.getChunks(0).getRowKey().toStringUtf8())
+            .collect(Collectors.toList()),
+        actual.stream()
+            .map(result -> ByteString.copyFrom(result.getRow()).toStringUtf8())
+            .collect(Collectors.toList()));
+  }
+
+  @Test
+  public void testRetryIdleTimeoutWithReadRowsRequest() throws Exception {
+    byte[] startKey = "A".getBytes();
+    byte[] endKey = "B".getBytes();
+
+    List<ReadRowsResponse> responses = generateResponses(fakeService, "A", "B", true, 10);
+
+    responses.remove(responses.size() - 1);
+
+    ReadRowsRequest request =
+        ReadRowsRequest.newBuilder()
+            .setTableName("projects/project/instances/instance/tables/table")
+            .setRows(
+                RowSet.newBuilder()
+                    .addRowRanges(
+                        RowRange.newBuilder()
+                            .setStartKeyClosed(ByteString.copyFrom(startKey))
+                            .setEndKeyOpen(ByteString.copyFrom(endKey))
+                            .build())
+                    .build())
+            .build();
+
+    CloudBigtableScanConfiguration config =
+        new CloudBigtableScanConfiguration.Builder()
+            .withProjectId("project")
+            .withInstanceId("instsance")
+            .withTableId("table")
+            .withRequest(request)
+            .withConfiguration(
+                BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + port)
+            .withConfiguration(BigtableOptionsFactory.BIGTABLE_TEST_IDLE_TIMEOUT_MS, "15000")
+            .build();
+
+    CloudBigtableIO.Source source = (CloudBigtableIO.Source) CloudBigtableIO.read(config);
+    CloudBigtableIO.Reader reader = (CloudBigtableIO.Reader) source.createReader(null);
+
+    List<Result> actual = new ArrayList<>();
+
+    // Reader.start() will read the first row
+    reader.start();
+    actual.add(reader.getCurrent());
+    int count = 1;
+
+    boolean sleep = false;
+    while (reader.advance()) {
+      count++;
+      actual.add(reader.getCurrent());
+      if (!sleep) {
+        Thread.sleep(20 * 1000);
+        sleep = true;
+      }
+    }
+
+    // Make sure idle timeout is retried
+    Assert.assertTrue(fakeService.count.get() > 1);
+    Assert.assertEquals(responses.size(), count);
+    Assert.assertEquals(
+        responses.stream()
+            .map(response -> response.getChunks(0).getRowKey())
+            .collect(Collectors.toList()),
+        actual.stream()
+            .map(result -> ByteString.copyFrom(result.getRow()))
+            .collect(Collectors.toList()));
+  }
+
+  private List<ReadRowsResponse> generateResponses(
+      FakeService fakeService, String starKey, String endKey, boolean addEndKey, int numResponses) {
+    List<ReadRowsResponse> responses = new ArrayList<>();
+
+    for (int i = 0; i < numResponses; i++) {
+      responses.add(
+          ReadRowsResponse.newBuilder()
+              .addChunks(
+                  ReadRowsResponse.CellChunk.newBuilder()
+                      .setRowKey(ByteString.copyFromUtf8(starKey + i))
+                      .setFamilyName(StringValue.of("cf"))
+                      .setQualifier(
+                          BytesValue.newBuilder().setValue(ByteString.copyFrom("q".getBytes())))
+                      .setTimestampMicros(1000)
+                      .setValue(ByteString.copyFromUtf8("value"))
+                      .setCommitRow(true)
+                      .build())
+              .build());
+    }
+
+    if (addEndKey) {
+      // add the end key which shouldn't be included in the response
+      responses.add(
+          ReadRowsResponse.newBuilder()
+              .addChunks(
+                  ReadRowsResponse.CellChunk.newBuilder()
+                      .setRowKey(ByteString.copyFromUtf8(endKey))
+                      .setFamilyName(StringValue.of("cf"))
+                      .setQualifier(
+                          BytesValue.newBuilder().setValue(ByteString.copyFrom("q".getBytes())))
+                      .setTimestampMicros(1000)
+                      .setValue(ByteString.copyFromUtf8("value"))
+                      .setCommitRow(true)
+                      .build())
+              .build());
+    }
+
+    fakeService.addResponses(responses);
+
+    return responses;
+  }
+
   private void split(CloudBigtableIO.Reader reader, ByteKeyRangeTracker baseRangeTracker) {
     double halfway = bisectPercentage(baseRangeTracker);
     reader.splitAtFraction(halfway);
@@ -190,5 +392,33 @@ public class CloudBigtableIOReaderTest {
   private static double bisectPercentage(ByteKeyRangeTracker baseRangeTracker) {
     double fractionConsumed = baseRangeTracker.getFractionConsumed();
     return (1.0 + fractionConsumed) / 2.0;
+  }
+
+  static class FakeService extends BigtableGrpc.BigtableImplBase {
+    List<ReadRowsResponse> responses = new ArrayList<>();
+    AtomicInteger count = new AtomicInteger(0);
+
+    @Override
+    public void readRows(
+        ReadRowsRequest request, StreamObserver<ReadRowsResponse> responseObserver) {
+      count.getAndIncrement();
+      ByteString startKey = request.getRows().getRowRanges(0).getStartKeyClosed();
+      ByteString endKey = request.getRows().getRowRanges(0).getEndKeyOpen();
+      int index = 0;
+
+      while (index < responses.size()) {
+        ReadRowsResponse current = responses.get(index++);
+        if (ByteStringComparator.INSTANCE.compare(current.getChunks(0).getRowKey(), startKey) >= 0
+            && ByteStringComparator.INSTANCE.compare(current.getChunks(0).getRowKey(), endKey)
+                < 0) {
+          responseObserver.onNext(current);
+        }
+      }
+      responseObserver.onCompleted();
+    }
+
+    void addResponses(List<ReadRowsResponse> allResponses) {
+      responses.addAll(allResponses);
+    }
   }
 }

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/test/java/com/google/cloud/bigtable/beam/CloudBigtableIOReaderTest.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/test/java/com/google/cloud/bigtable/beam/CloudBigtableIOReaderTest.java
@@ -373,15 +373,8 @@ public class CloudBigtableIOReaderTest {
       }
       Assert.fail("Should throw idle timeout exception");
     } catch (Throwable e) {
-      Throwable throwable = e;
-      while (throwable != null && !(throwable instanceof WatchdogTimeoutException)) {
-        throwable = throwable.getCause();
-      }
-
-      if (throwable == null) {
-        Assert.fail("Exception is not idle timeout");
-      }
-
+      Throwable throwable = CloudBigtableIO.Reader.findCause(e, WatchdogTimeoutException.class);
+      Assert.assertNotNull(throwable);
       Assert.assertTrue(throwable.getMessage().contains("idle"));
     }
   }


### PR DESCRIPTION
SeqFileWriter#write() which write to sequence file buffer could be slow. And the latency depends on the size of the data. Watchdog could throw idle timeout exceptions and this shouldn't bubble up to the pipeline. Retrying idle timeout exception.