### PR TITLE
chore: clean up dependency enforcement checks

### DIFF
--- a/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-beam-import/pom.xml
@@ -37,18 +37,6 @@ limitations under the License.
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-
-      <!-- force update transitive deps to exclude CVEs -->
-      <dependency>
-        <groupId>commons-codec</groupId>
-        <artifactId>commons-codec</artifactId>
-        <version>1.15</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-compress</artifactId>
-        <version>1.21</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -69,12 +57,27 @@ limitations under the License.
     <dependency>
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
+      <exclusions>
+        <exclusion>
+          <!-- Avoid conflicts with commons-logging: beam-sdks-java-io-kafka pulls in spring-core which hijacks commons-logging -->
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-jcl</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>com.google.cloud.bigdataoss</groupId>
       <artifactId>gcs-connector</artifactId>
       <version>hadoop2-2.2.16</version>
+      <classifier>shaded</classifier>
+      <exclusions>
+        <!-- shaded variant doesn't have deps -->
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
 
@@ -189,20 +192,9 @@ limitations under the License.
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
           <executions>
+            <!-- TODO: figure out how to deal with beam enforcement errors -->
             <execution>
               <id>enforce</id>
-              <configuration>
-                <skip>true</skip>
-              </configuration>
-            </execution>
-            <execution>
-              <id>enforce-version-consistency</id>
-              <configuration>
-                <skip>true</skip>
-              </configuration>
-            </execution>
-            <execution>
-              <id>enforce-version-consistency-slf4j</id>
               <configuration>
                 <skip>true</skip>
               </configuration>
@@ -211,6 +203,7 @@ limitations under the License.
         </plugin>
       </plugins>
     </pluginManagement>
+
 
     <plugins>
       <plugin>
@@ -335,6 +328,7 @@ limitations under the License.
         <artifactId>bigtable-build-helper</artifactId>
         <version>2.12.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-parent:current} -->
         <executions>
+          <!-- We are using beam's bom, so no need to check if the beam deps are mirrored -->
           <execution>
             <id>verify-mirror-deps-hbase</id>
             <phase>verify</phase>
@@ -350,31 +344,6 @@ limitations under the License.
                 <!-- Use Beam's version of slf4j-api -->
                 <dependency>org.slf4j:slf4j-api</dependency>
               </ignoredDependencies>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <!-- For conflicts that need to be ignored for dependency mirroring, we need to make sure that
-            we pick a newer version -->
-            <id>enforce-conflict-upper-bounds</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <requireUpperBoundDeps>
-                  <includes>
-                    <include>org.slf4j:slf4j-api</include>
-                    <include>org.apache.commons:commons-compress</include>
-                  </includes>
-                </requireUpperBoundDeps>
-              </rules>
             </configuration>
           </execution>
         </executions>

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/pom.xml
@@ -161,28 +161,6 @@ limitations under the License.
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <executions>
-            <!-- Silence checks for old version commons-compress. The the actual
-            issue is irrelevant, but fixing it will create real dependency issues
-            for end users -->
-            <execution>
-              <id>enforce-banned-deps</id>
-              <configuration>
-                <skip>true</skip>
-              </configuration>
-            </execution>
-            <execution>
-              <id>enforce-version-consistency-slf4j</id>
-              <configuration>
-                <skip>true</skip>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <configuration>
             <windowtitle>
@@ -261,30 +239,6 @@ limitations under the License.
                 <!-- beam's dependency tree has an older version closer higher in the tree -->
                 <dependency>com.google.errorprone:error_prone_annotations</dependency>
               </ignoredDependencies>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <!-- For conflicts that need to be ignored for dependency mirroring, we need to make sure that
-            we pick a newer version -->
-            <id>enforce-conflict-upper-bounds</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <requireUpperBoundDeps>
-                  <includes>
-                    <include>com.google.errorprone:error_prone_annotations</include>
-                  </includes>
-                </requireUpperBoundDeps>
-              </rules>
             </configuration>
           </execution>
         </executions>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
@@ -98,13 +98,16 @@ limitations under the License.
   <build>
     <pluginManagement>
       <plugins>
