### PR TITLE
fix: Remove duplicated calls to proto oneof builders

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminClientWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminClientWrapper.java
@@ -236,7 +236,6 @@ public class BigtableTableAdminClientWrapper implements IBigtableTableAdminClien
     DropRowRangeRequest protoRequest =
         DropRowRangeRequest.newBuilder()
             .setName(instanceName.toTableNameStr(tableId))
-            .setDeleteAllDataFromTable(false)
             .setRowKeyPrefix(rowKeyPrefix)
             .build();
     delegate.dropRowRange(protoRequest);
@@ -254,7 +253,6 @@ public class BigtableTableAdminClientWrapper implements IBigtableTableAdminClien
     DropRowRangeRequest protoRequest =
         DropRowRangeRequest.newBuilder()
             .setName(instanceName.toTableNameStr(tableId))
-            .setDeleteAllDataFromTable(false)
             .setRowKeyPrefix(rowKeyPrefix)
             .build();
     return ApiFutureUtil.transformAndAdapt(


### PR DESCRIPTION
This change removes duplicated calls to proto oneof builders where a previously set value is overwritten in the fluent chain.

Fixes #4359 ☕️