### PR TITLE
deps: unflatten deps for 1x shaded and hadoop

### DIFF
--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
@@ -30,11 +30,6 @@ limitations under the License.
     bigtable-hbase-1.x.
   </description>
 
-  <properties>
-    <!-- define a property that can be ignored by renovate -->
-    <hbase1-hadoop-slf4j.version>1.6.1</hbase1-hadoop-slf4j.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -47,8 +42,8 @@ limitations under the License.
           <artifactId>hbase-shaded-client</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>jsr305</artifactId>
+          <groupId>ch.qos.reload4j</groupId>
+          <artifactId>reload4j</artifactId>
         </exclusion>
 
         <!-- Workaround MNG-5899 & MSHADE-206. Maven >= 3.3.0 doesn't use the dependency reduced
@@ -73,45 +68,22 @@ limitations under the License.
         </exclusion>
       </exclusions>
     </dependency>
+
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-client</artifactId>
       <version>${hbase1.version}</version>
-    </dependency>
-
-    <!-- Manually promote dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
-    <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-      <version>${commons-logging.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>ch.qos.reload4j</groupId>
       <artifactId>reload4j</artifactId>
       <version>${reload4j.version}</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-core</artifactId>
-      <version>${hbase1-metrics.version}</version>
-      <exclusions>
-        <!-- see slf4j notes below -->
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <!-- unlike hbase-shaded-client, hbase-client depends on slf4j 1.6.1.
-      Which is older than the version requested by metrics-core. However,
-      metrics-core will work fine with the older version and we want to stay
-      compatible with hbase-client deps -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${hbase1-hadoop-slf4j.version}</version>
     </dependency>
 
     <!-- Test deps -->
@@ -124,34 +96,31 @@ limitations under the License.
   </dependencies>
 
   <build>
-    <plugins>
-      <!-- disable google-cloud-shared-config enforcement checks because
-      hbase-client's dependency subtree doesn't follow the same rules and is
-      unable to be fixed here -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>enforce</id>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </execution>
-          <!-- This must be a drop in replacement for hbase-client, so can't
-            manage hbase's deps -->
-          <execution>
-            <id>enforce-banned-deps</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>enforce</id>
+              <!-- requireUpperBoundDeps, banDuplicateClasses -->
+              <configuration>
+                <skip>true</skip>
+              </configuration>
+            </execution>
+            <execution>
+              <id>enforce-banned-deps</id>
+              <configuration>
+                <skip>true</skip>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
 
+    <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
@@ -165,9 +134,12 @@ limitations under the License.
               <shadedArtifactAttached>false</shadedArtifactAttached>
               <createDependencyReducedPom>true</createDependencyReducedPom>
               <!-- Need to manually promote to dependencies to keep the structure of hbase-shade-client -->
-              <promoteTransitiveDependencies>
-                false
-              </promoteTransitiveDependencies>
+              <promoteTransitiveDependencies>false</promoteTransitiveDependencies>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+              </transformers>
               <filters>
                 <filter>
                   <artifact>*:*</artifact>
@@ -178,29 +150,11 @@ limitations under the License.
                   </excludes>
                 </filter>
               </filters>
-              <transformers>
-                <transformer
-                    implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
-                <transformer
-                    implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-              </transformers>
               <artifactSet>
                 <includes>
-                  <include>
-                    com.google.cloud.bigtable:bigtable-hbase-1.x-shaded
-                  </include>
+                  <include>com.google.cloud.bigtable:bigtable-hbase-1.x-shaded</include>
                 </includes>
               </artifactSet>
-              <relocations>
-                <!-- Undo the relocation that hbase-shaded-client did to make it compatible with the regular hbase-client -->
-                <relocation>
-                  <pattern>
-                    org.apache.hadoop.hbase.shaded.com.google.protobuf
-                  </pattern>
-                  <shadedPattern>com.google.protobuf</shadedPattern>
-                </relocation>
-              </relocations>
             </configuration>
           </execution>
         </executions>
@@ -240,18 +194,14 @@ limitations under the License.
             <id>verify-mirror-deps</id>
             <phase>verify</phase>
             <goals>
-              <goal>verify-mirror-deps</goal>
+              <goal>verify-mirror-deps-hbase</goal>
             </goals>
             <configuration>
               <targetDependencies>
                 <targetDependency>org.apache.hbase:hbase-client</targetDependency>
               </targetDependencies>
               <ignoredDependencies>
-                <!-- Unfortunately we can't use hadoop's version of slf4j
-                because dropwizard metrics slf4j logger requires a higher version
-                we can't shade it either -->
-                <dependency>org.slf4j:slf4j-api</dependency>
-
+                <dependency>log4j:log4j</dependency>
                 <!-- for some reason hbase-client exposes testing deps as a compile dep, just ignore them -->
                 <dependency>junit:junit</dependency>
                 <dependency>org.hamcrest:hamcrest-core</dependency>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
@@ -191,10 +191,10 @@ limitations under the License.
             </goals>
           </execution>
           <execution>
-            <id>verify-mirror-deps</id>
+            <id>verify-mirror-deps-hbase</id>
             <phase>verify</phase>
             <goals>
-              <goal>verify-mirror-deps-hbase</goal>
+              <goal>verify-mirror-deps</goal>
             </goals>
             <configuration>
               <targetDependencies>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
@@ -146,6 +146,12 @@ limitations under the License.
               <skip>true</skip>
             </configuration>
           </execution>
+          <execution>
+            <id>enforce-version-consistency-slf4j</id>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </execution>
           <!-- We are not introducing any new deps here. We expect to be
           running in hadoop's provided classpath -->
           <execution>
@@ -229,8 +235,6 @@ limitations under the License.
                 <targetDependency>org.apache.hbase:hbase-server:${hbase1.version}</targetDependency>
               </targetDependencies>
               <ignoredDependencies>
-                <!-- TODO: figure out why this diverges from hbase-client -->
-                <ignoredDependency>org.slf4j:slf4j-api</ignoredDependency>
                 <!-- For some reason, hbase-server pulls in test deps -->
                 <ignoredDependency>junit:junit</ignoredDependency>
                 <ignoredDependency>org.hamcrest:hamcrest-core</ignoredDependency>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -62,20 +62,45 @@ limitations under the License.
         <artifactId>conscrypt-openjdk</artifactId>
         <scope>provided</scope>
       </dependency>
+
+      <!-- Annotation jars that should not be relocated, but are also not required during runtime -->
       <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>${slf4j.version}</version>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-log4j12</artifactId>
-        <version>${slf4j.version}</version>
+        <groupId>org.checkerframework</groupId>
+        <artifactId>checker-qual</artifactId>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <scope>provided</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
 
   <dependencies>
+    <!-- HBase public deps -->
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-shaded-client</artifactId>
+      <version>${hbase1.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+      <version>${reload4j.version}</version>
+    </dependency>
+
     <!-- Internal dependencies that will be shaded along with their transitive dependencies.
      When adding new internal dependencies, make sure to exclude them from the reactor in direct dependents.
      See the *-hadoop/pom.xml and bigtable-hbase-beam/pom.xml for more details-->
@@ -83,26 +108,8 @@ limitations under the License.
       <groupId>${project.groupId}</groupId>
       <artifactId>bigtable-hbase-1.x</artifactId>
       <version>2.12.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-parent:current} -->
-      <exclusions>
-        <!-- api-common recently declared dependency on autovalue during migration to gradle. We don't
-            have a use of it so we're excluding it from the shaded jar. -->
-        <exclusion>
-          <groupId>com.google.auto.value</groupId>
-          <artifactId>auto-value</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
-    <dependency>
-      <groupId>com.google.cloud.bigtable</groupId>
-      <artifactId>bigtable-metrics-api</artifactId>
-      <version>${bigtable-metrics-api.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.api</groupId>
-          <artifactId>api-common</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
+
     <!-- Since opencensus-api is a transitive dep, we have to shade its impl as well.
     Otherwise the -api will be permanently severed from the impl and exporters -->
     <dependency>
@@ -116,26 +123,10 @@ limitations under the License.
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-exporter-stats-stackdriver</artifactId>
-      <exclusions>
-        <!-- api-common recently declared dependency on autovalue during migration to gradle. We don't
-            have a use of it so we're excluding it from the shaded jar. -->
-        <exclusion>
-          <groupId>com.google.auto.value</groupId>
-          <artifactId>auto-value</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-exporter-trace-stackdriver</artifactId>
-      <exclusions>
-        <!-- api-common recently declared dependency on autovalue during migration to gradle. We don't
-            have a use of it so we're excluding it from the shaded jar. -->
-        <exclusion>
-          <groupId>com.google.auto.value</groupId>
-          <artifactId>auto-value</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.opencensus</groupId>
@@ -161,46 +152,11 @@ limitations under the License.
         </exclusion>
       </exclusions>
     </dependency>
+
     <!-- grpc-census needed alongside opencensus-exporter-stats-stackdriver for GRPC stats exports to work -->
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-census</artifactId>
-    </dependency>
-
-    <!-- Manually promote public dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-shaded-client</artifactId>
-      <version>${hbase1.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.reload4j</groupId>
-      <artifactId>reload4j</artifactId>
-      <version>${reload4j.version}</version>
-      <scope>runtime</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-      <version>${commons-logging.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-core</artifactId>
-      <version>${hbase1-metrics.version}</version>
-    </dependency>
-    <!--needs to be declared as a dependency to be excluded from shading-->
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>${jsr305.version}</version>
     </dependency>
   </dependencies>
 
@@ -220,8 +176,7 @@ limitations under the License.
             <configuration>
               <excludedScopes>test,provided,system</excludedScopes>
               <!-- Should mirror the shade plugin exclusions-->
-              <excludedArtifacts>metrics-core|commons-logging|hbase-shaded-client|slf4j-api|slf4j-log4j12|log4j|htrace-core|findbugs-annotations|htrace-core4|jsr305</excludedArtifacts>
-              <excludedGroups>javax.annotation|org.checkerframework</excludedGroups>
+              <excludedArtifacts>hbase-shaded-client|commons-logging|slf4j-api|findbugs-annotations|htrace-core4|log4j|htrace-core|slf4j-log4j12|reload4j</excludedArtifacts>
               <generateBundle>true</generateBundle>
             </configuration>
           </execution>
@@ -242,9 +197,12 @@ limitations under the License.
               <!-- Need to manually promote to dependencies to keep the structure of hbase-shade-client.
                Also, this is needed to workaround maven reactor not using dependency-reduced-pom.xml
                files. See note in bigtable-1.x-hadoop .-->
-              <promoteTransitiveDependencies>
-                false
-              </promoteTransitiveDependencies>
+              <promoteTransitiveDependencies>false</promoteTransitiveDependencies>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+              </transformers>
               <filters>
                 <filter>
                   <artifact>*:*</artifact>
@@ -258,38 +216,25 @@ limitations under the License.
                   </excludes>
                 </filter>
               </filters>
-              <transformers>
-                <transformer
-                    implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
-                <transformer
-                    implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-              </transformers>
               <artifactSet>
                 <excludes>
-                  <!-- exclude user visible deps -->
-                  <exclude>io.dropwizard.metrics:metrics-core</exclude>
-                  <exclude>commons-logging:commons-logging</exclude>
-                  <exclude>ch.qos.reload4j:reload4j</exclude>
                   <!-- exclude hbase-shaded-client & all of its dependencies -->
                   <exclude>org.apache.hbase:hbase-shaded-client</exclude>
+                  <exclude>commons-logging:commons-logging</exclude>
                   <exclude>org.slf4j:slf4j-api</exclude>
-                  <exclude>org.slf4j:slf4j-log4j12</exclude>
-                  <exclude>log4j:log4j</exclude>
-                  <exclude>org.apache.htrace:htrace-core</exclude>
                   <exclude>com.github.stephenc.findbugs:findbugs-annotations</exclude>
                   <exclude>org.apache.htrace:htrace-core4</exclude>
-                  <exclude>javax.annotation:*</exclude>
-                  <exclude>org.checkerframework:*</exclude>
-                  <exclude>com.google.code.findbugs:jsr305</exclude>
+                  <exclude>log4j:log4j</exclude>
+                  <exclude>org.apache.htrace:htrace-core</exclude>
+                  <exclude>org.slf4j:slf4j-log4j12</exclude>
+                  <!-- Exclude reload4j -->
+                  <exclude>ch.qos.reload4j:reload4j</exclude>
                 </excludes>
               </artifactSet>
               <relocations>
                 <relocation>
                   <pattern>com.google</pattern>
-                  <shadedPattern>
-                    com.google.bigtable.repackaged.com.google
-                  </shadedPattern>
+                  <shadedPattern>com.google.bigtable.repackaged.com.google</shadedPattern>
                   <excludes>
                     <!-- don't shade our public hbase implementation. This includes com.google.cloud.bigtable.hbase.*
                      and references to com.google.cloud.bigtable.hbase1_x in the version specific jars.
@@ -305,15 +250,11 @@ limitations under the License.
 
                 <relocation>
                   <pattern>com.fasterxml</pattern>
-                  <shadedPattern>
-                    com.google.bigtable.repackaged.com.faster.xml
-                  </shadedPattern>
+                  <shadedPattern>com.google.bigtable.repackaged.com.faster.xml</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>com.twitter</pattern>
-                  <shadedPattern>
-                    com.google.bigtable.repackaged.com.twitter
-                  </shadedPattern>
+                  <shadedPattern>com.google.bigtable.repackaged.com.twitter</shadedPattern>
                 </relocation>
                 <!-- Take special care of grpc-netty-shaded, it uses the package
                      io.grpc.netty.shaded.io.grpc.netty, which will cause the
@@ -321,15 +262,11 @@ limitations under the License.
                  -->
                 <relocation>
                   <pattern>io.grpc.netty.shaded.io.grpc.netty</pattern>
-                  <shadedPattern>
-                    com.google.bigtable.repackaged.io.grpc.netty
-                  </shadedPattern>
+                  <shadedPattern>com.google.bigtable.repackaged.io.grpc.netty</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>io.grpc</pattern>
-                  <shadedPattern>
-                    com.google.bigtable.repackaged.io.grpc
-                  </shadedPattern>
+                  <shadedPattern>com.google.bigtable.repackaged.io.grpc</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>io.perfmark</pattern>
@@ -340,9 +277,7 @@ limitations under the License.
                 <!-- Opencensus related shading -->
                 <relocation>
                   <pattern>io.opencensus</pattern>
-                  <shadedPattern>
-                    com.google.bigtable.repackaged.io.opencensus
-                  </shadedPattern>
+                  <shadedPattern>com.google.bigtable.repackaged.io.opencensus</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>google.monitoring</pattern>
@@ -350,15 +285,11 @@ limitations under the License.
                 </relocation>
                 <relocation>
                   <pattern>org.json</pattern>
-                  <shadedPattern>
-                    com.google.bigtable.repackaged.org.json
-                  </shadedPattern>
+                  <shadedPattern>com.google.bigtable.repackaged.org.json</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>com.lmax</pattern>
-                  <shadedPattern>
-                    com.google.bigtable.repackaged.com.lmax
-                  </shadedPattern>
+                  <shadedPattern>com.google.bigtable.repackaged.com.lmax</shadedPattern>
                 </relocation>
 
                 <!-- Relocate netty, taking care to keep the prefix consistent for native tcnative
@@ -367,55 +298,36 @@ limitations under the License.
                     https://github.com/grpc/grpc-java/pull/2485
                 -->
                 <relocation>
-                  <pattern>
-                    META-INF/native/libio_grpc_netty_shaded_netty
-                  </pattern>
-                  <shadedPattern>
-                    META-INF/native/libcom_google_bigtable_repackaged_io_grpc_netty_shaded_netty
-                  </shadedPattern>
+                  <pattern>META-INF/native/libio_grpc_netty_shaded_netty</pattern>
+                  <shadedPattern>META-INF/native/libcom_google_bigtable_repackaged_io_grpc_netty_shaded_netty</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>META-INF/native/io_grpc_netty_shaded_netty</pattern>
-                  <shadedPattern>
-                    META-INF/native/com_google_bigtable_repackaged_io_grpc_netty_shaded_netty
-                  </shadedPattern>
+                  <shadedPattern>META-INF/native/com_google_bigtable_repackaged_io_grpc_netty_shaded_netty</shadedPattern>
                 </relocation>
-
                 <relocation>
                   <pattern>org.joda</pattern>
-                  <shadedPattern>
-                    com.google.bigtable.repackaged.org.joda
-                  </shadedPattern>
+                  <shadedPattern>com.google.bigtable.repackaged.org.joda</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.apache.http</pattern>
-                  <shadedPattern>
-                    com.google.bigtable.repackaged.org.apache.http
-                  </shadedPattern>
+                  <shadedPattern>com.google.bigtable.repackaged.org.apache.http</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.apache.commons.codec</pattern>
-                  <shadedPattern>
-                    com.google.bigtable.repackaged.org.apache.commons.codec
-                  </shadedPattern>
+                  <shadedPattern>com.google.bigtable.repackaged.org.apache.commons.codec</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.apache.commons.lang3</pattern>
-                  <shadedPattern>
-                    com.google.bigtable.repackaged.org.apache.commons.lang3
-                  </shadedPattern>
+                  <shadedPattern>com.google.bigtable.repackaged.org.apache.commons.lang3</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.threeten</pattern>
-                  <shadedPattern>
-                    com.google.bigtable.repackaged.org.threeten
-                  </shadedPattern>
+                  <shadedPattern>com.google.bigtable.repackaged.org.threeten</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.codehaus</pattern>
-                  <shadedPattern>
-                    com.google.bigtable.repackaged.org.codehaus
-                  </shadedPattern>
+                  <shadedPattern>com.google.bigtable.repackaged.org.codehaus</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>android.annotation</pattern>
@@ -461,7 +373,7 @@ limitations under the License.
             </goals>
           </execution>
           <execution>
-            <id>verify-mirror-deps</id>
+            <id>verify-mirror-deps-hbase</id>
             <phase>verify</phase>
             <goals>
               <goal>verify-mirror-deps</goal>
@@ -473,6 +385,18 @@ limitations under the License.
               <ignoredDependencies>
                 <ignoredDependency>log4j:log4j</ignoredDependency>
               </ignoredDependencies>
+            </configuration>
+          </execution>
+          <execution>
+            <id>verify-mirror-deps-hbase-cbt</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>verify-mirror-deps</goal>
+            </goals>
+            <configuration>
+              <targetDependencies>
+                <targetDependency>com.google.cloud:google-cloud-bigtable</targetDependency>
+              </targetDependencies>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
* order deps as: hbase, then bigtable, then bigtable-hbase
* mark all annotation deps as provided
* mark conscrypt as provided, which is optional as provided, end users will need to add it themselves if it is needed
* some formatting changes
* ensure that dep tree of bigtable & hbase are separately respected

At this point both of the artifacts (w/o any other deps) can be dropped into the HBASE_CLASSPATH and allow the end user to connect to bigtable