+        <!-- The only dep that has changed in this module is hbase-shaded-client to hbase-client. hbase-client
+        does not adhere to our enforcement rules and we dont have any way to influence it. So just disable enforcement.
+        TODO: remove this once hbase deps become provided
+        -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
           <executions>
             <execution>
               <id>enforce</id>
-              <!-- requireUpperBoundDeps, banDuplicateClasses -->
               <configuration>
                 <skip>true</skip>
               </configuration>
@@ -119,7 +122,6 @@ limitations under the License.
         </plugin>
       </plugins>
     </pluginManagement>
-
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/pom.xml
@@ -125,45 +125,6 @@ limitations under the License.
   </dependencies>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <!-- skip UpperBound enforcement for hadoop jars -->
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>enforce</id>
-              <goals>
-                <goal>enforce</goal>
-              </goals>
-              <configuration>
-                <skip>true</skip>
-              </configuration>
-            </execution>
-            <execution>
-              <id>enforce-version-consistency-slf4j</id>
-              <goals>
-                <goal>enforce</goal>
-              </goals>
-              <configuration>
-                <skip>true</skip>
-              </configuration>
-            </execution>
-            <!-- We are not introducing any new deps here. We expect to be
-            running in hadoop's provided classpath -->
-            <execution>
-              <id>enforce-banned-deps</id>
-              <configuration>
-                <skip>true</skip>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-
-
     <plugins>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/pom.xml
@@ -127,28 +127,6 @@
           </archive>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>enforce-banned-deps</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <bannedDependencies>
-                  <excludes>
-                    <exclude>org.apache.logging.log4j:*:*</exclude>
-                    <exclude>log4j:log4j:*</exclude>
-                  </excludes>
-                </bannedDependencies>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
@@ -79,25 +79,22 @@ limitations under the License.
   <build>
     <pluginManagement>
       <plugins>
+        <!-- The only dep that has changed in this module is hbase-shaded-client to hbase-client. hbase-client
+        does not adhere to our enforcement rules and we dont have any way to influence it. So just disable enforcement.
+        TODO: remove this once hbase deps become provided
+        -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
           <executions>
             <execution>
               <id>enforce</id>
-              <!-- requireUpperBoundDeps, banDuplicateClasses -->
               <configuration>
                 <skip>true</skip>
               </configuration>
             </execution>
             <execution>
               <id>enforce-banned-deps</id>
-              <configuration>
-                <skip>true</skip>
-              </configuration>
-            </execution>
-            <execution>
-              <id>enforce-version-consistency-slf4j</id>
               <configuration>
                 <skip>true</skip>
               </configuration>

--- a/hbase-migration-tools/bigtable-hbase-replication/bigtable-hbase-1.x-replication/pom.xml
+++ b/hbase-migration-tools/bigtable-hbase-replication/bigtable-hbase-1.x-replication/pom.xml
@@ -35,45 +35,6 @@ limitations under the License.
   </description>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <!-- disable google-cloud-shared-config enforcement checks because
-            hbase-client's dependency subtree doesn't follow the same rules and is
-            unable to be fixed here -->
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>enforce</id>
-              <!-- requireUpperBoundDeps, banDuplicateClasses -->
-              <configuration>
-                <skip>true</skip>
-              </configuration>
-            </execution>
-
-            <!-- This must be a drop in replacement for hbase-client, so can't
-                          manage hbase's deps -->
-            <execution>
-              <id>enforce-banned-deps</id>
-              <goals>
-                <goal>enforce</goal>
-              </goals>
-              <configuration>
-                <skip>true</skip>
-              </configuration>
-            </execution>
-            <execution>
-              <id>enforce-version-consistency-slf4j</id>
-              <configuration>
-                <skip>true</skip>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-
     <plugins>
       <plugin>
         <groupId>com.google.cloud.bigtable.test</groupId>

