### PR TITLE
fix: align the handling of regular expressions between hbase & bigtable

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestFilters.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestFilters.java
@@ -2341,21 +2341,17 @@ public abstract class AbstractTestFilters extends AbstractTest {
     List<Filter> anchoredRegex =
         Arrays.asList(
             new RowFilter(CompareOp.EQUAL, new RegexStringComparator("^" + key)),
-            new RowFilter(CompareOp.EQUAL, new RegexStringComparator( key + "$")),
-            new RowFilter(CompareOp.EQUAL, new RegexStringComparator( "^" + key + "$")),
-
+            new RowFilter(CompareOp.EQUAL, new RegexStringComparator(key + "$")),
+            new RowFilter(CompareOp.EQUAL, new RegexStringComparator("^" + key + "$")),
             new FamilyFilter(CompareOp.EQUAL, new RegexStringComparator("^" + family)),
             new FamilyFilter(CompareOp.EQUAL, new RegexStringComparator(family + "$")),
             new FamilyFilter(CompareOp.EQUAL, new RegexStringComparator("^" + family + "$")),
-
             new QualifierFilter(CompareOp.EQUAL, new RegexStringComparator("^" + qualifier + "$")),
             new QualifierFilter(CompareOp.EQUAL, new RegexStringComparator("^" + qualifier)),
             new QualifierFilter(CompareOp.EQUAL, new RegexStringComparator("^" + qualifier)),
-
             new ValueFilter(CompareOp.EQUAL, new RegexStringComparator("^" + value + "$")),
             new ValueFilter(CompareOp.EQUAL, new RegexStringComparator("^" + value)),
-            new ValueFilter(CompareOp.EQUAL, new RegexStringComparator(value + "$"))
-        );
+            new ValueFilter(CompareOp.EQUAL, new RegexStringComparator(value + "$")));
 
     for (Filter filter : anchoredRegex) {
       System.out.println("Testing anchored: " + filter);
@@ -2371,26 +2367,24 @@ public abstract class AbstractTestFilters extends AbstractTest {
     List<Filter> anchoredPartialRegex =
         Arrays.asList(
             new RowFilter(CompareOp.EQUAL, new RegexStringComparator("^" + keyRoot)),
-            new RowFilter(CompareOp.EQUAL, new RegexStringComparator( keyRoot + "$")),
-            new RowFilter(CompareOp.EQUAL, new RegexStringComparator( "^" + keyRoot + "$")),
-
+            new RowFilter(CompareOp.EQUAL, new RegexStringComparator(keyRoot + "$")),
+            new RowFilter(CompareOp.EQUAL, new RegexStringComparator("^" + keyRoot + "$")),
             new FamilyFilter(CompareOp.EQUAL, new RegexStringComparator("^" + familyRoot)),
             new FamilyFilter(CompareOp.EQUAL, new RegexStringComparator(familyRoot + " $")),
             new FamilyFilter(CompareOp.EQUAL, new RegexStringComparator("^" + familyRoot + " $")),
-
-            new QualifierFilter(CompareOp.EQUAL, new RegexStringComparator("^" + qualifierRoot + "$")),
+            new QualifierFilter(
+                CompareOp.EQUAL, new RegexStringComparator("^" + qualifierRoot + "$")),
             new QualifierFilter(CompareOp.EQUAL, new RegexStringComparator("^" + qualifierRoot)),
             new QualifierFilter(CompareOp.EQUAL, new RegexStringComparator("^" + qualifierRoot)),
-
             new ValueFilter(CompareOp.EQUAL, new RegexStringComparator("^" + valueRoot + "$")),
             new ValueFilter(CompareOp.EQUAL, new RegexStringComparator("^" + valueRoot)),
-            new ValueFilter(CompareOp.EQUAL, new RegexStringComparator(valueRoot + "$"))
-        );
+            new ValueFilter(CompareOp.EQUAL, new RegexStringComparator(valueRoot + "$")));
 
     for (Filter filter : anchoredPartialRegex) {
       try (ResultScanner scanner =
           table.getScanner(new Scan().withStartRow(key.getBytes()).setLimit(1).setFilter(filter))) {
-        assertWithMessage("Filter with anchored partial regex: " + filter + " yielded unpexpected results")
+        assertWithMessage(
+                "Filter with anchored partial regex: " + filter + " yielded unpexpected results")
             .that(scanner)
             .isEmpty();
       }

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestFilters.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestFilters.java
@@ -2365,16 +2365,16 @@ public abstract class AbstractTestFilters extends AbstractTest {
     // Make sure that explicitly anchored partial regexes dont overmatch
     List<Filter> anchoredPartialRegex =
         Arrays.asList(
+            new RowFilter(CompareOp.EQUAL, new RegexStringComparator("^" + keyRoot + "$")),
             new RowFilter(CompareOp.EQUAL, new RegexStringComparator("^" + keyRoot)),
             new RowFilter(CompareOp.EQUAL, new RegexStringComparator(keyRoot + "$")),
-            new RowFilter(CompareOp.EQUAL, new RegexStringComparator("^" + keyRoot + "$")),
+            new FamilyFilter(CompareOp.EQUAL, new RegexStringComparator("^" + familyRoot + " $")),
             new FamilyFilter(CompareOp.EQUAL, new RegexStringComparator("^" + familyRoot)),
             new FamilyFilter(CompareOp.EQUAL, new RegexStringComparator(familyRoot + " $")),
-            new FamilyFilter(CompareOp.EQUAL, new RegexStringComparator("^" + familyRoot + " $")),
             new QualifierFilter(
                 CompareOp.EQUAL, new RegexStringComparator("^" + qualifierRoot + "$")),
             new QualifierFilter(CompareOp.EQUAL, new RegexStringComparator("^" + qualifierRoot)),
-            new QualifierFilter(CompareOp.EQUAL, new RegexStringComparator("^" + qualifierRoot)),
+            new QualifierFilter(CompareOp.EQUAL, new RegexStringComparator(qualifierRoot + "$")),
             new ValueFilter(CompareOp.EQUAL, new RegexStringComparator("^" + valueRoot + "$")),
             new ValueFilter(CompareOp.EQUAL, new RegexStringComparator("^" + valueRoot)),
             new ValueFilter(CompareOp.EQUAL, new RegexStringComparator(valueRoot + "$")));

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestFilters.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestFilters.java
@@ -2354,7 +2354,6 @@ public abstract class AbstractTestFilters extends AbstractTest {
             new ValueFilter(CompareOp.EQUAL, new RegexStringComparator(value + "$")));
 
     for (Filter filter : anchoredRegex) {
-      System.out.println("Testing anchored: " + filter);
       try (ResultScanner scanner =
           table.getScanner(new Scan().withStartRow(key.getBytes()).setLimit(1).setFilter(filter))) {
         assertWithMessage("Filter with full regex: " + filter + " yielded no results")

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FamilyFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FamilyFilterAdapter.java
@@ -55,6 +55,9 @@ public class FamilyFilterAdapter extends TypedFilterAdapterBase<FamilyFilter> {
       throw new IllegalStateException("Comparator cannot be null");
     } else if (comparator instanceof RegexStringComparator) {
       family = Bytes.toString(comparator.getValue());
+      // HBase regex matching is unanchored, while Bigtable requires a full string match
+      // To align the two, surround the user regex with wildcards
+      family = ".*" + family + ".*";
     } else if (comparator instanceof BinaryComparator) {
       ByteString quotedRegularExpression =
           ReaderExpressionHelper.quoteRegularExpression(comparator.getValue());

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FamilyFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/FamilyFilterAdapter.java
@@ -57,7 +57,9 @@ public class FamilyFilterAdapter extends TypedFilterAdapterBase<FamilyFilter> {
       family = Bytes.toString(comparator.getValue());
       // HBase regex matching is unanchored, while Bigtable requires a full string match
       // To align the two, surround the user regex with wildcards
-      family = ".*" + family + ".*";
+      if (!family.isEmpty()) {
+        family = ".*" + family + ".*";
+      }
     } else if (comparator instanceof BinaryComparator) {
       ByteString quotedRegularExpression =
           ReaderExpressionHelper.quoteRegularExpression(comparator.getValue());

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/QualifierFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/QualifierFilterAdapter.java
@@ -115,7 +115,9 @@ public class QualifierFilterAdapter extends TypedFilterAdapterBase<QualifierFilt
     String pattern = FilterAdapterHelper.extractRegexPattern(comparator);
     // HBase regex matching is unanchored, while Bigtable requires a full string match
     // To align the two, surround the user regex with wildcards
-    pattern = "\\C*" + pattern + "\\C*";
+    if (!pattern.isEmpty()) {
+      pattern = "\\C*" + pattern + "\\C*";
+    }
     switch (compareOp) {
       case EQUAL:
         return FILTERS.qualifier().regex(pattern);

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/QualifierFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/QualifierFilterAdapter.java
@@ -113,6 +113,9 @@ public class QualifierFilterAdapter extends TypedFilterAdapterBase<QualifierFilt
   private static Filter adaptRegexStringComparator(
       CompareOp compareOp, RegexStringComparator comparator) {
     String pattern = FilterAdapterHelper.extractRegexPattern(comparator);
+    // HBase regex matching is unanchored, while Bigtable requires a full string match
+    // To align the two, surround the user regex with wildcards
+    pattern = "\\C*" + pattern + "\\C*";
     switch (compareOp) {
       case EQUAL:
         return FILTERS.qualifier().regex(pattern);

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/RowFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/RowFilterAdapter.java
@@ -58,7 +58,12 @@ public class RowFilterAdapter
     if (comparator == null) {
       throw new IllegalStateException("Comparator cannot be null");
     } else if (comparator instanceof RegexStringComparator) {
-      regexValue = ByteString.copyFrom(comparator.getValue());
+      // HBase regex matching is unanchored, while Bigtable requires a full string match
+      // To align the two, surround the user regex with wildcards
+      regexValue =
+        ByteString.copyFromUtf8("\\C*")
+                .concat(ByteString.copyFrom(comparator.getValue()))
+            .concat(ByteString.copyFromUtf8("\\C*"));
     } else if (comparator instanceof BinaryComparator) {
       regexValue = ReaderExpressionHelper.quoteRegularExpression(comparator.getValue());
     } else {

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/RowFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/RowFilterAdapter.java
@@ -60,10 +60,15 @@ public class RowFilterAdapter
     } else if (comparator instanceof RegexStringComparator) {
       // HBase regex matching is unanchored, while Bigtable requires a full string match
       // To align the two, surround the user regex with wildcards
-      regexValue =
-        ByteString.copyFromUtf8("\\C*")
+      if (comparator.getValue().length > 0) {
+        regexValue =
+            ByteString.copyFromUtf8("\\C*")
                 .concat(ByteString.copyFrom(comparator.getValue()))
-            .concat(ByteString.copyFromUtf8("\\C*"));
+                .concat(ByteString.copyFromUtf8("\\C*"));
+      } else {
+        regexValue = ByteString.EMPTY;
+      }
+
     } else if (comparator instanceof BinaryComparator) {
       regexValue = ReaderExpressionHelper.quoteRegularExpression(comparator.getValue());
     } else {

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ValueFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ValueFilterAdapter.java
@@ -118,7 +118,10 @@ public class ValueFilterAdapter extends TypedFilterAdapterBase<ValueFilter> {
       case EQUAL:
         // HBase regex matching is unanchored, while Bigtable requires a full string match
         // To align the two, surround the user regex with wildcards
-        return FILTERS.value().regex("\\C*" + pattern + "\\C*");
+        if (!pattern.isEmpty()) {
+          pattern = "\\C*" + pattern + "\\C*";
+        }
+        return FILTERS.value().regex(pattern);
         // No-ops are always filtered out.
         // See:
         // https://github.com/apache/hbase/blob/master/hbase-client/src/main/java/org/apache/hadoop/hbase/filter/ColumnValueFilter.java#L127-L138

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ValueFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/ValueFilterAdapter.java
@@ -116,7 +116,9 @@ public class ValueFilterAdapter extends TypedFilterAdapterBase<ValueFilter> {
     String pattern = FilterAdapterHelper.extractRegexPattern(comparator);
     switch (compareOp) {
       case EQUAL:
-        return FILTERS.value().regex(pattern);
+        // HBase regex matching is unanchored, while Bigtable requires a full string match
+        // To align the two, surround the user regex with wildcards
+        return FILTERS.value().regex("\\C*" + pattern + "\\C*");
         // No-ops are always filtered out.
         // See:
         // https://github.com/apache/hbase/blob/master/hbase-client/src/main/java/org/apache/hadoop/hbase/filter/ColumnValueFilter.java#L127-L138

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFamilyFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestFamilyFilterAdapter.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.bigtable.v2.RowFilter;
 import com.google.cloud.bigtable.hbase.adapters.read.ReaderExpressionHelper;
 import com.google.protobuf.ByteString;
@@ -45,13 +47,16 @@ public class TestFamilyFilterAdapter {
 
   @Test
   public void testAdapt_RegexAndEquals() throws IOException {
-    String regexp = "^.*hello world.*$";
+    String regexp = "^hello world[?!]$";
     RegexStringComparator comparator = new RegexStringComparator(regexp);
     org.apache.hadoop.hbase.filter.RowFilter filter =
         new org.apache.hadoop.hbase.filter.RowFilter(CompareFilter.CompareOp.EQUAL, comparator);
-    Assert.assertEquals(
-        RowFilter.newBuilder().setRowKeyRegexFilter(ByteString.copyFrom(regexp.getBytes())).build(),
-        adapter.adapt(context, filter).toProto());
+    assertThat(adapter.adapt(context, filter).toProto())
+        .isEqualTo(
+            RowFilter.newBuilder()
+                // user regex needs to be wrapped in wildcards to
+                .setRowKeyRegexFilter(ByteString.copyFrom(("\\C*" + regexp + "\\C*").getBytes()))
+                .build());
   }
 
   @Test
@@ -74,9 +79,11 @@ public class TestFamilyFilterAdapter {
     RegexStringComparator comparator = new RegexStringComparator(regexp);
     org.apache.hadoop.hbase.filter.RowFilter filter =
         new org.apache.hadoop.hbase.filter.RowFilter(CompareFilter.CompareOp.EQUAL, comparator);
-    Assert.assertEquals(
-        RowFilter.newBuilder().setRowKeyRegexFilter(ByteString.copyFrom(regexp.getBytes())).build(),
-        adapter.adapt(context, filter).toProto());
+    assertThat(adapter.adapt(context, filter).toProto())
+        .isEqualTo(
+            RowFilter.newBuilder()
+                .setRowKeyRegexFilter(ByteString.copyFrom(regexp.getBytes()))
+                .build());
   }
 
   @Test

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestQualifierFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestQualifierFilterAdapter.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
 
 import com.google.cloud.bigtable.data.v2.models.Filters;
+import com.google.common.truth.Truth;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
 import org.apache.hadoop.hbase.client.Scan;
@@ -28,7 +29,6 @@ import org.apache.hadoop.hbase.filter.CompareFilter.CompareOp;
 import org.apache.hadoop.hbase.filter.QualifierFilter;
 import org.apache.hadoop.hbase.filter.RegexStringComparator;
 import org.apache.hadoop.hbase.util.Bytes;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -51,7 +51,7 @@ public class TestQualifierFilterAdapter {
       throws IOException {
     QualifierFilter filter = new QualifierFilter(op, comparable);
     Filters.Filter actualFilter = adapter.adapt(scanWithOnFamilyScanContext, filter);
-    Assert.assertEquals(expectedFilter.toProto(), actualFilter.toProto());
+    Truth.assertThat(actualFilter.toProto()).isEqualTo(expectedFilter.toProto());
   }
 
   @Test
@@ -112,6 +112,6 @@ public class TestQualifierFilterAdapter {
     assertAdaptedForm(
         new RegexStringComparator(pattern),
         CompareOp.EQUAL,
-        FILTERS.qualifier().regex(ByteString.copyFromUtf8(pattern)));
+        FILTERS.qualifier().regex(ByteString.copyFromUtf8("\\C*" + pattern + "\\C*")));
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestRowFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestRowFilterAdapter.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
+import static com.google.common.truth.Truth.assertThat;
 
 import com.google.cloud.bigtable.hbase.adapters.read.ReaderExpressionHelper;
 import com.google.protobuf.ByteString;
@@ -50,8 +51,8 @@ public class TestRowFilterAdapter {
     RegexStringComparator comparator = new RegexStringComparator(regexp);
     org.apache.hadoop.hbase.filter.RowFilter filter =
         new org.apache.hadoop.hbase.filter.RowFilter(CompareFilter.CompareOp.EQUAL, comparator);
-    Assert.assertEquals(
-        FILTERS.key().regex(regexp).toProto(), adapter.adapt(context, filter).toProto());
+    assertThat(adapter.adapt(context, filter).toProto())
+        .isEqualTo(FILTERS.key().regex("\\C*" + regexp + "\\C*").toProto());
   }
 
   @Test

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestValueFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestValueFilterAdapter.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
+import static com.google.common.truth.Truth.assertThat;
 
 import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.cloud.bigtable.hbase.adapters.read.ReaderExpressionHelper;
@@ -29,7 +30,6 @@ import org.apache.hadoop.hbase.filter.CompareFilter.CompareOp;
 import org.apache.hadoop.hbase.filter.RegexStringComparator;
 import org.apache.hadoop.hbase.filter.ValueFilter;
 import org.apache.hadoop.hbase.util.Bytes;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -110,7 +110,9 @@ public class TestValueFilterAdapter {
   public void testRegexValueFilter() throws IOException {
     String pattern = "Foo\\d+";
     assertAdaptedForm(
-        new RegexStringComparator(pattern), CompareOp.EQUAL, FILTERS.value().regex(pattern));
+        new RegexStringComparator(pattern),
+        CompareOp.EQUAL,
+        FILTERS.value().regex("\\C*" + pattern + "\\C*"));
   }
 
   private void assertAdaptedForm(
@@ -118,6 +120,6 @@ public class TestValueFilterAdapter {
       throws IOException {
     ValueFilter filter = new ValueFilter(op, comparable);
     Filters.Filter actualFilter = adapter.adapt(emptyScanContext, filter);
-    Assert.assertEquals(expectedFilter.toProto(), actualFilter.toProto());
+    assertThat(actualFilter.toProto()).isEqualTo(expectedFilter.toProto());
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestGetAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestGetAdapter.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.hbase.adapters.read;
 
 import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
+import static com.google.common.truth.Truth.assertThat;
 
 import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.cloud.bigtable.data.v2.models.Filters;
@@ -182,12 +183,12 @@ public class TestGetAdapter {
 
     Filters.Filter actualFilter = getAdapter.buildFilter(get);
 
-    Assert.assertEquals(
-        FILTERS
-            .chain()
-            .filter(FILTERS.limit().cellsPerColumn(5))
-            .filter(FILTERS.family().regex("a"))
-            .toProto(),
-        actualFilter.toProto());
+    assertThat(actualFilter.toProto())
+        .isEqualTo(
+            FILTERS
+                .chain()
+                .filter(FILTERS.limit().cellsPerColumn(5))
+                .filter(FILTERS.family().regex(".*a.*"))
+                .toProto());
   }
 }


### PR DESCRIPTION
When using RegexStringComparator, HBase will try to match a substring of the target. While bigtable requires a full match. For example, given the target `"abcd"`, in HBase the regex `"[bc]*"` will match the string. However Bigtable will not. Bigtable will require the regex to also match `a` & `d`.

This PR addresses this discrepancy by surrounding the user provided regex with a zero or more wildcards. ie transform `"[bc]*"`  into `".*[bc]*.*"`

Change-Id: I7404bddd4c9c9d907d57225d99f7062c4407fc35

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable-hbase/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
