### PR TITLE
deps: clean up mirroring client deps

### DIFF
--- a/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x-hadoop/pom.xml
+++ b/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x-hadoop/pom.xml
@@ -39,6 +39,25 @@ limitations under the License.
   </properties>
 
   <dependencies>
+    <!-- Environment deps first -->
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-client</artifactId>
+      <version>${hbase1.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+      <version>${reload4j.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+
     <!-- Internal dependencies that will be shaded along with their transitive dependencies. -->
     <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
@@ -60,30 +79,7 @@ limitations under the License.
           <groupId>${project.groupId}</groupId>
           <artifactId>bigtable-hbase-mirroring-client-1.x</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>io.opencensus</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
       </exclusions>
-    </dependency>
-
-    <!-- Manually promote public dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-client</artifactId>
-      <version>${hbase1.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.reload4j</groupId>
-      <artifactId>reload4j</artifactId>
-      <version>${reload4j.version}</version>
-      <scope>runtime</scope>
     </dependency>
   </dependencies>
 
@@ -146,9 +142,6 @@ limitations under the License.
                 <includes>
                   <include>
                     com.google.cloud.bigtable:bigtable-hbase-mirroring-client-1.x-shaded
-                  </include>
-                  <include>
-                    com.google.cloud.bigtable:bigtable-hbase-mirroring-client-1.x
                   </include>
                 </includes>
               </artifactSet>

--- a/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x-integration-tests/pom.xml
+++ b/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x-integration-tests/pom.xml
@@ -178,29 +178,13 @@ limitations under the License.
   </profiles>
 
   <dependencies>
-    <dependency>
-      <groupId>com.google.cloud.bigtable</groupId>
-      <artifactId>bigtable-hbase-mirroring-client-1.x</artifactId>
-      <version>0.7.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-mirroring:current} -->
-      <scope>test</scope>
-    </dependency>
-
+    <!-- Environment deps first -->
     <dependency>
       <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-shaded-client</artifactId>
+      <artifactId>hbase-shaded-testing-util</artifactId>
       <version>${hbase1.version}</version>
       <scope>test</scope>
       <exclusions>
-        <!-- exclusion to avoid version conflict with existing artifact  -->
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-        <!-- exclusion to avoid version conflict with existing artifact  -->
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
         <exclusion>
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
@@ -211,48 +195,64 @@ limitations under the License.
       <groupId>ch.qos.reload4j</groupId>
       <artifactId>reload4j</artifactId>
       <version>${reload4j.version}</version>
-      <scope>runtime</scope>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Project Modules -->
+    <dependency>
+      <groupId>com.google.cloud.bigtable</groupId>
+      <artifactId>bigtable-hbase-mirroring-client-1.x</artifactId>
+      <version>0.7.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-mirroring:current} -->
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-shaded-client</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>bigtable-hbase-1.x-hadoop</artifactId>
+      <artifactId>bigtable-hbase-1.x</artifactId>
       <version>2.12.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-parent:current} -->
+      <scope>test</scope>
+      <exclusions>
+        <!-- already included in the hbase-shaded-testing-util -->
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-shaded-client</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- This gets pulled in by bigtable-hbase-1.x.
+    Add ths to resolve conflict with the guava version that opencensus-exporter-trace-zipkin pulls in -->
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-bigtable</artifactId>
+      <version>${bigtable.version}</version>
       <scope>test</scope>
     </dependency>
 
-    <!-- HBase testing tools -->
+
+    <!-- Internal testing utils -->
     <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-shaded-testing-util</artifactId>
-      <version>${hbase1.version}</version>
+      <groupId>com.google.cloud.bigtable</groupId>
+      <artifactId>bigtable-hbase-mirroring-client-core</artifactId>
+      <version>0.7.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-mirroring:current} -->
+      <type>test-jar</type>
       <scope>test</scope>
       <exclusions>
