### PR TITLE
deps: add a direct dep on google-cloud-bigtable in the -shaded artifa…

### DIFF
--- a/bigtable-dataflow-parent/bigtable-hbase-beam/pom.xml
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/pom.xml
@@ -69,6 +69,10 @@ limitations under the License.
           <artifactId>bigtable-hbase-1.x</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>com.google.cloud</groupId>
+          <artifactId>google-cloud-bigtable</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>io.opencensus</groupId>
           <artifactId>*</artifactId>
         </exclusion>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/pom.xml
@@ -51,8 +51,12 @@ limitations under the License.
         the dependencies. Note that this works in conjunction with the manually promoted dependencies
         in bigtable-hbase-1.x-shaded/pom.xml -->
         <exclusion>
-          <groupId>${project.groupId}</groupId>
+          <groupId>com.google.cloud.bigtable</groupId>
           <artifactId>bigtable-hbase-1.x</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.cloud</groupId>
+          <artifactId>google-cloud-bigtable</artifactId>
         </exclusion>
         <exclusion>
           <groupId>com.google.cloud.bigtable</groupId>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -105,9 +105,16 @@ limitations under the License.
      When adding new internal dependencies, make sure to exclude them from the reactor in direct dependents.
      See the *-hadoop/pom.xml and bigtable-hbase-beam/pom.xml for more details-->
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>com.google.cloud.bigtable</groupId>
       <artifactId>bigtable-hbase-1.x</artifactId>
       <version>2.12.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-parent:current} -->
+    </dependency>
+
+    <!-- This isnt strictly necessary as it will be pulled in by bigtable-hbase-1.x. However, it helps to resolve
+    RequireUpperBoundDeps issues introduced by the opencensus exporters -->
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-bigtable</artifactId>
     </dependency>
 
     <!-- Since opencensus-api is a transitive dep, we have to shade its impl as well.
@@ -115,10 +122,6 @@ limitations under the License.
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-impl</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.opencensus</groupId>
-      <artifactId>opencensus-contrib-zpages</artifactId>
     </dependency>
     <dependency>
       <groupId>io.opencensus</groupId>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-tools/pom.xml
@@ -34,6 +34,10 @@
           <artifactId>bigtable-hbase-1.x</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>com.google.cloud</groupId>
+          <artifactId>google-cloud-bigtable</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>com.google.cloud.bigtable</groupId>
           <artifactId>bigtable-metrics-api</artifactId>
         </exclusion>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/pom.xml
@@ -51,6 +51,10 @@ limitations under the License.
           <artifactId>bigtable-hbase-2.x</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>com.google.cloud</groupId>
+          <artifactId>google-cloud-bigtable</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>io.opencensus</groupId>
           <artifactId>*</artifactId>
         </exclusion>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
@@ -90,6 +90,14 @@ limitations under the License.
       <version>${hbase2.version}</version>
     </dependency>
 
+    <!-- This isnt strictly necessary as it will be pulled in by bigtable-hbase-1.x. However, it helps to resolve
+    RequireUpperBoundDeps issues introduced by the opencensus exporters -->
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-bigtable</artifactId>
+      <version>${bigtable.version}</version>
+    </dependency>
+
 
     <!-- Internal dependencies that will be shaded along with their transitive dependencies.
      When adding new internal dependencies, make sure to exclude them from the reactor in direct dependents.
@@ -105,10 +113,6 @@ limitations under the License.
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-impl</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.opencensus</groupId>
-      <artifactId>opencensus-contrib-zpages</artifactId>
     </dependency>
     <dependency>
       <groupId>io.opencensus</groupId>


### PR DESCRIPTION
…cts to workaround UpperBound issues

Both google-cloud-bigtable & opencensus exporters have a transitive deps on checker-qual. checker-qual is only used for annotations and doesnt actually affect anything in the shaded jars. In fact it is marked as provided. It doesnt matter what version (if any) is present at runtime. However RequireUppperBounds enforcer check trips over this. So as a workaround, this PR adds a direct dep on google-cloud-bigtable in the -shaded artifacts. This should have no effect on the final build as that artifact will be shaded regardless

Change-Id: I44a000379d822c28daf4dc27a41d1d8f6998689f

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable-hbase/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
