### PR TITLE
test: remove references to guava in the integration tests

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestBatch.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestBatch.java
@@ -20,10 +20,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import org.apache.commons.lang.ArrayUtils;
@@ -429,14 +429,14 @@ public abstract class AbstractTestBatch extends AbstractTest {
     actualError = null;
 
     try {
-      table.batch(ImmutableList.<Row>of(), new Object[0]);
+      table.batch(Collections.emptyList(), new Object[0]);
     } catch (Exception ex) {
       actualError = ex;
     }
     assertNull(actualError);
 
     try {
-      table.batch(ImmutableList.<Row>of(null), new Object[0]);
+      table.batch(Collections.singletonList(null), new Object[0]);
     } catch (Exception ex) {
       actualError = ex;
     }

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestCreateTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestCreateTable.java
@@ -115,11 +115,7 @@ public abstract class AbstractTestCreateTable extends AbstractTest {
               es));
     }
 
-    try {
-      futures.stream().forEach(CompletableFuture::join);
-    } finally {
-      es.shutdown();
-    }
+    futures.stream().forEach(CompletableFuture::join);
   }
 
   private void createTable(String goodName, TableName[] tableNames) throws Exception {

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestFilters.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestFilters.java
@@ -17,14 +17,13 @@ package com.google.cloud.bigtable.hbase;
 
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY2;
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterators;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1474,7 +1473,7 @@ public abstract class AbstractTestFilters extends AbstractTest {
     table.put(put);
 
     // Filter for results
-    Filter filter = new TimestampsFilter(ImmutableList.<Long>of(0L, 1L));
+    Filter filter = new TimestampsFilter(Arrays.asList(0L, 1L));
 
     Get get = new Get(rowKey).setFilter(filter);
     Result result = table.get(get);
@@ -2038,7 +2037,7 @@ public abstract class AbstractTestFilters extends AbstractTest {
     PageFilter pageFilter = new PageFilter(20);
     scan.setFilter(pageFilter);
     try (ResultScanner scanner = table.getScanner(scan)) {
-      Assert.assertEquals(20, Iterators.size(scanner.iterator()));
+      assertThat(scanner).hasSize(20);
     }
 
     FilterList filterList =
@@ -2048,7 +2047,7 @@ public abstract class AbstractTestFilters extends AbstractTest {
             pageFilter);
     scan.setFilter(filterList);
     try (ResultScanner scanner = table.getScanner(scan)) {
-      Assert.assertEquals(20, Iterators.size(scanner.iterator()));
+      assertThat(scanner).hasSize(20);
     }
   }
 
@@ -2172,7 +2171,7 @@ public abstract class AbstractTestFilters extends AbstractTest {
     Pair<byte[], byte[]> fuzzyData =
         Pair.newPair(createKey(1, 0, 0, 4), createFuzzyMask(0, 1, 1, 0));
 
-    Scan scan = new Scan().setFilter(new FuzzyRowFilter(ImmutableList.of(fuzzyData)));
+    Scan scan = new Scan().setFilter(new FuzzyRowFilter(Collections.singletonList(fuzzyData)));
 
     // only the first and second keys should be matched
     try (ResultScanner scanner = table.getScanner(scan)) {
@@ -2209,7 +2208,7 @@ public abstract class AbstractTestFilters extends AbstractTest {
     // match keys with 5 in the first position and 126/127/128/129 in the 3rd position
     FuzzyRowFilter filter =
         new FuzzyRowFilter(
-            ImmutableList.of(
+            Arrays.asList(
                 Pair.newPair(createKey(5, 0, 126, 0), createFuzzyMask(0, 1, 0, 1)),
                 Pair.newPair(createKey(5, 0, 127, 0), createFuzzyMask(0, 1, 0, 1)),
                 Pair.newPair(createKey(5, 0, 128, 0), createFuzzyMask(0, 1, 0, 1)),

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestModifyTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestModifyTable.java
@@ -18,8 +18,8 @@ package com.google.cloud.bigtable.hbase;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.base.Function;
 import java.io.IOException;
+import java.util.function.Function;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/TestAdminOps.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/TestAdminOps.java
@@ -19,9 +19,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.collect.ImmutableList;
 import java.io.IOException;
-import org.apache.hadoop.hbase.TableName;
+import java.util.Collections;
 import org.apache.hadoop.hbase.client.Admin;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -88,7 +87,7 @@ public class TestAdminOps extends AbstractTest {
     try (Admin admin = getConnection().getAdmin()) {
       assertTrue(admin.getTableDescriptorsByTableName(null).length > 0);
 
-      assertTrue(admin.getTableDescriptorsByTableName(ImmutableList.<TableName>of()).length > 0);
+      assertTrue(admin.getTableDescriptorsByTableName(Collections.emptyList()).length > 0);
     }
   }
 
@@ -104,7 +103,7 @@ public class TestAdminOps extends AbstractTest {
       assertNotNull(actualError);
       assertTrue(actualError instanceof NullPointerException);
 
-      assertTrue(admin.getTableDescriptors(ImmutableList.<String>of()).length > 0);
+      assertTrue(admin.getTableDescriptors(Collections.emptyList()).length > 0);
     }
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/TestBufferedMutator.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/TestBufferedMutator.java
@@ -21,7 +21,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.hadoop.hbase.client.BufferedMutator;
@@ -120,7 +121,7 @@ public class TestBufferedMutator extends AbstractTest {
       actualError = null;
 
       try {
-        bm.mutate(ImmutableList.<Mutation>of());
+        bm.mutate(Collections.emptyList());
       } catch (Exception ex) {
         actualError = ex;
       }
@@ -176,13 +177,12 @@ public class TestBufferedMutator extends AbstractTest {
             getConnection().getBufferedMutator(sharedTestEnv.getDefaultTableName());
         Table tableForRead = getConnection().getTable(sharedTestEnv.getDefaultTableName())) {
 
-      ImmutableList.Builder<Put> builder = ImmutableList.builder();
+      List<Put> mutations = new ArrayList<>();
       for (int i = 0; i < 10; i++) {
-        builder.add(
+        mutations.add(
             new Put(Bytes.toBytes(rowKeyPrefix + i))
                 .addColumn(COLUMN_FAMILY, qualifier, 10_001L, value));
       }
-      List<Put> mutations = builder.build();
 
       mutator.mutate(mutations);
       // force bufferedMutator to apply mutation

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/TestScan.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/TestScan.java
@@ -17,10 +17,8 @@ package com.google.cloud.bigtable.hbase;
 
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY2;
-import static com.google.common.truth.Truth.*;
+import static com.google.common.truth.Truth.assertThat;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -346,7 +344,7 @@ public class TestScan extends AbstractTest {
             .collect(Collectors.toList());
 
     List<String> expectedRowKeys =
-        ImmutableList.of(
+        Arrays.asList(
             new String(rowKeys[6]),
             new String(rowKeys[5]),
             new String(rowKeys[4]),
@@ -387,7 +385,7 @@ public class TestScan extends AbstractTest {
             .setReversed(true)
             .setFilter(
                 new MultiRowRangeFilter(
-                    Lists.newArrayList(
+                    Arrays.asList(
                         new RowRange(rowKeys[3], false, rowKeys[4], true),
                         new RowRange(rowKeys[6], true, rowKeys[8], false))));
 
@@ -398,7 +396,7 @@ public class TestScan extends AbstractTest {
             .collect(Collectors.toList());
 
     List<String> expectedRowKeys =
-        ImmutableList.of(new String(rowKeys[7]), new String(rowKeys[6]), new String(rowKeys[4]));
+        Arrays.asList(new String(rowKeys[7]), new String(rowKeys[6]), new String(rowKeys[4]));
 
     assertThat(actualRowKeys).containsExactlyElementsIn(expectedRowKeys).inOrder();
   }
@@ -437,7 +435,7 @@ public class TestScan extends AbstractTest {
             .withStopRow(rowKeys[1])
             .setFilter(
                 new MultiRowRangeFilter(
-                    Lists.newArrayList(
+                    Arrays.asList(
                         new RowRange(rowKeys[3], true, rowKeys[4], true),
                         new RowRange(rowKeys[6], true, rowKeys[8], false))));
 
@@ -448,7 +446,7 @@ public class TestScan extends AbstractTest {
             .collect(Collectors.toList());
 
     List<String> expectedRowKeys =
-        ImmutableList.of(new String(rowKeys[6]), new String(rowKeys[4]), new String(rowKeys[3]));
+        Arrays.asList(new String(rowKeys[6]), new String(rowKeys[4]), new String(rowKeys[3]));
 
     assertThat(actualRowKeys).containsExactlyElementsIn(expectedRowKeys).inOrder();
   }

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/TestSingleColumnValueFilter.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/TestSingleColumnValueFilter.java
@@ -19,10 +19,10 @@ package com.google.cloud.bigtable.hbase;
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
 
 import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
-import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -57,10 +57,10 @@ public class TestSingleColumnValueFilter extends AbstractTest {
     table = SharedTestEnvRule.getInstance().getDefaultTable();
 
     List<Put> puts = new ArrayList<>();
-    ImmutableSet.Builder<String> keyBuilder = ImmutableSet.builder();
+    keys = new HashSet<>();
     for (long i = 0; i < count; i++) {
       byte[] row = dataHelper.randomData(PREFIX);
-      keyBuilder.add(Bytes.toString(row));
+      keys.add(Bytes.toString(row));
       int randomValue = (int) Math.floor(count * Math.random());
       puts.add(
           new Put(row)
@@ -72,7 +72,6 @@ public class TestSingleColumnValueFilter extends AbstractTest {
     byte[] stringVal = Bytes.toBytes("Not a number");
     puts.add(new Put(otheRow).addColumn(COLUMN_FAMILY, OTHER_QUALIFIER, stringVal));
 
-    keys = keyBuilder.build();
     table.put(puts);
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnv.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnv.java
@@ -16,7 +16,6 @@
 package com.google.cloud.bigtable.hbase.test_env;
 
 import java.io.IOException;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnv.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnv.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.hbase.test_env;
 
 import java.io.IOException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -57,7 +58,7 @@ abstract class SharedTestEnv {
     }
   }
 
-  public ExecutorService getExecutor() {
+  public Executor getExecutor() {
     return executor;
   }
 
@@ -67,11 +68,11 @@ abstract class SharedTestEnv {
       AtomicInteger threadIndex = new AtomicInteger();
       executor =
           Executors.newCachedThreadPool(
-              r -> {
-                Thread thread = new Thread(r);
-                thread.setDaemon(true);
-                thread.setName("shared-test-env-rule-" + threadIndex.getAndIncrement());
-                return null;
+              (r) -> {
+                Thread t = new Thread(r);
+                t.setName("shared-test-env-rule-" + threadIndex.getAndIncrement());
+                t.setDaemon(true);
+                return t;
               });
       setup();
     }

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnv.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/SharedTestEnv.java
@@ -58,7 +58,7 @@ abstract class SharedTestEnv {
     }
   }
 
-  public Executor getExecutor() {
+  public ExecutorService getExecutor() {
     return executor;
   }
 

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestModifyTable.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestModifyTable.java
@@ -15,8 +15,8 @@
  */
 package com.google.cloud.bigtable.hbase;
 
-import com.google.common.base.Function;
 import java.io.IOException;
+import java.util.function.Function;
 import javax.annotation.Nullable;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.client.Admin;

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestBatch.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestBatch.java
@@ -18,7 +18,7 @@ package com.google.cloud.bigtable.hbase;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.verify;
 
-import com.google.common.collect.ImmutableList;
+import java.util.Collections;
 import org.apache.hadoop.hbase.client.Append;
 import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.client.coprocessor.Batch;
@@ -38,7 +38,7 @@ public class TestBatch extends AbstractTestBatch {
     Batch.Callback mockCallBack = Mockito.mock(Batch.Callback.class);
     try {
       // This is accepted behaviour in HBase 2 API, It ignores the `new Object[1]` param.
-      table.batchCallback(ImmutableList.of(), new Object[1], mockCallBack);
+      table.batchCallback(Collections.emptyList(), new Object[1], mockCallBack);
     } catch (Exception ex) {
       actualError = ex;
     }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestModifyTable.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestModifyTable.java
@@ -15,9 +15,9 @@
  */
 package com.google.cloud.bigtable.hbase;
 
-import com.google.common.base.Function;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import javax.annotation.Nullable;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.client.Admin;

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncCheckAndMutate.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncCheckAndMutate.java
@@ -16,7 +16,6 @@
 package com.google.cloud.bigtable.hbase.async;
 
 import com.google.cloud.bigtable.hbase.AbstractTestCheckAndMutate;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -42,12 +41,7 @@ public class TestAsyncCheckAndMutate extends AbstractTestCheckAndMutate {
 
   @BeforeClass
   public static void setup() {
-    executor =
-        Executors.newCachedThreadPool(
-            new ThreadFactoryBuilder()
-                .setDaemon(true)
-                .setNameFormat("TestAsyncCheckAndMutate")
-                .build());
+    executor = Executors.newCachedThreadPool();
   }
 
   @AfterClass

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncConnection.java
@@ -15,10 +15,12 @@
  */
 package com.google.cloud.bigtable.hbase.async;
 
-import com.google.common.util.concurrent.MoreExecutors;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -33,15 +35,24 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class TestAsyncConnection extends AbstractAsyncTest {
 
-  private static final ExecutorService directExecutorService =
-      MoreExecutors.newDirectExecutorService();
+  private ExecutorService executorService;
 
   @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Before
+  public void setUp() throws Exception {
+    executorService = Executors.newCachedThreadPool();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    executorService.shutdown();
+  }
 
   @Test
   public void testAdmin() throws InterruptedException, ExecutionException {
     Assert.assertNotNull(getAsyncConnection().getAdmin());
-    Assert.assertNotNull(getAsyncConnection().getAdmin(directExecutorService));
+    Assert.assertNotNull(getAsyncConnection().getAdmin(executorService));
   }
 
   @Test
@@ -53,10 +64,10 @@ public class TestAsyncConnection extends AbstractAsyncTest {
   @Test
   public void testTable() throws InterruptedException, ExecutionException {
     Assert.assertNotNull(
-        getAsyncConnection().getTable(sharedTestEnv.getDefaultTableName(), directExecutorService));
+        getAsyncConnection().getTable(sharedTestEnv.getDefaultTableName(), executorService));
     Assert.assertNotNull(
         getAsyncConnection()
-            .getTableBuilder(sharedTestEnv.getDefaultTableName(), directExecutorService)
+            .getTableBuilder(sharedTestEnv.getDefaultTableName(), executorService)
             .build());
   }
 
@@ -70,7 +81,7 @@ public class TestAsyncConnection extends AbstractAsyncTest {
             .build());
     Assert.assertNotNull(
         getAsyncConnection()
-            .getBufferedMutatorBuilder(sharedTestEnv.getDefaultTableName(), directExecutorService)
+            .getBufferedMutatorBuilder(sharedTestEnv.getDefaultTableName(), executorService)
             .build());
   }
 

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncScan.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncScan.java
@@ -18,10 +18,10 @@ package com.google.cloud.bigtable.hbase.async;
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
 
 import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
-import com.google.common.util.concurrent.SettableFuture;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.client.AsyncTable;
@@ -104,7 +104,7 @@ public class TestAsyncScan extends AbstractAsyncTest {
     Scan scan = new Scan();
     scan.setRowPrefixFilter(Bytes.toBytes(prefix));
 
-    SettableFuture<Integer> lock = SettableFuture.create();
+    CompletableFuture<Integer> lock = new CompletableFuture<>();
     getDefaultAsyncTable()
         .scan(
             scan,
@@ -118,19 +118,20 @@ public class TestAsyncScan extends AbstractAsyncTest {
                   count++;
                   return true;
                 } catch (Exception e) {
-                  lock.setException(e);
+                  lock.completeExceptionally(e);
                   return false;
                 }
               }
 
               @Override
               public void onError(Throwable e) {
-                lock.setException(e);
+                lock.completeExceptionally(e);
+                ;
               }
 
               @Override
               public void onComplete() {
-                lock.set(count);
+                lock.complete(count);
               }
             });
 

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestModifyTableAsync.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestModifyTableAsync.java
@@ -16,10 +16,10 @@
 package com.google.cloud.bigtable.hbase.async;
 
 import com.google.cloud.bigtable.hbase.AbstractTestModifyTable;
-import com.google.common.base.Function;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import javax.annotation.Nullable;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.client.AsyncAdmin;


### PR DESCRIPTION
Since hbase-shaded-client shades guava and hbase-client doesnt its currently impossible to use the integration tests with both. This change will pave the way for mixing and matching bigtable-hbase & hbase-client flavors. 

Change-Id: I4836a5627a5e8673577db4051899a47e922cc7e6

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable-hbase/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