-        <!-- exclusion to avoid version conflict with existing artifact  -->
+        <!-- Only want test helpers -->
         <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-        <!-- exclusion to avoid version conflict with existing artifact  -->
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
 
     <!-- Misc -->
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-      <version>3.22.2</version>
-      <scope>test</scope>
-    </dependency>
-
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
@@ -264,22 +264,26 @@ limitations under the License.
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-impl</artifactId>
       <version>${opencensus.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-exporter-trace-zipkin</artifactId>
       <version>${opencensus.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-exporter-stats-prometheus</artifactId>
       <version>${opencensus.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_httpserver</artifactId>
       <!-- Should match prometheus version used by opencensus-exporter-stats-prometheus -->
       <version>0.6.0</version>
+      <scope>test</scope>
     </dependency>
 
     <!-- Testing deps -->
@@ -300,25 +304,6 @@ limitations under the License.
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>2.20.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>2.20.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.cloud.bigtable</groupId>
-      <artifactId>bigtable-hbase-mirroring-client-core</artifactId>
-      <version>0.7.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-mirroring:current} -->
-      <type>test-jar</type>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x-shaded/pom.xml
+++ b/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x-shaded/pom.xml
@@ -35,15 +35,7 @@ limitations under the License.
   </description>
 
   <dependencies>
-    <!-- Internal dependencies that will be shaded along with their transitive dependencies. -->
-    <dependency>
-      <groupId>com.google.cloud.bigtable</groupId>
-      <artifactId>bigtable-hbase-mirroring-client-1.x</artifactId>
-      <version>0.7.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-mirroring:current} -->
-      <scope>compile</scope>
-    </dependency>
-
-    <!-- Manually promote public dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
+    <!-- Environment deps first -->
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-shaded-client</artifactId>
@@ -59,6 +51,14 @@ limitations under the License.
       <groupId>ch.qos.reload4j</groupId>
       <artifactId>reload4j</artifactId>
       <version>${reload4j.version}</version>
+    </dependency>
+
+    <!-- Internal dependencies that will be shaded along with their transitive dependencies. -->
+    <dependency>
+      <groupId>com.google.cloud.bigtable</groupId>
+      <artifactId>bigtable-hbase-mirroring-client-1.x</artifactId>
+      <version>0.7.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-mirroring:current} -->
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 
@@ -100,18 +100,17 @@ limitations under the License.
               </transformers>
               <artifactSet>
                 <excludes>
-                  <!-- exclude user visible deps -->
-                  <exclude>commons-logging:commons-logging</exclude>
                   <!-- exclude hbase-shaded-client & all of its dependencies -->
                   <exclude>org.apache.hbase:hbase-shaded-client</exclude>
+                  <exclude>commons-logging:commons-logging</exclude>
                   <exclude>org.slf4j:slf4j-api</exclude>
-                  <exclude>org.slf4j:slf4j-log4j12</exclude>
-                  <exclude>log4j:log4j</exclude>
-                  <exclude>ch.qos.reload4j:reload4j</exclude>
-                  <exclude>org.apache.htrace:htrace-core4</exclude>
-                  <exclude>org.apache.htrace:htrace-core</exclude>
                   <exclude>com.github.stephenc.findbugs:findbugs-annotations</exclude>
+                  <exclude>org.apache.htrace:htrace-core4</exclude>
                   <exclude>log4j:log4j</exclude>
+                  <exclude>org.apache.htrace:htrace-core</exclude>
+                  <exclude>org.slf4j:slf4j-log4j12</exclude>
+                  <!-- Exclude reload4j -->
+                  <exclude>ch.qos.reload4j:reload4j</exclude>
                 </excludes>
               </artifactSet>
               <relocations>

--- a/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/pom.xml
+++ b/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/pom.xml
@@ -34,14 +34,46 @@ limitations under the License.
   </description>
 
   <dependencies>
+    <!-- Environment deps first -->
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-shaded-client</artifactId>
+      <version>${hbase1.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+      <version>${reload4j.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+
+    <!-- Project deps -->
     <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
       <artifactId>bigtable-hbase-mirroring-client-core</artifactId>
       <version>0.7.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-mirroring:current} -->
       <scope>compile</scope>
+
+      <exclusions>
+        <!-- Exclude the environment deps, as they are declared explicitly above -->
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-shaded-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>ch.qos.reload4j</groupId>
+          <artifactId>reload4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
-    <!-- Test deps -->
+    <!-- Test dependencies -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -66,6 +98,13 @@ limitations under the License.
       <version>0.7.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-mirroring:current} -->
       <type>test-jar</type>
       <scope>test</scope>
+      <exclusions>
+        <!-- We only want the test helpers -->
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 
@@ -92,30 +131,6 @@ limitations under the License.
                 <!-- forcefully replaced with reload4j -->
                 <dependency>log4j:log4j</dependency>
               </ignoredDependencies>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <!-- copy protobuf-java-format-shaded and core into jar -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <shadedArtifactAttached>false</shadedArtifactAttached>