--- a/hbase-migration-tools/bigtable-hbase-replication/bigtable-hbase-2.x-replication/pom.xml
+++ b/hbase-migration-tools/bigtable-hbase-replication/bigtable-hbase-2.x-replication/pom.xml
@@ -32,50 +32,6 @@ limitations under the License.
     <description>Library to enable one way replication from HBase to Cloud Bigtable. </description>
 
     <build>
-        <pluginManagement>
-            <plugins>
-                <!-- disable google-cloud-shared-config enforcement checks because
-                    hbase-client's dependency subtree doesn't follow the same rules and is
-                    unable to be fixed here -->
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-enforcer-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <id>enforce</id>
-                            <!-- requireUpperBoundDeps, banDuplicateClasses -->
-                            <configuration>
-                                <skip>true</skip>
-                            </configuration>
-                        </execution>
-                        <!-- This must be a drop in replacement for hbase-client, so can't
-                          manage hbase's deps -->
-                        <execution>
-                            <id>enforce-banned-deps</id>
-                            <goals>
-                                <goal>enforce</goal>
-                            </goals>
-                            <configuration>
-                                <skip>true</skip>
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <id>enforce-version-consistency</id>
-                            <configuration>
-                                <skip>true</skip>
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <id>enforce-version-consistency-slf4j</id>
-                            <configuration>
-                                <skip>true</skip>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/hbase-migration-tools/bigtable-hbase-replication/bigtable-hbase-replication-core/pom.xml
+++ b/hbase-migration-tools/bigtable-hbase-replication/bigtable-hbase-replication-core/pom.xml
@@ -34,35 +34,6 @@ limitations under the License.
     Bigtable.
   </description>
 
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>enforce</id>
-              <!-- disable banDuplicateClasses
-                    hbase-server has overlapping classes from commons-beanutils-core & commons-beanutils, since the
-                    classpath is provided by HBase, there is nothing we can do
-              -->
-              <configuration>
-                <skip>true</skip>
-              </configuration>
-            </execution>
-            <execution>
-              <id>enforce-banned-deps</id>
-              <configuration>
-                <skip>true</skip>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x-hadoop/pom.xml
+++ b/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x-hadoop/pom.xml
@@ -90,9 +90,10 @@ limitations under the License.
   <build>
     <pluginManagement>
       <plugins>
-        <!-- disable google-cloud-shared-config enforcement checks because
-        hbase-client's dependency subtree doesn't follow the same rules and is
-        unable to be fixed here -->
+        <!-- The only dep that has changed in this module is hbase-shaded-client to hbase-client. hbase-client
+        does not adhere to our enforcement rules and we dont have any way to influence it. So just disable enforcement.
+        TODO: remove this once hbase deps become provided
+        -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
@@ -103,13 +104,8 @@ limitations under the License.
                 <skip>true</skip>
               </configuration>
             </execution>
-            <!-- This must be a drop in replacement for hbase-client, so can't
-              manage hbase's deps -->
             <execution>
               <id>enforce-banned-deps</id>
-              <goals>
-                <goal>enforce</goal>
-              </goals>
               <configuration>
                 <skip>true</skip>
               </configuration>

--- a/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x-integration-tests/pom.xml
+++ b/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x-integration-tests/pom.xml
@@ -278,7 +278,8 @@ limitations under the License.
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_httpserver</artifactId>
-      <version>0.16.0</version>
+      <!-- Should match prometheus version used by opencensus-exporter-stats-prometheus -->
+      <version>0.6.0</version>
     </dependency>
 
     <!-- Testing deps -->
