### PR TITLE
deps: upgrade java-bigtable to 2.45.0

### DIFF
--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-shaded/pom.xml
@@ -164,6 +164,22 @@ limitations under the License.
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <!-- TODO: remove this next release -->
+        <!-- Temporarily disable requireUpperBoundDeps
+            rule to downgrade bad grpc release:
+             https://github.com/grpc/grpc-java/releases/tag/v1.68.0-->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <configuration>
+            <rulesToSkip>requireUpperBoundDeps</rulesToSkip>
+            <failIfNoRules>false</failIfNoRules>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-shaded/pom.xml
@@ -155,6 +155,23 @@ limitations under the License.
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <!-- TODO: remove this next release -->
+        <!-- Temporarily disable requireUpperBoundDeps
+            rule to downgrade bad grpc release:
+             https://github.com/grpc/grpc-java/releases/tag/v1.68.0-->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <configuration>
+            <rulesToSkip>requireUpperBoundDeps</rulesToSkip>
+            <failIfNoRules>false</failIfNoRules>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
     <plugins>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@ limitations under the License.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- core dependency versions -->
-    <bigtable.version>2.44.1</bigtable.version>
+    <bigtable.version>2.45.0</bigtable.version>
     <google-cloud-bigtable-emulator.version>0.175.0</google-cloud-bigtable-emulator.version>
     <bigtable-metrics-api.version>1.29.2</bigtable-metrics-api.version>
     <!-- Optional dep for bigtable-metrics-api used for tests -->


### PR DESCRIPTION
Upgrade to veneer to workaround a broken grpc-java release. This has to temporarily disable enforcer checks to workaround the UpperBounds rule