### PR TITLE
deps: upgrade java-bigtable to 2.49.0 and fix tests

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -51,7 +51,7 @@ javadoc)
     ;;
 integration)
 # clean needed when running more than one IT profile
-    mvn --no-transfer-progress clean verify -B ${INTEGRATION_TEST_ARGS} -Penable-integration-tests -DtrimStackTrace=false -Dclirr.skip=true -fae
+    mvn --no-transfer-progress clean verify -B ${INTEGRATION_TEST_ARGS} -Penable-integration-tests -DtrimStackTrace=false -Dclirr.skip=true -DskipUnitTests=true
     RETURN_CODE=$?
     ;;
 integration-migration)
@@ -60,7 +60,7 @@ integration-migration)
   RETURN_CODE=$?
   ;;
 clirr)
-    mvn --no-transfer-progress install -B -Denforcer.skip=true clirr:check
+    mvn --no-transfer-progress install -B -Denforcer.skip=true -DskipTests clirr:check
     RETURN_CODE=$?
     ;;
 *)

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BigtableHBaseSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BigtableHBaseSettings.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.hbase.wrappers;
 
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.APP_PROFILE_ID_KEY;
 import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.INSTANCE_ID_KEY;
 import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.PROJECT_ID_KEY;
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -38,6 +39,7 @@ public abstract class BigtableHBaseSettings {
   private final Configuration configuration;
   private final String projectId;
   private final String instanceId;
+  private final String appProfileId;
   private final int ttlSecondsForBackup;
 
   @VisibleForTesting
@@ -47,7 +49,7 @@ public abstract class BigtableHBaseSettings {
       "bulk.mutation.close.timeout.milliseconds";
 
   // Must be non-negative. Set to 0 to disable timeout.
-  private final long bulkMutationCloseTimeoutMilliseconds;
+  private final long bulkMutationCloseTimeoutMilliseconds;;
 
   public static BigtableHBaseSettings create(Configuration configuration) throws IOException {
     return BigtableHBaseVeneerSettings.create(configuration);
@@ -57,6 +59,8 @@ public abstract class BigtableHBaseSettings {
     this.configuration = new Configuration(configuration);
     this.projectId = getRequiredValue(PROJECT_ID_KEY, "Project ID");
     this.instanceId = getRequiredValue(INSTANCE_ID_KEY, "Instance ID");
+    this.appProfileId = configuration.get(APP_PROFILE_ID_KEY);
+
     this.ttlSecondsForBackup =
         configuration.getInt(
             BigtableOptionsFactory.BIGTABLE_SNAPSHOT_DEFAULT_TTL_SECS_KEY,
@@ -77,6 +81,10 @@ public abstract class BigtableHBaseSettings {
 
   public String getInstanceId() {
     return instanceId;
+  }
+
+  public String getAppProfileId() {
+    return appProfileId;
   }
 
   public int getTtlSecondsForBackup() {

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BulkMutationVeneerApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BulkMutationVeneerApi.java
@@ -83,6 +83,7 @@ public class BulkMutationVeneerApi implements BulkMutationWrapper {
     } catch (InterruptedException | ExecutionException e) {
       throw new IOException("Could not close the bulk mutation Batcher", e);
     } catch (TimeoutException e) {
+      bulkMutateBatcher.cancelOutstanding();
       throw new IOException("Cloud not close the bulk mutation Batcher, timed out in close()", e);
     }
   }

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableConnection.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-hadoop/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableConnection.java
@@ -103,6 +103,7 @@ public class TestBigtableConnection {
     public void pingAndWarm(
         PingAndWarmRequest request, StreamObserver<PingAndWarmResponse> responseObserver) {
       responseObserver.onNext(PingAndWarmResponse.getDefaultInstance());
+      responseObserver.onCompleted();
     }
   }
 }

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/src/main/java/com/google/cloud/bigtable/mapreduce/validation/BigtableSyncTableJob.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/src/main/java/com/google/cloud/bigtable/mapreduce/validation/BigtableSyncTableJob.java
@@ -16,7 +16,9 @@
 package com.google.cloud.bigtable.mapreduce.validation;
 
 import com.google.cloud.bigtable.hbase.BigtableConfiguration;
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
+import java.io.PrintStream;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -51,8 +53,9 @@ import org.apache.hadoop.util.ToolRunner;
  * hashes, cell-level comparison is performed.
  */
 public class BigtableSyncTableJob extends SyncTable {
-
   private static final Log LOG = LogFactory.getLog(BigtableSyncTableJob.class);
+  @VisibleForTesting PrintStream SOUT = System.out;
+  @VisibleForTesting PrintStream SERR = System.err;
 
   public static final String SOURCE_BT_PROJECTID_CONF_KEY = "sync.table.source.bt.projectid";
   public static final String SOURCE_BT_INSTANCE_CONF_KEY = "sync.table.source.bt.instance";
@@ -352,66 +355,66 @@ public class BigtableSyncTableJob extends SyncTable {
     return true;
   }
 
-  public static void printUsage(final String errorMsg, String[] args) {
+  public void printUsage(final String errorMsg, String[] args) {
     if (errorMsg != null && errorMsg.length() > 0) {
-      System.err.println("ERROR: " + errorMsg);
+      SERR.println("ERROR: " + errorMsg);
     }
 
     if (args != null) {
-      System.err.print("Input provided: ");
+      SERR.print("Input provided: ");
       for (int i = 0; i < args.length; i++) {
         if (i != 0) {
-          System.err.print(" ");
+          SERR.print(" ");
         }
-        System.err.print(args[i]);
+        SERR.print(args[i]);
       }
-      System.err.println();
+      SERR.println();
     }
 
-    System.err.println("Usage: SyncTable [options] <sourcehashdir> <sourcetable> <targettable>");
-    System.err.println();
-    System.err.println("Options:");
+    SERR.println("Usage: SyncTable [options] <sourcehashdir> <sourcetable> <targettable>");
+    SERR.println();
+    SERR.println("Options:");
 
-    System.err.println(" Source Configuration:");
-    System.err.println("    sourcezkcluster   ZK cluster key of the source table");
-    System.err.println("                      (defaults to cluster in classpath's config)");
-    System.err.println(" Or Source Configuration:");
-    System.err.println("    sourcebigtableproject  Bigtable project id of the source table");
-    System.err.println("                      (defaults to cluster in classpath's config)");
-    System.err.println("    sourcebigtableinstance  Bigtable instance id of the source table");
-    System.err.println("                      (defaults to cluster in classpath's config)");
-    System.err.println("    sourcebigtableappprofile  (optional) Bigtable app profile");
-    System.err.println(" Target Configuration:");
-    System.err.println("    targetzkcluster  ZK cluster key of the target table");
-    System.err.println("                      (defaults to cluster in classpath's config)");
-    System.err.println(" Or Target Configuration:");
-    System.err.println("    targetbigtableproject  Bigtable project id of the target table");
-    System.err.println("                      (defaults to cluster in classpath's config)");
-    System.err.println("    targetbigtableinstance  Bigtable instance id of the target table");
-    System.err.println("                      (defaults to cluster in classpath's config)");
-    System.err.println("    targetbigtableappprofile  (optional) Bigtable app profile");
-    System.err.println();
-    System.err.println(" dryrun           if true, output counters but no writes");
-    System.err.println("                  (defaults to true)");
-    System.err.println(" doDeletes        if false, does not perform deletes");
-    System.err.println("                  (defaults to true)");
-    System.err.println(" doPuts           if false, does not perform puts");
-    System.err.println("                  (defaults to true)");
-    System.err.println(" ignoreTimestamps if true, ignores cells timestamps while comparing ");
-    System.err.println("                  cell values. Any missing cell on target then gets");
-    System.err.println("                  added with current time as timestamp ");
-    System.err.println("                  (defaults to false)");
-    System.err.println();
-    System.err.println("Args:");
-    System.err.println(" sourcehashdir    path to HashTable output dir for source table");
-    System.err.println("                  (see org.apache.hadoop.hbase.mapreduce.HashTable)");
-    System.err.println(" sourcetable      Name of the source table to sync from");
-    System.err.println(" targettable      Name of the target table to sync to");
-    System.err.println();
-    System.err.println("Examples:");
-    System.err.println(" For SyncTable validation of tableA from a remote source cluster");
-    System.err.println(" to a local target cluster:");
-    System.err.println(
+    SERR.println(" Source Configuration:");
+    SERR.println("    sourcezkcluster   ZK cluster key of the source table");
+    SERR.println("                      (defaults to cluster in classpath's config)");
+    SERR.println(" Or Source Configuration:");
+    SERR.println("    sourcebigtableproject  Bigtable project id of the source table");
+    SERR.println("                      (defaults to cluster in classpath's config)");
+    SERR.println("    sourcebigtableinstance  Bigtable instance id of the source table");
+    SERR.println("                      (defaults to cluster in classpath's config)");
+    SERR.println("    sourcebigtableappprofile  (optional) Bigtable app profile");
+    SERR.println(" Target Configuration:");
+    SERR.println("    targetzkcluster  ZK cluster key of the target table");
+    SERR.println("                      (defaults to cluster in classpath's config)");
+    SERR.println(" Or Target Configuration:");
+    SERR.println("    targetbigtableproject  Bigtable project id of the target table");
+    SERR.println("                      (defaults to cluster in classpath's config)");
+    SERR.println("    targetbigtableinstance  Bigtable instance id of the target table");
+    SERR.println("                      (defaults to cluster in classpath's config)");
+    SERR.println("    targetbigtableappprofile  (optional) Bigtable app profile");
+    SERR.println();
+    SERR.println(" dryrun           if true, output counters but no writes");
+    SERR.println("                  (defaults to true)");
+    SERR.println(" doDeletes        if false, does not perform deletes");
+    SERR.println("                  (defaults to true)");
+    SERR.println(" doPuts           if false, does not perform puts");
+    SERR.println("                  (defaults to true)");
+    SERR.println(" ignoreTimestamps if true, ignores cells timestamps while comparing ");
+    SERR.println("                  cell values. Any missing cell on target then gets");
+    SERR.println("                  added with current time as timestamp ");
+    SERR.println("                  (defaults to false)");
+    SERR.println();
+    SERR.println("Args:");
+    SERR.println(" sourcehashdir    path to HashTable output dir for source table");
+    SERR.println("                  (see org.apache.hadoop.hbase.mapreduce.HashTable)");
+    SERR.println(" sourcetable      Name of the source table to sync from");
+    SERR.println(" targettable      Name of the target table to sync to");
+    SERR.println();
+    SERR.println("Examples:");
+    SERR.println(" For SyncTable validation of tableA from a remote source cluster");
+    SERR.println(" to a local target cluster:");
+    SERR.println(
         " $ bin/hbase "
             + "com.google.cloud.bigtable.mapreduce.validation.SyncTable --targetbigtableproject=project123"
             + " --targetbigtableinstance=instance123 --sourcezkcluster=zk1.example.com,zk2.example.com,zk3.example.com:2181:/hbase"

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/src/test/java/com/google/cloud/bigtable/mapreduce/validation/TestBigtableSyncTableJob.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-mapreduce/src/test/java/com/google/cloud/bigtable/mapreduce/validation/TestBigtableSyncTableJob.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.bigtable.mapreduce.validation;
 
+import java.io.OutputStream;
+import java.io.PrintStream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.mapreduce.BigtableSyncTableAccessor;
 import org.junit.Assert;
@@ -23,6 +25,12 @@ import org.junit.Test;
 /** test driver function */
 // TODO - parameterize this to run against prod in future
 public class TestBigtableSyncTableJob {
+  private static final PrintStream NOOP_STREAM =
+      new PrintStream(
+          new OutputStream() {
+            @Override
+            public void write(int b) {}
+          });
 
   @Test
   public void testMissingArgs() {
@@ -36,7 +44,7 @@ public class TestBigtableSyncTableJob {
     };
 
     Configuration conf = new Configuration(false);
-    BigtableSyncTableJob bigtableSyncTable = new BigtableSyncTableJob(conf);
+    BigtableSyncTableJob bigtableSyncTable = createJob(conf);
     boolean isSuccess = bigtableSyncTable.doCommandLine(bigtableSyncTable, args);
 
     Assert.assertFalse(isSuccess);
@@ -55,7 +63,7 @@ public class TestBigtableSyncTableJob {
     };
 
     Configuration conf = new Configuration(false);
-    BigtableSyncTableJob bigtableSyncTable = new BigtableSyncTableJob(conf);
+    BigtableSyncTableJob bigtableSyncTable = createJob(conf);
     boolean isSuccess = bigtableSyncTable.doCommandLine(bigtableSyncTable, args);
 
     Assert.assertTrue(isSuccess);
@@ -79,7 +87,7 @@ public class TestBigtableSyncTableJob {
     };
 
     Configuration conf = new Configuration(false);
-    BigtableSyncTableJob bigtableSyncTable = new BigtableSyncTableJob(conf);
+    BigtableSyncTableJob bigtableSyncTable = createJob(conf);
     boolean isSuccess = bigtableSyncTable.doCommandLine(bigtableSyncTable, args);
 
     Assert.assertTrue(isSuccess);
@@ -101,7 +109,7 @@ public class TestBigtableSyncTableJob {
     };
 
     Configuration conf = new Configuration(false);
-    BigtableSyncTableJob bigtableSyncTable = new BigtableSyncTableJob(conf);
+    BigtableSyncTableJob bigtableSyncTable = createJob(conf);
     boolean isSuccess = bigtableSyncTable.doCommandLine(bigtableSyncTable, args);
 
     Assert.assertTrue(isSuccess);
@@ -118,7 +126,7 @@ public class TestBigtableSyncTableJob {
     };
 
     Configuration conf = new Configuration(false);
-    BigtableSyncTableJob bigtableSyncTable = new BigtableSyncTableJob(conf);
+    BigtableSyncTableJob bigtableSyncTable = createJob(conf);
     boolean isSuccess = bigtableSyncTable.doCommandLine(bigtableSyncTable, args);
 
     Assert.assertFalse(isSuccess);
@@ -138,7 +146,7 @@ public class TestBigtableSyncTableJob {
     };
 
     Configuration conf = new Configuration(false);
-    BigtableSyncTableJob bigtableSyncTable = new BigtableSyncTableJob(conf);
+    BigtableSyncTableJob bigtableSyncTable = createJob(conf);
     boolean isSuccess = bigtableSyncTable.doCommandLine(bigtableSyncTable, args);
 
     Assert.assertFalse(isSuccess);
@@ -156,7 +164,7 @@ public class TestBigtableSyncTableJob {
     };
 
     Configuration conf = new Configuration(false);
-    BigtableSyncTableJob bigtableSyncTable = new BigtableSyncTableJob(conf);
+    BigtableSyncTableJob bigtableSyncTable = createJob(conf);
     boolean isSuccess = bigtableSyncTable.doCommandLine(bigtableSyncTable, args);
 
     Assert.assertFalse(isSuccess);
@@ -174,7 +182,7 @@ public class TestBigtableSyncTableJob {
     };
 
     Configuration conf = new Configuration(false);
-    BigtableSyncTableJob bigtableSyncTable = new BigtableSyncTableJob(conf);
+    BigtableSyncTableJob bigtableSyncTable = createJob(conf);
     boolean isSuccess = bigtableSyncTable.doCommandLine(bigtableSyncTable, args);
 
     Assert.assertFalse(isSuccess);
@@ -194,7 +202,7 @@ public class TestBigtableSyncTableJob {
     };
 
     Configuration conf = new Configuration(false);
-    BigtableSyncTableJob bigtableSyncTable = new BigtableSyncTableJob(conf);
+    BigtableSyncTableJob bigtableSyncTable = createJob(conf);
     boolean isSuccess = bigtableSyncTable.doCommandLine(bigtableSyncTable, args);
 
     Assert.assertFalse(isSuccess);
@@ -212,7 +220,7 @@ public class TestBigtableSyncTableJob {
     };
 
     Configuration conf = new Configuration(false);
-    BigtableSyncTableJob bigtableSyncTable = new BigtableSyncTableJob(conf);
+    BigtableSyncTableJob bigtableSyncTable = createJob(conf);
     boolean isSuccess = bigtableSyncTable.doCommandLine(bigtableSyncTable, args);
 
     Assert.assertFalse(isSuccess);
@@ -231,10 +239,17 @@ public class TestBigtableSyncTableJob {
     };
 
     Configuration conf = new Configuration(false);
-    BigtableSyncTableJob bigtableSyncTable = new BigtableSyncTableJob(conf);
+    BigtableSyncTableJob bigtableSyncTable = createJob(conf);
     boolean isSuccess = bigtableSyncTable.doCommandLine(bigtableSyncTable, args);
 
     Assert.assertFalse(isSuccess);
+  }
+
+  private static BigtableSyncTableJob createJob(Configuration conf) {
+    BigtableSyncTableJob bigtableSyncTable = new BigtableSyncTableJob(conf);
+    bigtableSyncTable.SERR = NOOP_STREAM;
+    bigtableSyncTable.SOUT = NOOP_STREAM;
+    return bigtableSyncTable;
   }
 
   private String parseKeyValueArg(String keyValueArg) {

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase/TestRetryBehavior.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase/TestRetryBehavior.java
@@ -260,7 +260,7 @@ public class TestRetryBehavior {
           .contains(ATTEMPT_TIMEOUT.minus(Duration.ofMillis(10)));
 
       // Altogether should still be limited by the operation timeout with some jitter
-      assertThat(elapsed).isAtMost(OPERATION_TIMEOUT.plus(ATTEMPT_TIMEOUT.dividedBy(2)));
+      assertThat(elapsed).isAtMost(OPERATION_TIMEOUT.plus(ATTEMPT_TIMEOUT));
     }
   }
 

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase1_x/TestMetrics.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase1_x/TestMetrics.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.hbase1_x;
 
+import static com.google.common.truth.Truth.assertAbout;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.gax.core.NoCredentialsProvider;
@@ -32,6 +33,9 @@ import com.google.cloud.bigtable.metrics.Timer;
 import com.google.cloud.bigtable.test.helper.TestServerBuilder;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Range;
+import com.google.common.truth.FailureMetadata;
+import com.google.common.truth.LongSubject;
+import com.google.common.truth.Subject;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.BytesValue;
 import com.google.protobuf.StringValue;
@@ -44,15 +48,18 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.*;
 import org.apache.hadoop.hbase.client.Row;
 import org.apache.hadoop.hbase.shaded.org.apache.commons.lang.RandomStringUtils;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -133,46 +140,42 @@ public class TestMetrics {
    */
   @Test
   public void readRows() throws IOException, InterruptedException {
-    Table table = connection.getTable(TABLE_NAME);
-
-    Stopwatch stopwatch = Stopwatch.createStarted();
-    Result result = table.get(new Get(new byte[2]));
-    long methodInvocationLatency = stopwatch.elapsed(TimeUnit.MILLISECONDS);
+    final long methodInvocationLatency;
+    try (Table table = connection.getTable(TABLE_NAME)) {
+      Stopwatch stopwatch = Stopwatch.createStarted();
+      table.get(new Get(new byte[2]));
+      methodInvocationLatency = stopwatch.elapsed(TimeUnit.MILLISECONDS);
+    }
 
     fakeDataService.popLastRequest();
 
-    long tableGetLatencyMetric =
-        fakeMetricRegistry.results.get("google-cloud-bigtable.table.get.latency").get();
-    long retriesPerformedMetric =
-        fakeMetricRegistry
-            .results
-            .get("google-cloud-bigtable.grpc.method.ReadRow.retries.performed")
-            .get();
-    long clientOperationLatencyMetric =
-        fakeMetricRegistry
-            .results
-            .get("google-cloud-bigtable.grpc.method.ReadRow.operation.latency")
-            .get();
-    long rpcErrorsMetric =
-        fakeMetricRegistry
-            .results
-            .get("google-cloud-bigtable.grpc.errors." + fakeErrorStatus.getCode().name())
-            .get();
-    long rpcPerformedMetric =
-        fakeMetricRegistry.results.get("google-cloud-bigtable.grpc.rpc.performed").get();
+    MetricsRegistrySubject.assertThat(fakeMetricRegistry)
+        .eventuallyHasMetricThat(
+            "google-cloud-bigtable.table.get.latency", s -> s.isAtMost(methodInvocationLatency));
 
-    assertThat(retriesPerformedMetric).isEqualTo(fakeErrorCount);
-    assertThat(tableGetLatencyMetric).isAtMost(methodInvocationLatency);
-    assertThat(clientOperationLatencyMetric).isAtMost(methodInvocationLatency);
-    assertThat(rpcErrorsMetric).isEqualTo(fakeErrorCount);
-    assertThat(rpcPerformedMetric).isEqualTo(fakeErrorCount + 1);
+    MetricsRegistrySubject.assertThat(fakeMetricRegistry)
+        .eventuallyHasMetricThat(
+            "google-cloud-bigtable.grpc.method.ReadRow.retries.performed",
+            s -> s.isEqualTo(fakeErrorCount));
+
+    MetricsRegistrySubject.assertThat(fakeMetricRegistry)
+        .eventuallyHasMetricThat(
+            "google-cloud-bigtable.grpc.method.ReadRow.operation.latency",
+            s -> s.isAtMost(methodInvocationLatency));
+
+    MetricsRegistrySubject.assertThat(fakeMetricRegistry)
+        .eventuallyHasMetricThat(
+            "google-cloud-bigtable.grpc.errors." + fakeErrorStatus.getCode().name(),
+            s -> s.isEqualTo(fakeErrorCount));
+    MetricsRegistrySubject.assertThat(fakeMetricRegistry)
+        .eventuallyHasMetricThat(
+            "google-cloud-bigtable.grpc.rpc.performed", s -> s.isEqualTo(fakeErrorCount + 1));
 
     // ReadRows sleeps 40 milliseconds before returning the response. Wait for response to return
     // and verify again there should have no more active rpc
     Thread.sleep(40);
-    long activeRpcMetric =
-        fakeMetricRegistry.results.get("google-cloud-bigtable.grpc.rpc.active").get();
-    assertThat(activeRpcMetric).isEqualTo(0);
+    MetricsRegistrySubject.assertThat(fakeMetricRegistry)
+        .hasMetric("google-cloud-bigtable.grpc.rpc.active", 0);
   }
 
   @Test
@@ -198,80 +201,70 @@ public class TestMetrics {
   }
 
   @Test
-  public void appendFailure() throws IOException {
-    Table table = connection.getTable(TABLE_NAME);
-    Append append = new Append(rowKey);
-    append.add(columnFamily, qualifier, value);
-    Stopwatch stopwatch = Stopwatch.createUnstarted();
-    try {
-      stopwatch.start();
-      table.append(append);
-      Assert.fail("operation should have failed");
-    } catch (Exception e) {
-      long methodInvocationLatency = stopwatch.elapsed(TimeUnit.MILLISECONDS);
-      fakeDataService.popLastRequest();
-      long failureCount =
-          fakeMetricRegistry
-              .results
-              .get("google-cloud-bigtable.grpc.method.ReadModifyWriteRow.failure")
-              .get();
-      long operationLatency =
-          fakeMetricRegistry
-              .results
-              .get("google-cloud-bigtable.grpc.method.ReadModifyWriteRow.operation.latency")
-              .get();
+  public void appendFailure() throws IOException, InterruptedException {
+    final long methodInvocationLatency;
 
-      assertThat(failureCount).isEqualTo(1);
-      assertThat(operationLatency)
-          .isIn(
-              Range.closed(
-                  fakeDataService.getReadModifyWriteRowServerSideLatency(),
-                  methodInvocationLatency));
+    try (Table table = connection.getTable(TABLE_NAME)) {
+      Append append = new Append(rowKey);
+      append.add(columnFamily, qualifier, value);
+
+      Stopwatch stopwatch = Stopwatch.createStarted();
+      Assert.assertThrows(Exception.class, () -> table.append(append));
+      methodInvocationLatency = stopwatch.elapsed(TimeUnit.MILLISECONDS);
     }
+
+    fakeDataService.popLastRequest();
+
+    MetricsRegistrySubject.assertThat(fakeMetricRegistry)
+        .eventuallyHasMetricThat(
+            "google-cloud-bigtable.grpc.method.ReadModifyWriteRow.failure", s -> s.isEqualTo(1));
+
+    MetricsRegistrySubject.assertThat(fakeMetricRegistry)
+        .eventuallyHasMetricThat(
+            "google-cloud-bigtable.grpc.method.ReadModifyWriteRow.operation.latency",
+            s ->
+                s.isIn(
+                    Range.closed(
+                        fakeDataService.getReadModifyWriteRowServerSideLatency(),
+                        methodInvocationLatency)));
   }
 
   @Test
-  public void testScanMetrics() throws IOException {
+  public void testScanMetrics() throws IOException, InterruptedException {
     Scan scan = new Scan().withStartRow(rowKey).withStopRow(rowKey, true);
-    Table table = connection.getTable(TABLE_NAME);
-
     Stopwatch stopwatch = Stopwatch.createStarted();
-    ResultScanner testScanner = table.getScanner(scan);
-    testScanner.next();
-    testScanner.close();
+    try (Table table = connection.getTable(TABLE_NAME);
+        ResultScanner s = table.getScanner(scan)) {
+      s.next();
+    }
     long methodInvocationLatency = stopwatch.elapsed(TimeUnit.MILLISECONDS);
 
     fakeDataService.popLastRequest();
 
-    long scannerResultsLatencyMetric =
-        fakeMetricRegistry.results.get("google-cloud-bigtable.scanner.results.latency").get();
-    long scannerResultsMetric =
-        fakeMetricRegistry.results.get("google-cloud-bigtable.scanner.results").get();
-
-    assertThat(scannerResultsMetric).isEqualTo(1);
-    assertThat(scannerResultsLatencyMetric).isAtMost(methodInvocationLatency);
+    MetricsRegistrySubject.assertThat(fakeMetricRegistry)
+        .eventuallyHasMetricThat("google-cloud-bigtable.scanner.results", s -> s.isEqualTo(1));
+    MetricsRegistrySubject.assertThat(fakeMetricRegistry)
+        .eventuallyHasMetricThat(
+            "google-cloud-bigtable.scanner.results.latency",
+            s -> s.isAtMost(methodInvocationLatency));
   }
 
   @Test
-  public void testFirstResponseLatency() throws IOException {
+  public void testFirstResponseLatency() throws IOException, InterruptedException {
     Scan scan = new Scan().withStartRow(rowKey).withStopRow(rowKey, true);
-    Table table = connection.getTable(TABLE_NAME);
-
     Stopwatch stopwatch = Stopwatch.createStarted();
-    ResultScanner testScanner = table.getScanner(scan);
-    testScanner.next();
-    testScanner.close();
+    try (Table table = connection.getTable(TABLE_NAME);
+        ResultScanner s = table.getScanner(scan)) {
+      s.next();
+    }
     long methodInvocationLatency = stopwatch.elapsed(TimeUnit.MILLISECONDS);
 
     fakeDataService.popLastRequest();
 
-    long firstResponseLatencyMetric =
-        fakeMetricRegistry
-            .results
-            .get("google-cloud-bigtable.grpc.method.ReadRows.firstResponse.latency")
-            .get();
-
-    assertThat(firstResponseLatencyMetric).isAtMost(methodInvocationLatency);
+    MetricsRegistrySubject.assertThat(fakeMetricRegistry)
+        .eventuallyHasMetricThat(
+            "google-cloud-bigtable.grpc.method.ReadRows.firstResponse.latency",
+            s -> s.isAtMost(methodInvocationLatency));
   }
 
   @Test
@@ -289,27 +282,24 @@ public class TestMetrics {
     // Create a new session
     int connectionCount = 10;
     Configuration configuration = new Configuration(false);
+    configuration.set(
+        BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + server.getPort());
     configuration.set(BigtableOptionsFactory.PROJECT_ID_KEY, TEST_PROJECT_ID);
     configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, TEST_INSTANCE_ID);
     configuration.set(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, "true");
     configuration.set(
         BigtableOptionsFactory.BIGTABLE_DATA_CHANNEL_COUNT_KEY, String.valueOf(connectionCount));
 
-    BigtableConnection newConnection = new BigtableConnection(configuration);
-    currentActiveSessions =
-        fakeMetricRegistry.results.get("google-cloud-bigtable.session.active").get();
-    currentActiveChannels =
-        fakeMetricRegistry.results.get("google-cloud-bigtable.grpc.channel.active").get();
-    assertThat(currentActiveSessions).isEqualTo(2);
-    assertThat(currentActiveChannels).isEqualTo(connectionCount + 1);
-
-    newConnection.close();
-    currentActiveSessions =
-        fakeMetricRegistry.results.get("google-cloud-bigtable.session.active").get();
-    currentActiveChannels =
-        fakeMetricRegistry.results.get("google-cloud-bigtable.grpc.channel.active").get();
-    assertThat(currentActiveSessions).isEqualTo(1);
-    assertThat(currentActiveChannels).isEqualTo(1);
+    try (BigtableConnection ignored = new BigtableConnection(configuration)) {
+      MetricsRegistrySubject.assertThat(fakeMetricRegistry)
+          .hasMetric("google-cloud-bigtable.session.active", 2);
+      MetricsRegistrySubject.assertThat(fakeMetricRegistry)
+          .hasMetric("google-cloud-bigtable.grpc.channel.active", connectionCount + 1);
+    }
+    MetricsRegistrySubject.assertThat(fakeMetricRegistry)
+        .hasMetric("google-cloud-bigtable.session.active", 1);
+    MetricsRegistrySubject.assertThat(fakeMetricRegistry)
+        .hasMetric("google-cloud-bigtable.grpc.channel.active", 1);
   }
 
   @Test
@@ -317,6 +307,8 @@ public class TestMetrics {
     // Test channel pool caching
     int connectionCount = 10;
     Configuration configuration = new Configuration(false);
+    configuration.set(
+        BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + server.getPort());
     configuration.set(BigtableOptionsFactory.PROJECT_ID_KEY, TEST_PROJECT_ID);
     configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, TEST_INSTANCE_ID);
     configuration.set(
@@ -328,43 +320,38 @@ public class TestMetrics {
     BigtableConnection sharedConnection1 = new BigtableConnection(configuration);
     BigtableConnection sharedConnection2 = new BigtableConnection(configuration);
 
-    long currentActiveChannels =
-        fakeMetricRegistry.results.get("google-cloud-bigtable.grpc.channel.active").get();
     // sharedConnection1 and 2 should share channels, plus the 1 that's created in setup
-    assertThat(currentActiveChannels).isEqualTo(connectionCount + 1);
+    MetricsRegistrySubject.assertThat(fakeMetricRegistry)
+        .hasMetric("google-cloud-bigtable.grpc.channel.active", connectionCount + 1);
 
     // closing one shared bigtable connection shouldn't decrement shared channels count
     sharedConnection1.close();
-    currentActiveChannels =
-        fakeMetricRegistry.results.get("google-cloud-bigtable.grpc.channel.active").get();
-    assertThat(currentActiveChannels).isEqualTo(connectionCount + 1);
+    MetricsRegistrySubject.assertThat(fakeMetricRegistry)
+        .hasMetric("google-cloud-bigtable.grpc.channel.active", connectionCount + 1);
 
     // Active channels should be 1 after both shared bigtable connections are closed
     sharedConnection2.close();
-    currentActiveChannels =
-        fakeMetricRegistry.results.get("google-cloud-bigtable.grpc.channel.active").get();
-    assertThat(currentActiveChannels).isEqualTo(1);
-
-    Thread.sleep(100);
+    MetricsRegistrySubject.assertThat(fakeMetricRegistry)
+        .hasMetric("google-cloud-bigtable.grpc.channel.active", 1);
   }
 
   @Test
   public void testBulkMutationMetrics() throws IOException, InterruptedException {
-    Table table = connection.getTable(TABLE_NAME);
-    List<Row> rows = new ArrayList<>();
-    int entries = 20;
-    for (int i = 0; i < entries; i++) {
-      rows.add(
-          new Put(Bytes.toBytes(RandomStringUtils.random(8)))
-              .addColumn(Bytes.toBytes("cf"), Bytes.toBytes("q"), Bytes.toBytes("SomeValue")));
-    }
-    Object[] resultsOrErrors = new Object[rows.size()];
-    table.batch(rows, resultsOrErrors);
+    try (Table table = connection.getTable(TABLE_NAME)) {
+      List<Row> rows = new ArrayList<>();
+      int entries = 20;
+      for (int i = 0; i < entries; i++) {
+        rows.add(
+            new Put(Bytes.toBytes(RandomStringUtils.random(8)))
+                .addColumn(Bytes.toBytes("cf"), Bytes.toBytes("q"), Bytes.toBytes("SomeValue")));
+      }
+      Object[] resultsOrErrors = new Object[rows.size()];
+      table.batch(rows, resultsOrErrors);
 
-    long mutationAdded =
-        fakeMetricRegistry.results.get("google-cloud-bigtable.bulk-mutator.mutations.added").get();
-    assertThat(mutationAdded).isEqualTo(entries);
-    table.close();
+      MetricsRegistrySubject.assertThat(fakeMetricRegistry)
+          .eventuallyHasMetricThat(
+              "google-cloud-bigtable.bulk-mutator.mutations.added", s -> s.isEqualTo(entries));
+    }
   }
 
   private static class FakeDataService extends BigtableGrpc.BigtableImplBase {
@@ -410,6 +397,12 @@ public class TestMetrics {
       readModifyWriteRowStopwatch.reset();
       mutateRowStopwatch.reset();
       callCount.set(1);
+    }
+
+    @Override
+    public void pingAndWarm(
+        PingAndWarmRequest request, StreamObserver<PingAndWarmResponse> responseObserver) {
+      responseObserver.onNext(PingAndWarmResponse.getDefaultInstance());
     }
 
     @Override
@@ -568,6 +561,49 @@ public class TestMetrics {
           }
         }
       };
+    }
+  }
+
+  private static class MetricsRegistrySubject extends Subject {
+    private final FakeMetricRegistry actual;
+
+    public MetricsRegistrySubject(FailureMetadata metadata, @Nullable FakeMetricRegistry actual) {
+      super(metadata, actual);
+      this.actual = actual;
+    }
+
+    private static Factory<MetricsRegistrySubject, FakeMetricRegistry> registry() {
+      return MetricsRegistrySubject::new;
+    }
+
+    static MetricsRegistrySubject assertThat(@Nullable FakeMetricRegistry actual) {
+      return assertAbout(registry()).that(actual);
+    }
+
+    void eventuallyHasMetricThat(String name, Consumer<LongSubject> cb)
+        throws InterruptedException {
+      for (int i = 10; i >= 0; i--) {
+        try {
+          LongSubject valueSubject =
+              check("results.get(%s)", name)
+                  .that(
+                      Optional.ofNullable(actual.results.get(name))
+                          .map(AtomicLong::get)
+                          .orElse(null));
+          cb.accept(valueSubject);
+        } catch (AssertionError e) {
+          if (i == 0) {
+            throw e;
+          }
+          Thread.sleep(100);
+        }
+      }
+    }
+
+    void hasMetric(String name, long value) {
+      check("results.get(%s)", name)
+          .that(Optional.ofNullable(actual.results.get(name)).map(AtomicLong::get).orElse(null))
+          .isEqualTo(value);
     }
   }
 }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-hadoop/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableConnection.java
@@ -15,8 +15,15 @@
  */
 package com.google.cloud.bigtable.hbase;
 
+import com.google.bigtable.repackaged.com.google.bigtable.v2.BigtableGrpc;
+import com.google.bigtable.repackaged.com.google.bigtable.v2.PingAndWarmRequest;
+import com.google.bigtable.repackaged.com.google.bigtable.v2.PingAndWarmResponse;
+import com.google.bigtable.repackaged.io.grpc.Server;
+import com.google.bigtable.repackaged.io.grpc.ServerBuilder;
+import com.google.bigtable.repackaged.io.grpc.stub.StreamObserver;
 import com.google.cloud.bigtable.hbase2_x.BigtableConnection;
 import java.io.IOException;
+import java.net.ServerSocket;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Admin;
@@ -62,12 +69,43 @@ public class TestBigtableConnection {
 
   @Test
   public void testTable() throws IOException {
+    Server server = createFakeServer();
+
     Configuration conf = BigtableConfiguration.configure("projectId", "instanceId", "appProfileId");
+    conf.set(BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + server.getPort());
     conf.set(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, "true");
     conf.set(BigtableOptionsFactory.BIGTABLE_USE_SERVICE_ACCOUNTS_KEY, "false");
-    BigtableConnection connection = new BigtableConnection(conf);
-    Admin admin = connection.getAdmin();
-    Table table = connection.getTable(TableName.valueOf("someTable"));
-    BufferedMutator mutator = connection.getBufferedMutator(TableName.valueOf("someTable"));
+
+    try (BigtableConnection connection = new BigtableConnection(conf);
+        Admin admin = connection.getAdmin();
+        Table table = connection.getTable(TableName.valueOf("someTable"));
+        BufferedMutator mutator = connection.getBufferedMutator(TableName.valueOf("someTable"))) {}
+  }
+
+  static Server createFakeServer() throws IOException {
+    Server server = null;
+    for (int i = 10; i >= 0; i--) {
+      int port;
+      try (ServerSocket ss = new ServerSocket(0)) {
+        port = ss.getLocalPort();
+      }
+      try {
+        return ServerBuilder.forPort(port).addService(new FakeDataService()).build().start();
+      } catch (IOException e) {
+        if (i == 0) {
+          throw e;
+        }
+      }
+    }
+    throw new IllegalStateException("This should never happen");
+  }
+
+  static class FakeDataService extends BigtableGrpc.BigtableImplBase {
+    @Override
+    public void pingAndWarm(
+        PingAndWarmRequest request, StreamObserver<PingAndWarmResponse> responseObserver) {
+      responseObserver.onNext(PingAndWarmResponse.getDefaultInstance());
+      responseObserver.onCompleted();
+    }
   }
 }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableConnection.java
@@ -206,6 +206,7 @@ public class TestBigtableConnection {
     public void pingAndWarm(
         PingAndWarmRequest request, StreamObserver<PingAndWarmResponse> responseObserver) {
       responseObserver.onNext(PingAndWarmResponse.getDefaultInstance());
+      responseObserver.onCompleted();
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@ limitations under the License.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- core dependency versions -->
-    <bigtable.version>2.47.0</bigtable.version>
+    <bigtable.version>2.49.0</bigtable.version>
     <google-cloud-bigtable-emulator.version>0.185.0</google-cloud-bigtable-emulator.version>
     <bigtable-metrics-api.version>1.29.2</bigtable-metrics-api.version>
     <!-- Optional dep for bigtable-metrics-api used for tests -->


### PR DESCRIPTION
* upgrade java-bigtable to 2.49.0
* update metrics integration to respect trailer skipping
* stop running unit tests as part of integration tests, they are run separately in parallel
*  use BigtableDataClientFactory for cached connections instead of duplicating the logic
* update unit tests to target a fake bigtable service instead of sending invalid resource ids to actual bigtable service
* fix cached connection keys for tests
* fix channel pool settings for emulator
* clean up some overly verbose test log output
* 