@@ -401,26 +402,6 @@ limitations under the License.
               <excludes>
                 <exclude>**/*.java</exclude>
               </excludes>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>enforce</id>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </execution>
-          <execution>
-            <id>enforce-banned-deps</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <skip>true</skip>
             </configuration>
           </execution>
         </executions>

--- a/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x-shaded/pom.xml
+++ b/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x-shaded/pom.xml
@@ -63,37 +63,6 @@ limitations under the License.
   </dependencies>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <!-- disable google-cloud-shared-config enforcement checks because
-      hbase-client's dependency subtree doesn't follow the same rules and is
-      unable to be fixed here -->
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>enforce</id>
-              <configuration>
-                <skip>true</skip>
-              </configuration>
-            </execution>
-            <!-- This must be a drop in replacement for hbase-client, so can't
-              manage hbase's deps -->
-            <execution>
-              <id>enforce-banned-deps</id>
-              <goals>
-                <goal>enforce</goal>
-              </goals>
-              <configuration>
-                <skip>true</skip>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-1.x-2.x-integration-tests/pom.xml
+++ b/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-1.x-2.x-integration-tests/pom.xml
@@ -262,7 +262,8 @@ limitations under the License.
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_httpserver</artifactId>
-      <version>0.16.0</version>
+      <!-- Should match prometheus version used by opencensus-exporter-stats-prometheus -->
+      <version>0.6.0</version>
     </dependency>
 
     <!-- Testing deps -->
@@ -403,32 +404,6 @@ limitations under the License.
               <excludes>
                 <exclude>**/*.java</exclude>
               </excludes>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>enforce-version-consistency</id>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </execution>
-          <execution>
-            <id>enforce</id>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </execution>
-          <execution>
-            <id>enforce-banned-deps</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <skip>true</skip>
             </configuration>
           </execution>
         </executions>

--- a/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x-hadoop/pom.xml
+++ b/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x-hadoop/pom.xml
@@ -87,40 +87,34 @@ limitations under the License.
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <!-- The only dep that has changed in this module is hbase-shaded-client to hbase-client. hbase-client
+        does not adhere to our enforcement rules and we dont have any way to influence it. So just disable enforcement.
+        TODO: remove this once hbase deps become provided
+        -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>enforce</id>
+              <configuration>
+                <skip>true</skip>
+              </configuration>
+            </execution>
+            <execution>
+              <id>enforce-banned-deps</id>
+              <configuration>
+                <skip>true</skip>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
     <plugins>
-      <plugin>
-        <!-- disable google-cloud-shared-config enforcement checks because
-        hbase-client's dependency subtree doesn't follow the same rules and is
-        unable to be fixed here -->
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>enforce</id>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </execution>
-          <!-- hbase-client doesnt align slf4j-api & slf4j-log4j -->
-          <execution>
-            <id>enforce-version-consistency-slf4j</id>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </execution>
-          <!-- This must be a drop in replacement for hbase-client, so can't
-            manage hbase's deps -->
-          <execution>
-            <id>enforce-banned-deps</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>

--- a/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x-integration-tests/pom.xml
+++ b/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x-integration-tests/pom.xml
@@ -267,7 +267,8 @@ limitations under the License.
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_httpserver</artifactId>
-      <version>0.16.0</version>
+      <!-- Should match prometheus version used by opencensus-exporter-stats-prometheus -->
+      <version>0.6.0</version>
     </dependency>
 
     <!-- Testing deps -->
@@ -425,32 +426,6 @@ limitations under the License.
           <source>8</source>
           <target>8</target>
         </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>enforce</id>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </execution>
-          <execution>
-            <id>enforce-version-consistency</id>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </execution>
-          <execution>
-            <id>enforce-banned-deps</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x-shaded/pom.xml
+++ b/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x-shaded/pom.xml
@@ -164,36 +164,6 @@ limitations under the License.
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>enforce</id>
-            <configuration>
-              <rules>
-                <requireUpperBoundDeps>
-                  <excludes>
-                    <!--
-                    ${guava.version} == 30.1-android
-                    api-common:1.10.4 requires 30.1.1-android
-                     -->
-                    <exclude>com.google.guava:guava</exclude>
-                    <!--
-                    guava:30.1-android requires error_prone_annotations:2.3.4
-                    truth:1.1.2 requires error_prone_annotations:2.5.1
-                     -->
-                    <exclude>com.google.errorprone:error_prone_annotations</exclude>
-                  </excludes>
-                </requireUpperBoundDeps>
-              </rules>
-            </configuration>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>com.google.cloud.bigtable.test</groupId>
         <artifactId>bigtable-build-helper</artifactId>
         <version>2.12.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-parent:current} -->