-              <createDependencyReducedPom>true</createDependencyReducedPom>
-              <artifactSet>
-                <includes>
-                  <include>com.google.cloud.bigtable:protobuf-java-format-shaded</include>
-                  <include>com.google.cloud.bigtable}:bigtable-hbase-mirroring-client-core</include>
-                </includes>
-              </artifactSet>
             </configuration>
           </execution>
         </executions>

--- a/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-1.x-parent/pom.xml
+++ b/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-1.x-parent/pom.xml
@@ -44,9 +44,24 @@ limitations under the License.
   <modules>
     <module>bigtable-hbase-mirroring-client-1.x</module>
     <module>bigtable-hbase-mirroring-client-1.x-integration-tests</module>
-    <module>bigtable-hbase-mirroring-client-1.x-shaded</module>
-    <module>bigtable-hbase-mirroring-client-1.x-hadoop</module>
   </modules>
+
+  <profiles>
+    <profile>
+      <!-- Shading workaround for IDEs:
+          resolve these modules from the local maven repo -->
+      <id>with-shaded</id>
+      <activation>
+        <property>
+          <name>!skip-shaded</name>
+        </property>
+      </activation>
+      <modules>
+        <module>bigtable-hbase-mirroring-client-1.x-shaded</module>
+        <module>bigtable-hbase-mirroring-client-1.x-hadoop</module>
+      </modules>
+    </profile>
+  </profiles>
 
   <build>
     <pluginManagement>

--- a/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-1.x-2.x-integration-tests/pom.xml
+++ b/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-1.x-2.x-integration-tests/pom.xml
@@ -182,12 +182,33 @@ limitations under the License.
   </profiles>
 
   <dependencies>
+    <!-- Environment deps first -->
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-shaded-testing-util</artifactId>
+      <version>${hbase2.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+      <version>${reload4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Project Modules -->
     <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
       <artifactId>bigtable-hbase-mirroring-client-2.x</artifactId>
       <version>0.7.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-mirroring:current} -->
       <scope>test</scope>
+      <exclusions>
+        <!-- already included in the hbase-shaded-testing-util -->
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-shaded-client</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -195,20 +216,21 @@ limitations under the License.
       <artifactId>bigtable-hbase-2.x</artifactId>
       <version>2.12.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-parent:current} -->
       <scope>test</scope>
+      <exclusions>
+        <!-- already included in the hbase-shaded-testing-util -->
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-shaded-client</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
+    <!-- This gets pulled in by bigtable-hbase-1.x.
+    Add ths to resolve conflict with the guava version that opencensus-exporter-trace-zipkin pulls in -->
     <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-shaded-client</artifactId>
-      <version>${hbase2.version}</version> <!-- {x-version-update:bigtable-client-parent:current} -->
-      <scope>test</scope>
-    </dependency>
-
-    <!-- HBase testing tools -->
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-shaded-testing-util</artifactId>
-      <version>${hbase2.version}</version>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-bigtable</artifactId>
+      <version>${bigtable.version}</version>
       <scope>test</scope>
     </dependency>
 
@@ -220,6 +242,13 @@ limitations under the License.
       <version>0.7.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-mirroring:current} -->
       <type>test-jar</type>
       <scope>test</scope>
+      <exclusions>
+        <!-- Only want test helpers -->
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
@@ -227,16 +256,16 @@ limitations under the License.
       <version>0.7.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-mirroring:current} -->
       <type>test-jar</type>
       <scope>test</scope>
