### PR TITLE
chore: try to fix versions for next release

### DIFF
--- a/versions.txt
+++ b/versions.txt
@@ -2,5 +2,5 @@
 # module:released-version:current-version
 
 bigtable-client-parent:2.13.0:2.14.0-SNAPSHOT
-bigtable-hbase-replication:1.11.2:1.13.0-SNAPSHOT
-bigtable-hbase-mirroring:0.7.2:0.9.0-SNAPSHOT
+bigtable-hbase-replication:1.12.0:1.13.0-SNAPSHOT
+bigtable-hbase-mirroring:0.8.0:0.9.0-SNAPSHOT


### PR DESCRIPTION
We want the next release to be:
main artifacts: 2.14.0
mirroring: 0.9.0
replication: 1.13.0

However the mirroring & replication versions are out of sync. This pr tries to align them by faking the last release version to be n - 0.1.0

Change-Id: I4d3df89d4dc2b0a12f345664162298880cf0adf7

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable-hbase/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