--- a/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/pom.xml
+++ b/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/pom.xml
@@ -56,7 +56,6 @@ limitations under the License.
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-shaded-client</artifactId>
       <version>${hbase2.version}</version>
-      <scope>${hbase.scope}</scope>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>

--- a/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/pom.xml
+++ b/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/pom.xml
@@ -56,7 +56,7 @@ limitations under the License.
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-shaded-client</artifactId>
       <version>${hbase2.version}</version>
-      <scope>compile</scope>
+      <scope>${hbase.scope}</scope>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
@@ -118,33 +118,6 @@ limitations under the License.
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>enforce</id>
-            <configuration>
-              <rules>
-                <requireUpperBoundDeps>
-                  <excludes>
-                    <exclude>com.google.guava:guava</exclude>
-                    <!--
-                    guava:30.1-android requires error_prone_annotations:2.3.4
-                    truth:1.1.2 requires error_prone_annotations:2.5.1
-                     -->
-                    <exclude>com.google.errorprone:error_prone_annotations</exclude>
-                  </excludes>
-                </requireUpperBoundDeps>
-              </rules>
-            </configuration>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
       <!-- copy protobuf-java-format-shaded and core into jar -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-core-parent/pom.xml
+++ b/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-core-parent/pom.xml
@@ -61,40 +61,6 @@ limitations under the License.
             </links>
           </configuration>
         </plugin>
-
-        <!-- disable google-cloud-shared-config enforcement checks because
-        hbase-client's dependency subtree doesn't follow the same rules and is
-        unable to be fixed here -->
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>enforce</id>
-              <configuration>
-                <skip>true</skip>
-              </configuration>
-            </execution>
-            <!-- hbase-client doesnt align slf4j-api & slf4j-log4j -->
-            <execution>
-              <id>enforce-version-consistency-slf4j</id>
-              <configuration>
-                <skip>true</skip>
-              </configuration>
-            </execution>
-            <!-- This must be a drop in replacement for hbase-client, so can't
-              manage hbase's deps -->
-            <execution>
-              <id>enforce-banned-deps</id>
-              <goals>
-                <goal>enforce</goal>
-              </goals>
-              <configuration>
-                <skip>true</skip>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -250,106 +250,18 @@ limitations under the License.
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>
           <execution>
-            <id>enforce-version-consistency</id>
+            <id>enforce</id>
             <goals>
               <goal>enforce</goal>
             </goals>
             <configuration>
               <rules>
