### PR TITLE
fix: set buffer size to 8MB for export jobs to reduce ram usage

### DIFF
--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/sequencefiles/ExportJob.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/sequencefiles/ExportJob.java
@@ -23,6 +23,7 @@ import java.io.Serializable;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
+import org.apache.beam.sdk.extensions.gcp.options.GcsOptions;
 import org.apache.beam.sdk.io.DefaultFilenamePolicy;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.Read;
@@ -95,7 +96,10 @@ import org.apache.hadoop.io.serializer.WritableSerialization;
  */
 @InternalExtensionOnly
 public class ExportJob {
-  public interface ExportOptions extends GcpOptions {
+
+  static final int GCS_UPLOAD_BUFFER_SIZE_BYTES_DEFAULT = 8388608;
+
+  public interface ExportOptions extends GcpOptions, GcsOptions {
     @Description("This Bigtable App Profile id.")
     ValueProvider<String> getBigtableAppProfileId();
 
@@ -182,6 +186,9 @@ public class ExportJob {
 
     ExportOptions opts =
         PipelineOptionsFactory.fromArgs(args).withValidation().as(ExportOptions.class);
+    if (opts.getGcsUploadBufferSizeBytes() == null) {
+      opts.setGcsUploadBufferSizeBytes(GCS_UPLOAD_BUFFER_SIZE_BYTES_DEFAULT);
+    }
 
     Pipeline pipeline = buildPipeline(opts);
 


### PR DESCRIPTION
Beam defaults to 1MB for streaming jobs to address memory usage, but doesn't for batch jobs. In addition, the {Spark,Flink}JobServerDriver do the same thing, setting it to 1MB:

https://github.com/apache/beam/pull/9647

In some internal benchmarks, 8M has been shown to not incur a cost on the throughput per worker that 1M has for the export job, so we are opting to set it to 8M.

Fixes #4365 ☕️