+      <exclusions>
+        <!-- Only want test helpers -->
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Misc -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>31.0.1-jre</version>
-      <scope>test</scope>
-    </dependency>
-
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
@@ -248,22 +277,26 @@ limitations under the License.
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-impl</artifactId>
       <version>${opencensus.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-exporter-trace-zipkin</artifactId>
       <version>${opencensus.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-exporter-stats-prometheus</artifactId>
       <version>${opencensus.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_httpserver</artifactId>
       <!-- Should match prometheus version used by opencensus-exporter-stats-prometheus -->
       <version>0.6.0</version>
+      <scope>test</scope>
     </dependency>
 
     <!-- Testing deps -->
@@ -277,50 +310,13 @@ limitations under the License.
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>1.1.3</version>
+      <version>${truth.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>2.20.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>2.20.0</version>
-      <scope>test</scope>
-    </dependency>
-
-    <!-- Needed by MiniHBaseCluster -->
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.20.0</version>
-      <scope>test</scope>
-    </dependency>
-
-    <!-- Version of slf4j copied from HBase 2.4.5 pom.xml -->
-    <!-- Pinned to prevent Enforcer errors -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.7.30</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.30</version>
-      <scope>test</scope>
-    </dependency>
-
-    <!-- Pinned to prevent Enforcer errors -->
-    <dependency>
-      <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-core</artifactId>
-      <version>3.2.6</version>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x-hadoop/pom.xml
+++ b/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x-hadoop/pom.xml
@@ -40,6 +40,24 @@ limitations under the License.
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-client</artifactId>
+      <version>${hbase2.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+      <version>${reload4j.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
       <artifactId>bigtable-hbase-mirroring-client-2.x-shaded</artifactId>
       <version>0.7.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-mirroring:current} -->
@@ -59,31 +77,9 @@ limitations under the License.
           <groupId>${project.groupId}</groupId>
           <artifactId>bigtable-hbase-mirroring-client-2.x</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>io.opencensus</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
 
-    <!-- Manually promote public dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-client</artifactId>
-      <version>${hbase2.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.reload4j</groupId>
-      <artifactId>reload4j</artifactId>
-      <version>${reload4j.version}</version>
-      <scope>runtime</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x-integration-tests/pom.xml
+++ b/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x-integration-tests/pom.xml
@@ -181,12 +181,33 @@ limitations under the License.
   </profiles>
 
   <dependencies>
+    <!-- Environment deps first -->
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-shaded-testing-util</artifactId>
+      <version>${hbase2.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+      <version>${reload4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Project Modules -->
     <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
       <artifactId>bigtable-hbase-mirroring-client-2.x</artifactId>
       <version>0.7.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-mirroring:current} -->
       <scope>test</scope>
+      <exclusions>
+        <!-- already included in the hbase-shaded-testing-util -->
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-shaded-client</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -194,22 +215,24 @@ limitations under the License.
       <artifactId>bigtable-hbase-2.x</artifactId>
       <version>2.12.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-parent:current} -->
       <scope>test</scope>
+      <exclusions>
+        <!-- already included in the hbase-shaded-testing-util -->
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-shaded-client</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
+    <!-- This gets pulled in by bigtable-hbase-1.x.
+    Add ths to resolve conflict with the guava version that opencensus-exporter-trace-zipkin pulls in -->
     <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-shaded-client</artifactId>
-      <version>${hbase2.version}</version>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-bigtable</artifactId>
+      <version>${bigtable.version}</version>
       <scope>test</scope>
     </dependency>
 
-    <!-- HBase testing tools -->
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-shaded-testing-util</artifactId>
-      <version>${hbase2.version}</version>
-      <scope>test</scope>
-    </dependency>
 
     <!-- Internal testing utils -->
     <dependency>
@@ -218,6 +241,13 @@ limitations under the License.
       <version>0.7.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-mirroring:current} -->
       <type>test-jar</type>
       <scope>test</scope>
+      <exclusions>
+        <!-- Only want test helpers -->
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
@@ -225,6 +255,13 @@ limitations under the License.
       <version>0.7.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-mirroring:current} -->
       <type>test-jar</type>
       <scope>test</scope>
+      <exclusions>
+        <!-- Only want test helpers -->
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
@@ -232,16 +269,16 @@ limitations under the License.
       <version>0.7.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-mirroring:current} -->
       <type>test-jar</type>
       <scope>test</scope>
+      <exclusions>
+        <!-- Only want test helpers -->
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Misc -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>31.0.1-jre</version>
-      <scope>test</scope>
-    </dependency>
-
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
@@ -253,22 +290,26 @@ limitations under the License.
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-impl</artifactId>
       <version>${opencensus.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-exporter-trace-zipkin</artifactId>
       <version>${opencensus.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-exporter-stats-prometheus</artifactId>
       <version>${opencensus.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_httpserver</artifactId>
       <!-- Should match prometheus version used by opencensus-exporter-stats-prometheus -->
       <version>0.6.0</version>
+      <scope>test</scope>
     </dependency>
 
     <!-- Testing deps -->
@@ -286,52 +327,9 @@ limitations under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>2.20.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>2.20.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <!-- Needed by MiniHBaseCluster -->
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.20.0</version>
-      <scope>test</scope>
-    </dependency>
-
-    <!-- Version of slf4j copied from HBase 2.4.5 pom.xml -->
-    <!-- Pinned to prevent Enforcer errors -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.7.30</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.30</version>
-      <scope>test</scope>
-    </dependency>
-
-    <!-- Pinned to prevent Enforcer errors -->
-    <dependency>
-      <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-core</artifactId>
-      <version>3.2.6</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -404,14 +402,6 @@ limitations under the License.
             </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>8</source>
-          <target>8</target>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x-shaded/pom.xml
+++ b/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x-shaded/pom.xml
@@ -34,19 +34,19 @@ limitations under the License.
   </description>
 
   <dependencies>
-    <!-- Internal dependencies that will be shaded along with their transitive dependencies. -->
-    <dependency>
-      <groupId>com.google.cloud.bigtable</groupId>
-      <artifactId>bigtable-hbase-mirroring-client-2.x</artifactId>
-      <version>0.7.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-mirroring:current} -->
-      <scope>compile</scope>
-    </dependency>
-
-    <!-- Manually promote dependencies: This is necessary to avoid flattening hbase-shaded-client's dependency tree -->
+    <!-- HBase public deps -->
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-shaded-client</artifactId>
       <version>${hbase2.version}</version>
+    </dependency>
+
+    <!-- Internal dependencies that will be shaded along with their transitive dependencies.
+     When adding new internal dependencies, make sure to exclude them from the reactor in direct dependents.-->
+    <dependency>
+      <groupId>com.google.cloud.bigtable</groupId>
+      <artifactId>bigtable-hbase-mirroring-client-2.x</artifactId>
+      <version>0.7.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-mirroring:current} -->
     </dependency>
   </dependencies>
 

--- a/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/pom.xml
+++ b/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/pom.xml
@@ -34,7 +34,14 @@ limitations under the License.
   </description>
 
   <dependencies>
-    <!-- external deps -->
+    <!-- Environment deps first -->
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-shaded-client</artifactId>
+      <version>${hbase2.version}</version>
+    </dependency>
+
+    <!-- Project deps -->
     <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
       <artifactId>bigtable-hbase-mirroring-client-core</artifactId>
@@ -42,6 +49,7 @@ limitations under the License.
       <scope>compile</scope>
 
       <exclusions>
+        <!-- Exclude the environment deps, as they are declared explicitly above -->
         <exclusion>
           <groupId>org.apache.hbase</groupId>
           <artifactId>hbase-shaded-client</artifactId>
@@ -52,24 +60,7 @@ limitations under the License.
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-shaded-client</artifactId>
-      <version>${hbase2.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.api</groupId>
-      <artifactId>api-common</artifactId>
-      <version>1.10.6</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <scope>compile</scope>
-    </dependency>
-    <!-- shaded deps -->
+
     <dependency>
       <groupId>net.javacrumbs.future-converter</groupId>
       <artifactId>future-converter-java8-guava</artifactId>
@@ -103,13 +94,10 @@ limitations under the License.
       <type>test-jar</type>
       <scope>test</scope>
       <exclusions>
+        <!-- We only want the test helpers -->
         <exclusion>
-          <artifactId>org.apache.hbase</artifactId>
           <groupId>*</groupId>
-        </exclusion>
-        <exclusion>
-          <groupId>ch.qos.reload4j</groupId>
-          <artifactId>reload4j</artifactId>
+          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -117,25 +105,25 @@ limitations under the License.
 
   <build>
     <plugins>
-      <!-- copy protobuf-java-format-shaded and core into jar -->
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
+        <groupId>com.google.cloud.bigtable.test</groupId>
+        <artifactId>bigtable-build-helper</artifactId>
+        <version>2.12.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-parent:current} -->
+
         <executions>
           <execution>
-            <phase>package</phase>
+            <id>verify-mirror-deps-hbase</id>
+            <phase>verify</phase>
             <goals>
-              <goal>shade</goal>
+              <goal>verify-mirror-deps</goal>
             </goals>
             <configuration>
-              <shadedArtifactAttached>false</shadedArtifactAttached>
-              <createDependencyReducedPom>true</createDependencyReducedPom>
-              <artifactSet>
-                <includes>
-                  <include>com.google.cloud.bigtable:protobuf-java-format-shaded</include>
-                  <include>${project.groupId}:bigtable-hbase-mirroring-client-core</include>
-                </includes>
-              </artifactSet>
+              <targetDependencies>
+                <!-- make sure that we are a strict superset of hbase -->
+                <targetDependency>org.apache.hbase:hbase-shaded-client</targetDependency>
+              </targetDependencies>
+              <ignoredDependencies>
+              </ignoredDependencies>
             </configuration>
           </execution>
         </executions>

--- a/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/pom.xml
+++ b/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-2.x-parent/pom.xml
@@ -36,7 +36,22 @@ limitations under the License.
     <module>bigtable-hbase-mirroring-client-2.x</module>
     <module>bigtable-hbase-mirroring-client-1.x-2.x-integration-tests</module>
     <module>bigtable-hbase-mirroring-client-2.x-integration-tests</module>
-    <module>bigtable-hbase-mirroring-client-2.x-shaded</module>
-    <module>bigtable-hbase-mirroring-client-2.x-hadoop</module>
   </modules>
+
+  <profiles>
+    <profile>
+      <!-- Shading workaround for IDEs:
+          resolve these modules from the local maven repo -->
+      <id>with-shaded</id>
+      <activation>
+        <property>
+          <name>!skip-shaded</name>
+        </property>
+      </activation>
+      <modules>
+        <module>bigtable-hbase-mirroring-client-2.x-shaded</module>
+        <module>bigtable-hbase-mirroring-client-2.x-hadoop</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>

--- a/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-core-parent/bigtable-hbase-mirroring-client-core/pom.xml
+++ b/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-core-parent/bigtable-hbase-mirroring-client-core/pom.xml
@@ -41,7 +41,7 @@ limitations under the License.
   </properties>
 
   <dependencies>
-    <!-- external deps -->
+    <!-- Environment deps first -->
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-shaded-client</artifactId>
@@ -60,17 +60,34 @@ limitations under the License.
       <scope>runtime</scope>
     </dependency>
 
+    <!-- Project deps -->
+    <dependency>
+      <groupId>com.google.cloud.bigtable</groupId>
+      <artifactId>protobuf-java-format-shaded</artifactId>
+      <version>0.7.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-mirroring:current} -->
+      <scope>compile</scope>
+
+      <exclusions>
+        <!-- Workaround MNG-5899 & MSHADE-206. Maven >= 3.3.0 doesn't use the dependency reduced
+        pom.xml files when invoking the build from a parent project. So we have to manually exclude
+        the dependencies. -->
+        <exclusion>
+          <groupId>com.googlecode.protobuf-java-format</groupId>
+          <artifactId>protobuf-java-format</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- impl deps -->
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>api-common</artifactId>
       <version>1.10.6</version>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
-      <scope>compile</scope>
     </dependency>
 
     <dependency>
@@ -80,19 +97,12 @@ limitations under the License.
       <scope>provided</scope>
     </dependency>
 
-    <!-- deps to be shaded -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>2.14.2</version>
-      <scope>compile</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.cloud.bigtable</groupId>
-      <artifactId>protobuf-java-format-shaded</artifactId>
-      <version>0.7.1-SNAPSHOT</version> <!-- {x-version-update:bigtable-hbase-mirroring:current} -->
-      <scope>compile</scope>
-    </dependency>
+
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-api</artifactId>

--- a/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-core-parent/pom.xml
+++ b/hbase-migration-tools/mirroring-client/bigtable-hbase-mirroring-client-core-parent/pom.xml
@@ -35,8 +35,23 @@ limitations under the License.
 
   <modules>
     <module>bigtable-hbase-mirroring-client-core</module>
-    <module>protobuf-java-format-shaded</module>
   </modules>
+
+  <profiles>
+    <profile>
+      <!-- Shading workaround for IDEs:
+          resolve these modules from the local maven repo -->
+      <id>with-shaded</id>
+      <activation>
+        <property>
+          <name>!skip-shaded</name>
+        </property>
+      </activation>
+      <modules>
+        <module>protobuf-java-format-shaded</module>
+      </modules>
+    </profile>
+  </profiles>
 
   <build>
     <pluginManagement>


### PR DESCRIPTION
* add IDE workaround for mirroring-client shaded deps to be resolved from ~/.m2
* drop shading from intermediate artifacts
* organize mirroring client poms so that env deps come first
* update mirroring client integration tests to avoid duplicated classes from hbase-shaded-client and hbase-shaded-testing-util
* use reload4j for integration test logging
* add google-cloud-bigtable as a dep to integration test modules to resolve conflict about guava
* update integration test modules to exclude transitive deps from each other to make easier to reason about the classpath

Change-Id: I0a9c57ac5eac609847cb28014c156436fb94abe2

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable-hbase/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