-                <requireSameVersions>
-                  <dependencies>
-                    <dependency>io.grpc:*</dependency>
-                  </dependencies>
-                </requireSameVersions>
-                <requireSameVersions>
-                  <dependencies>
-                    <dependency>com.google.cloud:google-cloud-bigtable</dependency>
-                    <dependency>com.google.api.grpc:proto-google-cloud-bigtable-v2</dependency>
-                    <dependency>com.google.api.grpc:grpc-google-cloud-bigtable-v2</dependency>
-                    <dependency>com.google.api.grpc:proto-google-cloud-bigtable-admin-v2</dependency>
-                    <dependency>com.google.api.grpc:grpc-google-cloud-bigtable-admin-v2</dependency>
-                  </dependencies>
-                </requireSameVersions>
-                <requireSameVersions>
-                  <dependencies>
-                    <dependency>com.google.auth:*</dependency>
-                  </dependencies>
-                </requireSameVersions>
-                <requireSameVersions>
-                  <dependencies>
-                    <dependency>com.google.api:gax</dependency>
-                    <dependency>com.google.api:gax-grpc</dependency>
-                  </dependencies>
-                </requireSameVersions>
-                <requireSameVersions>
-                  <dependencies>
-                    <dependency>org.apache.beam:beam-sdks-*</dependency>
-                    <dependency>org.apache.beam:beam-model-*</dependency>
-                  </dependencies>
-                </requireSameVersions>
-                <requireSameVersions>
-                  <dependencies>
-                    <dependency>io.netty:netty-all</dependency>
-                    <dependency>io.netty:netty-codec*</dependency>
-                    <dependency>io.netty:netty-handler*</dependency>
-                    <dependency>io.netty:netty-common</dependency>
-                    <dependency>io.netty:netty-resolver</dependency>
-                    <dependency>io.netty:netty-buffer</dependency>
-                    <dependency>io.netty:netty-transport</dependency>
-                    <!-- Everything but netty-tcnative-boringssl-static -->
-                  </dependencies>
-                </requireSameVersions>
-                <requireSameVersions>
-                  <dependencies>
-                    <dependency>com.google.auto.value</dependency>
-                  </dependencies>
-                </requireSameVersions>
-                <requireSameVersions>
-                  <dependencies>
-                    <dependency>org.hamcrest:*</dependency>
-                  </dependencies>
-                </requireSameVersions>
-                <requireSameVersions>
-                  <dependencies>
-                    <dependency>com.google.protobuf:*</dependency>
-                  </dependencies>
-                </requireSameVersions>
-                <requireSameVersions>
-                  <dependencies>
-                    <dependency>com.google.http-client:*</dependency>
-                  </dependencies>
-                </requireSameVersions>
-                <bannedDependencies>
-                  <includes>
-                    <!-- gax-grpc transitvely brings in opencensus-proto, which the latest version is 0.2.0-->
-                    <!-- Only allow 0.2.0 for opencensus-proto and then the latest version (currently 0.31.1) for all other modules-->
-                    <!-- this will need to be updated whenever the opencensus version gets updated -->
-                    <dependency>io.opencensus:*:[${opencensus.version}]</dependency>
-                    <dependency>io.opencensus:opencensus-proto:[0.2.0]</dependency>
-                    <!-- todo: revert this once we have a unified version -->
-                    <!-- jackson-databind's latest version is 2.13.4.2, while other jackson deps' latest version is 2.13.4 -->
-                    <dependency>com.fasterxml.jackson.core:jackson-databind:[2.13.4.2]</dependency>
-                    <dependency>com.fasterxml.jackson.core:[2.13.4]</dependency>
-                    <dependency>com.fasterxml.jackson:*</dependency>
-                  </includes>
-                </bannedDependencies>
-              </rules>
-            </configuration>
-          </execution>
-          <!-- extract slf4 consistency check to own execution so it can be
-          disabled for hbase-client 2.x -->
-          <execution>
-            <id>enforce-version-consistency-slf4j</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <requireSameVersions>
-                  <dependencies>
-                    <dependency>org.slf4j:*</dependency>
-                  </dependencies>
-                </requireSameVersions>
+                <!-- All hbase deps are provided and we have no hope of enforcing rules on them -->
+                <banDuplicateClasses>
+                  <scopes combine.children="override">
+                    <scope>compile</scope>
+                  </scopes>
+                </banDuplicateClasses>
               </rules>
             </configuration>
           </execution>
@@ -361,10 +273,11 @@ limitations under the License.
             <configuration>
               <rules>
                 <bannedDependencies>
+                  <includes>
+                    <include>*:*:*:*:provided</include>
+                    <include>*:*:*:*:test</include>
+                  </includes>
                   <excludes>
-                    <!-- Ban all known dependencies with CVEs -->
-                    <exclude>commons-codec:commons-codec:[,1.15)</exclude>
-                    <exclude>org.apache.commons:commons-compress:[,1.20)</exclude>
                     <!-- ban all log4j 2.x deps with CVEs -->
                     <exclude>org.apache.logging.log4j:*:[2.0-alpha1,2.16.0]</exclude>
                     <!-- ban all log4j -->


### PR DESCRIPTION
* remove version consistency checks, instead we now rely on dependency mirroring checks to ensure that deps are coherent
* exclude provided & test deps from the bannedDeps rule
* remove commons-codec & commons-compress from the banned list, we have no control over them: compress comes from beam and codec comes from hbase. Neither is used by this project
* fix class conflict in the import job for commons-logging
* switch to using shaded version of gcs-connector to avoid conflicts with beam
* disable all enforcement checks in -hadoop jars, they simply repackage -shaded jars so any enforcement failures are in the hbase-client domain and are out of our control
* fix version alignment in mirroring client integration tests
